### PR TITLE
fix(readme): correct IPv4 type name corrupted during version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,13 @@ FraiseQL separates testing into two workflows:
 ### Specialized Type System (50+ scalar types)
 
 ```python
-from fraiseql.types import EmailAddress, PhoneNumber, IPv1.9.9, Money, LTree
+from fraiseql.types import EmailAddress, PhoneNumber, IPv4, Money, LTree
 
 @fraiseql.type(sql_source="v_users")
 class User:
     email: EmailAddress      # Validated emails
     phone: PhoneNumber       # International phone numbers
-    ip: IPv1.9.9                 # IP addresses with subnet operations
+    ip: IPv4                 # IP addresses with subnet operations
     balance: Money           # Currency with precision
     location: LTree          # Hierarchical paths
 ```
@@ -807,7 +807,7 @@ query {
 - CurrencyCode, StockSymbol - Trading symbols
 
 **Network & Infrastructure:**
-- IPv1.9.9, IPv1.9.9, CIDR, MACAddress - Network addresses with subnet operations
+- IPv4, IPv6, CIDR, MACAddress - Network addresses with subnet operations
 - Hostname, DomainName, Port, EmailAddress - Internet identifiers
 - APIKey, HashSHA256 - Security tokens
 
@@ -834,7 +834,7 @@ query {
 from fraiseql import type
 from fraiseql.types import (
     EmailAddress, PhoneNumber, Money, Percentage,
-    CUSIP, ISIN, IPv1.9.9, MACAddress, LTree, DateRange
+    CUSIP, ISIN, IPv4, MACAddress, LTree, DateRange
 )
 
 @fraiseql.type(sql_source="v_financial_data")
@@ -849,7 +849,7 @@ class FinancialRecord:
 @fraiseql.type(sql_source="v_network_device")
 class NetworkDevice:
     id: int
-    ip_address: IPv1.9.9             # IPv1.9.9 addresses with subnet operations
+    ip_address: IPv4             # IPv4 addresses with subnet operations
     mac_address: MACAddress      # MAC addresses with validation
     location: LTree              # Hierarchical location paths
     maintenance_window: DateRange # Date ranges with overlap queries


### PR DESCRIPTION
## Issue

During the v1.9.9 version bump, the `version_manager.py` script incorrectly replaced `IPv4` with `IPv1.9.9` throughout the README.

## Root Cause

The version manager's regex pattern is too broad and caught the "4" in "IPv4", replacing it with "1.9.9".

## Fix

Corrected all 5 occurrences back to `IPv4`:
- Line 186: Import statement
- Line 192: Type annotation  
- Line 810: Network types list
- Line 837: Import statement (example)
- Line 852: Type annotation (example)

## Impact

- **Documentation only** - no functional changes
- **No code changes** - purely cosmetic fix
- **Zero breaking changes**

## Examples

**Before:**
```python
from fraiseql.types import EmailAddress, PhoneNumber, IPv1.9.9, Money, LTree
    ip: IPv1.9.9                 # IP addresses with subnet operations
```

**After:**
```python
from fraiseql.types import EmailAddress, PhoneNumber, IPv4, Money, LTree
    ip: IPv4                 # IP addresses with subnet operations
```

## Follow-up

This reveals a bug in `scripts/version_manager.py` that should be addressed separately to prevent similar issues in future releases.