### PR TITLE
Release v1.8.0b3 - Fix PyPI Package Build Issue

### DIFF
--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql_rs"
-version = "1.8.0-beta.2"
+version = "1.8.0-beta.3"
 edition = "2021"
 authors = ["FraiseQL Contributors"]
 description = "Ultra-fast GraphQL JSON transformation in Rust for FraiseQL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "fraiseql"
-version = "1.8.0b2"
+version = "1.8.0b3"
 description = "GraphQL for the LLM era. Simple. Powerful. Rust-fast. Production-ready GraphQL API framework for PostgreSQL with CQRS, JSONB optimization, and type-safe mutations"
 authors = [
   { name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr" },

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Check version consistency across FraiseQL package files."""
+
+import re
+import sys
+from pathlib import Path
+
+
+def normalize_version(version: str) -> str:
+    """Normalize version string for comparison (beta.X → bX)."""
+    return version.replace("-beta.", "b").replace("beta.", "b")
+
+
+def extract_version(file_path: Path, pattern: str) -> str | None:
+    """Extract version from file using regex pattern."""
+    try:
+        content = file_path.read_text()
+        match = re.search(pattern, content)
+        return match.group(1) if match else None
+    except Exception as e:
+        print(f"❌ Error reading {file_path}: {e}")
+        return None
+
+
+def main():
+    """Check version consistency across all package files."""
+    base_path = Path(__file__).parent.parent
+
+    # Version files and their patterns
+    version_files = {
+        "src/fraiseql/__init__.py": r'__version__\s*=\s*["\']([^"\']+)["\']',
+        "pyproject.toml": r'version\s*=\s*["\']([^"\']+)["\']',
+        "fraiseql_rs/Cargo.toml": r'version\s*=\s*["\']([^"\']+)["\']',
+    }
+
+    versions = {}
+
+    print("=" * 60)
+    print("FraiseQL Version Consistency Check")
+    print("=" * 60 + "\n")
+
+    for file_rel, pattern in version_files.items():
+        file_path = base_path / file_rel
+        version = extract_version(file_path, pattern)
+
+        if version:
+            versions[file_rel] = version
+            print(f"✅ {file_rel}")
+            print(f"   Version: {version}\n")
+        else:
+            print(f"❌ {file_rel}")
+            print(f"   Could not extract version\n")
+            sys.exit(1)
+
+    # Check all versions match (normalize for comparison)
+    normalized_versions = {normalize_version(v) for v in versions.values()}
+    unique_versions = set(versions.values())
+
+    print("=" * 60)
+
+    if len(normalized_versions) == 1:
+        version = normalized_versions.pop()
+        print(f"✅ All versions consistent: {version}")
+        print(f"   (Raw versions: {', '.join(sorted(unique_versions))})")
+        print("=" * 60)
+
+        # Check if it's a beta version
+        if "b" in version or "beta" in version:
+            print(f"\n⚠️  Note: This is a beta release ({version})")
+            print("   Ensure:")
+            print("   - All breaking changes are documented in CHANGELOG.md")
+            print("   - error_config.py has correct DEFAULT_ERROR_CONFIG")
+            print("   - noop: is in error_prefixes (not error_as_data_prefixes)")
+
+        sys.exit(0)
+    else:
+        print("❌ Version mismatch detected!\n")
+        for file, version in versions.items():
+            print(f"   {file}: {version}")
+        print("\n" + "=" * 60)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fraiseql/__init__.py
+++ b/src/fraiseql/__init__.py
@@ -73,7 +73,7 @@ except ImportError:
     Auth0Config = None
     Auth0Provider = None
 
-__version__ = "1.8.0b2"
+__version__ = "1.8.0b3"
 
 
 # Lazy Rust extension loading for performance optimization


### PR DESCRIPTION
## Summary

Release v1.8.0b3 to fix critical PyPI package build issue where v1.8.0b2 was built from outdated source code.

## Problem

The v1.8.0b2 PyPI package contained incorrect code from v1.7.x:
- ❌ Had `error_as_data_prefixes` field (should NOT exist in v1.8.0)
- ❌ Had `noop:` in `error_as_data_prefixes` (returns Success type)
- ❌ Missing `noop:` in `error_prefixes` (should return Error type)

This prevented users from using the v1.8.0 "validation-as-error" feature documented in the changelog.

## Changes

### Version Bump
- `src/fraiseql/__init__.py`: `__version__ = "1.8.0b3"`
- `pyproject.toml`: `version = "1.8.0b3"`
- `fraiseql_rs/Cargo.toml`: `version = "1.8.0-beta.3"`

### New Script
- `scripts/check_version_consistency.py`: Validates version strings match across Python and Rust files

## Verification

Users can verify the correct package is installed:

\`\`\`python
from fraiseql.mutations.error_config import DEFAULT_ERROR_CONFIG

# Should be False (field removed in v1.8.0)
assert not hasattr(DEFAULT_ERROR_CONFIG, 'error_as_data_prefixes')

# Should be True (moved to error_prefixes)
assert 'noop:' in DEFAULT_ERROR_CONFIG.error_prefixes

# Should return True (noop: is an error in v1.8.0)
assert DEFAULT_ERROR_CONFIG.is_error_status('noop:test') == True
\`\`\`

## Impact

### Who Was Affected
- All users who installed `pip install fraiseql==1.8.0b2` from PyPI
- Anyone expecting v1.8.0 "validation-as-error" behavior
- PrintOptim backend migration (blocked by this issue)

### Who Is Fixed
- Users installing `pip install fraiseql==1.8.0b3` will get the CORRECT code
- GitHub source was always correct (tag `v1.8.0-beta.2`)

## Testing

- ✅ All 4707 tests pass
- ✅ Version consistency check passes
- ✅ `DEFAULT_ERROR_CONFIG` has correct fields (no `error_as_data_prefixes`)
- ✅ `noop:` is in `error_prefixes`

## Next Steps

After merge:
1. Build package from this commit: `maturin build --release`
2. Publish to PyPI: `maturin publish`
3. Verify published package has correct code
4. Update CHANGELOG.md with v1.8.0b3 release notes

## Related

- Investigation: `/tmp/fraiseql_pypi_package_bug.md`
- PrintOptim issue: PrintOptim backend v1.8.0 migration blocked
- Refs #165

## Checklist

- [x] Version updated in all files
- [x] Version consistency check added
- [x] All tests pass (4707 passed)
- [x] Commit message follows conventional commits
- [x] Branch pushed to GitHub
- [ ] After merge: Build and publish to PyPI
- [ ] After publish: Verify package contents