### PR TITLE
bump: version to 1.8.0b2 for consistent beta.2 release

### DIFF
--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql_rs"
-version = "1.8.0-beta.1"
+version = "1.8.0-beta.2"
 edition = "2021"
 authors = ["FraiseQL Contributors"]
 description = "Ultra-fast GraphQL JSON transformation in Rust for FraiseQL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "fraiseql"
-version = "1.8.0b1"
+version = "1.8.0b2"
 description = "GraphQL for the LLM era. Simple. Powerful. Rust-fast. Production-ready GraphQL API framework for PostgreSQL with CQRS, JSONB optimization, and type-safe mutations"
 authors = [
   { name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr" },

--- a/src/fraiseql/__init__.py
+++ b/src/fraiseql/__init__.py
@@ -73,7 +73,7 @@ except ImportError:
     Auth0Config = None
     Auth0Provider = None
 
-__version__ = "1.8.0b1"
+__version__ = "1.8.0b2"
 
 
 # Lazy Rust extension loading for performance optimization


### PR DESCRIPTION
Update all version files to v1.8.0b2 for consistent versioning across the codebase.

## Changes
- pyproject.toml: 1.8.0b1 → 1.8.0b2
- fraiseql_rs/Cargo.toml: 1.8.0-beta.1 → 1.8.0-beta.2  
- src/fraiseql/__init__.py: 1.8.0b1 → 1.8.0b2

## Verification
All versions now consistent: 1.8.0b2 (normalized: 1.8.0-beta.2)

This PR prepares for the v1.8.0-beta.2 release with proper version alignment.