### PR TITLE
fix(version-manager): use word boundaries to prevent IPv4 corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,13 @@ FraiseQL separates testing into two workflows:
 ### Specialized Type System (50+ scalar types)
 
 ```python
-from fraiseql.types import EmailAddress, PhoneNumber, IPv1.9.9, Money, LTree
+from fraiseql.types import EmailAddress, PhoneNumber, IPv4, Money, LTree
 
 @fraiseql.type(sql_source="v_users")
 class User:
     email: EmailAddress      # Validated emails
     phone: PhoneNumber       # International phone numbers
-    ip: IPv1.9.9                 # IP addresses with subnet operations
+    ip: IPv4                 # IP addresses with subnet operations
     balance: Money           # Currency with precision
     location: LTree          # Hierarchical paths
 ```
@@ -807,7 +807,7 @@ query {
 - CurrencyCode, StockSymbol - Trading symbols
 
 **Network & Infrastructure:**
-- IPv1.9.9, IPv1.9.9, CIDR, MACAddress - Network addresses with subnet operations
+- IPv4, IPv6, CIDR, MACAddress - Network addresses with subnet operations
 - Hostname, DomainName, Port, EmailAddress - Internet identifiers
 - APIKey, HashSHA256 - Security tokens
 
@@ -834,7 +834,7 @@ query {
 from fraiseql import type
 from fraiseql.types import (
     EmailAddress, PhoneNumber, Money, Percentage,
-    CUSIP, ISIN, IPv1.9.9, MACAddress, LTree, DateRange
+    CUSIP, ISIN, IPv4, MACAddress, LTree, DateRange
 )
 
 @fraiseql.type(sql_source="v_financial_data")
@@ -849,7 +849,7 @@ class FinancialRecord:
 @fraiseql.type(sql_source="v_network_device")
 class NetworkDevice:
     id: int
-    ip_address: IPv1.9.9             # IPv1.9.9 addresses with subnet operations
+    ip_address: IPv4             # IPv4 addresses with subnet operations
     mac_address: MACAddress      # MAC addresses with validation
     location: LTree              # Hierarchical location paths
     maintenance_window: DateRange # Date ranges with overlap queries

--- a/scripts/version_manager.py
+++ b/scripts/version_manager.py
@@ -47,7 +47,7 @@ VERSION_FILES = {
         "first_only": True,
     },
     "README.md": {
-        "pattern": r"v([0-9.]+)",
+        "pattern": r"\bv(\d+\.\d+\.\d+)\b",
         "replacement": "v{version}",
         "line_match": r"v\d+\.\d+\.\d+",
     },


### PR DESCRIPTION
## Problem

During the v1.9.9 release, the version manager script corrupted `IPv4` to `IPv1.9.9` in the README.

**Root cause**: The regex pattern for README.md was too broad:
```python
"pattern": r"v([0-9.]+)",  # Matches ANY 'v' followed by digits
```

This matched `IPv4` as `IPv` + `4`, then replaced `4` with `1.9.9`.

## Solution

This PR fixes both the cause and the effect:

### 1. Fixed version_manager.py regex pattern
```python
# Before (buggy):
"pattern": r"v([0-9.]+)"

# After (fixed):
"pattern": r"\bv(\d+\.\d+\.\d+)\b"
```

Uses word boundaries to only match actual version strings (vX.Y.Z format).

### 2. Fixed README.md IPv4 references
Corrected all 5 occurrences of `IPv1.9.9` back to `IPv4`:
- Line 186: Import statement
- Line 192: Type annotation
- Line 810: Network types list (also fixed IPv6)
- Line 837: Import statement (example)
- Line 852: Type annotation (example)

## Test Results

```
OLD pattern (buggy):
  'v1.9.9' -> ['1.9.9']  ✅ Correct
  'IPv4'   -> ['4']      ❌ BUG!

NEW pattern (fixed):
  'v1.9.9' -> ['1.9.9']  ✅ Correct  
  'IPv4'   -> NO MATCH   ✅ Correct
```

## Impact

- **Fixes corrupted IPv4 references in README**
- **Prevents future version bumps from corrupting IPv4/IPv6 references**
- **No functional changes** - only affects documentation and version_manager.py script
- **Tested with dry-run** - confirmed it works correctly

## Files Changed

- `scripts/version_manager.py`: Fixed regex pattern
- `README.md`: Fixed 5 IPv4 references

## Supersedes

This PR makes **PR #241** redundant since it includes the README fix.

## Verification

```bash
# Test the fix
python scripts/version_manager.py --dry-run patch
# Should show clean version updates without touching IPv4

# Verify README is fixed
grep IPv4 README.md  # Should show IPv4, not IPv1.9.9
```