### PR TITLE
chore(release): bump version to v1.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql"
-version = "1.9.4"
+version = "1.9.6"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql"
-version = "1.9.4"
+version = "1.9.6"
 edition = "2021"
 authors = ["FraiseQL Contributors"]
 description = "Production-ready GraphQL API framework for PostgreSQL with CQRS, JSONB optimization, and type-safe mutations"

--- a/docs/archive/strategic/version-status.md
+++ b/docs/archive/strategic/version-status.md
@@ -1,7 +1,7 @@
 # FraiseQL Version Status & Roadmap
 
 **Last Updated**: January 5, 2025
-**Current Stable**: v1.9.4
+**Current Stable**: v1.9.6
 
 ---
 

--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql_rs"
-version = "1.9.4"
+version = "1.9.6"
 edition = "2021"
 authors = ["FraiseQL Contributors"]
 description = "Ultra-fast GraphQL JSON transformation in Rust for FraiseQL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "fraiseql"
-version = "1.9.4"
+version = "1.9.6"
 description = "GraphQL for the LLM era. Simple. Powerful. Rust-fast. Production-ready GraphQL API framework for PostgreSQL with CQRS, JSONB optimization, and type-safe mutations"
 authors = [
   { name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr" },

--- a/src/fraiseql/__init__.py
+++ b/src/fraiseql/__init__.py
@@ -76,7 +76,7 @@ except ImportError:
     Auth0Config = None
     Auth0Provider = None
 
-__version__ = "1.9.4"
+__version__ = "1.9.6"
 
 
 # Lazy Rust extension loading for performance optimization

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql"
-version = "1.9.3"
+version = "1.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Version bump to v1.9.6.

Note: v1.9.5 was released as a hotfix directly to main (manylinux CI fixes).

## Changes

- Bump version in all locations to 1.9.6

## Test plan

- [x] All version files updated consistently
- CI will run tests