### PR TITLE
chore(ci): bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/chaos-engineering-tests.yml
+++ b/.github/workflows/chaos-engineering-tests.yml
@@ -113,7 +113,7 @@ jobs:
 
     - name: Upload chaos test results
       if: always()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: chaos-test-results
         path: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -57,7 +57,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -83,14 +83,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Extract metadata for Docker Hub
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: fraiseql/fraiseql
           tags: |
@@ -101,7 +101,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           cp fraiseql_rs/target/wheels/*.whl dist/
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ matrix.target }}
           path: dist/*.whl
@@ -116,7 +116,7 @@ jobs:
           cp fraiseql_rs/target/wheels/*.tar.gz dist/
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -141,7 +141,7 @@ jobs:
         EOF
 
     - name: Upload SBOM artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: sbom-artifacts-${{ steps.version.outputs.version }}
         path: sbom-artifacts/

--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -132,7 +132,7 @@ jobs:
             });
 
       - name: Upload scan results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: base-image-security-scans
           path: /tmp/*-scan.json
@@ -218,7 +218,7 @@ jobs:
             });
 
       - name: Upload CVE monitoring report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cve-monitoring-report
           path: /tmp/cve-monitoring-report.md
@@ -272,7 +272,7 @@ jobs:
           cat compliance-summary.md
 
       - name: Upload compliance summary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-compliance-summary
           path: compliance-summary.md

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -110,7 +110,7 @@ jobs:
         fi
 
     - name: Upload license report
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: license-report
         path: python-licenses.md
@@ -214,7 +214,7 @@ jobs:
          cat security-report.md
 
      - name: Upload detailed scan results
-       uses: actions/upload-artifact@v6
+       uses: actions/upload-artifact@v7
        if: always()
        with:
          name: trivy-${{ matrix.dockerfile.label }}-detailed
@@ -231,7 +231,7 @@ jobs:
          output: 'sbom-${{ matrix.dockerfile.label }}.json'
 
      - name: Upload SBOM
-       uses: actions/upload-artifact@v6
+       uses: actions/upload-artifact@v7
        if: always()
        with:
          name: sbom-${{ matrix.dockerfile.label }}
@@ -273,7 +273,7 @@ jobs:
         fi
 
     - name: Upload audit results
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: dependency-audit-results


### PR DESCRIPTION
## Summary

- **docker/login-action**: v3 → v4
- **docker/metadata-action**: v5 → v6
- **docker/build-push-action**: v5 → v7
- **actions/upload-artifact**: v6 → v7 (11 occurrences across 5 workflow files)
- **actions/setup-node**: already at v6, no change needed

Supersedes: #303, #302, #301, #298, #293

## Test plan

- [ ] CI workflows run successfully after merge
- [ ] Docker build workflow completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)