### PR TITLE
fix(ci): use valid environment value 'testing' instead of 'ci'

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -169,7 +169,7 @@ jobs:
         DB_PORT: 5432
         DB_USER: fraiseql
         DB_PASSWORD: fraiseql
-        FRAISEQL_ENVIRONMENT: ci
+        FRAISEQL_ENVIRONMENT: testing
         FRAISEQL_AUTO_INSTALL: false
         FRAISEQL_LOG_LEVEL: INFO
       run: |


### PR DESCRIPTION
## Problem

Integration tests were failing with pydantic validation errors:
```
ValidationError: 1 validation error for FraiseQLConfig
environment
  Input should be 'development', 'production' or 'testing' [input_value='ci']
```

## Root Cause

`FRAISEQL_ENVIRONMENT=ci` is not a valid value according to the config schema.

## Solution

Changed to `FRAISEQL_ENVIRONMENT=testing` which is:
- ✅ Valid according to pydantic schema
- ✅ Semantically correct for CI environment
- ✅ Has appropriate defaults (introspection enabled, playground allowed)

## Impact

- Fixes 50+ integration test failures
- Unblocks PR #146 (v1.7.0 release)
- No behavioral changes (testing env is appropriate for CI)

## Testing

- [x] Tested locally with `FRAISEQL_ENVIRONMENT=testing`
- [x] Config instantiation succeeds
- [ ] CI passes (will verify after merge)