### PR TITLE
chore(ci): improve Dependabot config to prevent PR backlog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "UTC"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
@@ -16,16 +16,18 @@ updates:
       - "dependencies"
       - "security"
     groups:
-      patch-updates:
+      # Group all patch and minor updates into single PRs
+      patch-and-minor:
         patterns:
           - "*"
         update-types:
           - "patch"
-      minor-updates:
-        patterns:
-          - "*"
-        update-types:
           - "minor"
+      # Major updates get individual PRs for careful review
+    # Ignore packages where we manage version constraints manually
+    ignore:
+      - dependency-name: "boto3"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -33,11 +35,17 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(ci)"
     labels:
       - "ci"
       - "dependencies"
+    groups:
+      # Group all GH Actions updates into a single PR
+      actions-updates:
+        patterns:
+          - "*"
 
 # Note: We intentionally do not scan benchmark directories as they:
 # - Are not part of the distributed package


### PR DESCRIPTION
## Summary

- Reduce open PR limits from 10 to 5 for both pip and github-actions
- Merge patch + minor pip updates into a single group (reduces PR noise)
- Group all GitHub Actions updates into a single PR
- Ignore boto3 major bumps (tightly coupled with aioboto3/aiobotocore, causes resolver conflicts)

This prevents the accumulation of 17+ stale Dependabot PRs that we just cleaned up.

## Test plan

- [ ] Verify Dependabot creates grouped PRs on next weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)