### PR TITLE
feat(security): operation + field authorization (#362, #364–#367) + field-decorator composition fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-06-06
+
+### Added
+
+- **First-class operation authorization extension point** (#362)
+  - `Authorizer` protocol + `AuthorizationDecision` value type (`allow`/`deny`,
+    optional `code`/`message`/`filters`), exported from `fraiseql` and
+    `fraiseql.security`; a single decision contract aligned with v2 (#422)
+  - `create_fraiseql_app(authorizer=...)` and `build_fraiseql_schema(authorizer=...)`
+    install a global default authorizer on `SchemaRegistry.default_authorizer`;
+    `@query(authorizer=...)` / `@mutation(authorizer=...)` add per-operation overrides
+  - Enforcement around every root query and mutation (sync + async resolvers) with
+    **fail-closed** semantics in one shared helper: an authorizer that raises denies,
+    a deny becomes a `GraphQLError` with `extensions.code`, and the raw exception is
+    never surfaced to the client
+  - **Resolver-bypass paths gated**: TurboRouter / persisted queries,
+    `POST /graphql/rust`, and APQ cached passthrough all enforce the same authorizer
+    before reaching the database / Rust
+  - **Row-scoping filter injection**: a query authorizer may return `filters` that are
+    AND-merged into the repository's validated, parameterized `mandatory_filters` via
+    the repository context (keyed per root field; overlapping columns rejected). On the
+    bypass paths a returned filter is logged (rely on session variables + RLS); APQ
+    skips the cache when filters are present
+  - Authorizer survives schema hot-reload; the legacy `registry._mutations` rewrite
+    keeps working during migration
+  - Field-level `authorize_field` accepts `AuthorizationDecision | bool` on one contract;
+    `field_authorizer_adapter` lets one policy object serve fields and operations
+  - New guide `docs/security/authorization.md` and `examples/authorization/`
+
 ## [1.22.0] - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.4] - 2026-06-06
+
+### Added
+
+- **Automatic field-level authorization** (#366) — ergonomics follow-up to #362
+  - `@fraise_type(authorize_fields=[...])` gates the listed fields with the configured
+    operation `Authorizer` automatically, checked with `operation_type="field"` and
+    `operation_name="TypeName.fieldName"` before each field resolver runs — no per-field
+    `@authorize_field` needed. Narrow opt-in by design (no gate-everything switch)
+  - Fail-closed: `field_authorizer_adapter` now normalizes a raising authorizer to a
+    `FIELD_AUTHORIZATION_ERROR` deny (parity with the operation path). An explicit
+    `@authorize_field` AND-combines with the automatic gate
+  - With no authorizer configured the gate is a no-op (byte-for-byte unchanged). The gate
+    consults the optional decision cache (#367), which collapses the per-object call volume
+    on nested lists; the per-object cost is documented in `docs/security/authorization.md`
+
 ## [1.23.3] - 2026-06-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.2] - 2026-06-06
+
+### Changed
+
+- **`POST /graphql/rust` is now opt-in** (#365) — defense-in-depth follow-up to #362
+  - New `FraiseQLConfig.enable_rust_endpoint` flag (default `False`,
+    `FRAISEQL_ENABLE_RUST_ENDPOINT`). The Rust passthrough bypasses Python resolvers
+    entirely, so the route is mounted only when explicitly enabled; when disabled it is
+    not registered (a request 404s). When mounted it is still authorization-gated (#362).
+  - ⚠️ **Behavior change:** apps that were calling `/graphql/rust` must now set
+    `enable_rust_endpoint=True`, or the endpoint returns 404.
+
 ## [1.23.1] - 2026-06-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.1] - 2026-06-06
+
+### Added
+
+- **Subscription authorization** (#364) — follow-up to the operation PEP (#362)
+  - The configured `Authorizer` now gates subscriptions, enforced **once at subscribe
+    time** with `operation_type="subscription"`, before the event stream is created. A
+    deny (or a raising authorizer) raises a `GraphQLError` during the awaited `subscribe`,
+    so the inner generator is never built and the database is never queried. Covers both
+    the schema path and the websocket transport (which routes through graphql-core's
+    `subscribe`)
+  - `@subscription(authorizer=...)` per-operation override, mirroring
+    `@query` / `@mutation`; the global default still applies otherwise
+  - A returned `decision.filters` is **logged, not silently dropped** on subscriptions
+    (no row-scoping semantics on a stream), mirroring the mutation path
+  - Per-event re-checking of live streams is explicitly a future opt-in, not this change
+  - With no authorizer configured, subscriptions stream byte-for-byte as before
+
 ## [1.23.0] - 2026-06-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.3] - 2026-06-06
+
+### Added
+
+- **Optional authorization decision caching** (#367) — performance follow-up to #362
+  - `AuthorizationCacheConfig` + `DecisionCache` (exported from `fraiseql` and
+    `fraiseql.security`): opt-in TTL+LRU memoization of authorization decisions, wired via
+    `create_fraiseql_app(authorization_cache=...)` and installed on
+    `SchemaRegistry.decision_cache`; survives schema hot-reload
+  - Consulted on every gated path — the resolver wrap, subscriptions, and the three
+    resolver-bypass gates (TurboRouter, `/graphql/rust`, APQ) — keyed on
+    `(principal_key(context), operation_type, operation_name, stable_hash(arguments))`
+  - **Off by default** (always-evaluate is the safe default). Fail-closed is never cached
+    around: a raising authorizer is never cached; a `None` principal is never cached;
+    non-JSON-serializable arguments fall through to evaluate
+  - **Correctness contract:** enable only if the authorizer is a pure function of
+    principal + operation + arguments — a non-pure authorizer is served a wrong decision on
+    a hit (documented in `docs/security/authorization.md`). TTL-only invalidation (no active
+    revoke hook in this version)
+
 ## [1.23.2] - 2026-06-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.5] - 2026-06-06
+
+### Fixed
+
+- **`@field` / `@authorize_field` compose in either decorator order** — a pre-existing
+  field-resolver defect, surfaced during the #366 work
+  - A field method gated with `@authorize_field` now runs its check and resolver with the
+    correct arguments regardless of decorator order (`@authorize_field` outer / `@field`
+    inner, or `@field` outer / `@authorize_field` inner) and for any method shape (`self`,
+    `self, info`, sync or `async`). Previously the `@field`-outer order silently failed for
+    `self`-only methods (the order the docs showed).
+  - Auth wrappers no longer mis-report their signature: `@authorize_field` drops the
+    `functools.wraps`-set `__wrapped__`, so an outer `@field` (and `inspect.signature`) reads
+    the wrapper's real `(root, info, *args, **kwargs)` interface. **Note:** external tooling
+    that followed `__wrapped__` on an auth wrapper now sees this real signature instead of the
+    inner method's.
+  - A sync field resolver gated by an async authorizer (e.g. `field_authorizer_adapter`) no
+    longer emits a `RuntimeWarning` or risks an event-loop deadlock: the wrapper is async
+    end-to-end whenever the resolver or the check is async, so graphql-core awaits it directly.
+  - Internals: a single `invoke_resolver` convention
+    (`fraiseql.core.resolver_invocation`) is now the source of truth for how `@field` and
+    `@authorize_field` call what they wrap. Fail-closed behavior is unchanged on every deny.
+
 ## [1.23.4] - 2026-06-06
 
 ### Added

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -8,6 +8,7 @@ tags:
   - config
 ---
 
+<!-- markdownlint-disable-next-line MD025 -->
 # Configuration
 
 FraiseQLConfig class for comprehensive application configuration.
@@ -45,7 +46,7 @@ app = create_fraiseql_app(types=[User, Post], config=config)
 
 FraiseQL uses psycopg3's `AsyncConnectionPool` for efficient connection management. You can configure the pool using either `FraiseQLConfig` or directly via `create_fraiseql_app()` parameters.
 
-**Method 1: Using FraiseQLConfig**
+#### Method 1: Using FraiseQLConfig
 
 ```python
 # Standard PostgreSQL URL
@@ -68,7 +69,7 @@ config = FraiseQLConfig(
 )
 ```
 
-**Method 2: Using create_fraiseql_app() parameters**
+#### Method 2: Using create_fraiseql_app() parameters
 
 ```python
 # Quick configuration without creating FraiseQLConfig
@@ -417,6 +418,7 @@ FraiseQL uses an exclusive Rust pipeline for all query execution.
 
 - `field_projection: bool = True` - Enable Rust-based field filtering
 - `schema_registry: bool = True` - Enable schema-based transformation
+- `enable_rust_endpoint: bool = False` - Mount the `POST /graphql/rust` passthrough route
 
 ### Example
 
@@ -427,6 +429,24 @@ config = FraiseQLConfig(
     field_projection=True,  # Optional: disable for debugging
 )
 ```
+
+### `enable_rust_endpoint` (opt-in, issue #365)
+
+`POST /graphql/rust` is a Rust passthrough that **bypasses Python resolvers entirely**. It is
+**off by default** — a resolver-bypass route should not exist unless explicitly requested —
+and is mounted only when `enable_rust_endpoint=True`:
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://localhost/mydb",
+    enable_rust_endpoint=True,  # or FRAISEQL_ENABLE_RUST_ENDPOINT=true
+)
+```
+
+When disabled the route is not mounted (a request 404s). When enabled it is still
+authorization-gated (issue #362); row scoping relies on session variables + RLS, not per-row
+filter injection. **Behavior change:** apps that relied on `/graphql/rust` must now set this
+flag.
 
 ## Schema Settings
 

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -121,13 +121,22 @@ is impossible** on them:
 | Path | Gate | Row scoping |
 |------|------|-------------|
 | **TurboRouter / persisted queries** | enforced before the cached SQL template runs | session variables + database **RLS** |
-| **`POST /graphql/rust`** | enforced before the Rust pipeline is called | session variables + database **RLS** |
+| **`POST /graphql/rust`** (opt-in) | enforced before the Rust pipeline is called | session variables + database **RLS** |
 | **APQ cached passthrough** | enforced before the cached response is served | a returned filter **bypasses the cache** and falls through to normal resolver execution (which applies the filter) |
 
 If an authorizer returns `filters` on the turbo or rust path, the filter is **logged, not
 silently dropped** — rely on session variables + RLS for row scoping there. For APQ, a returned
 filter is honored by skipping the (unscoped) cache entry. `filters` are also ignored (with a
 warning) on mutations and at field granularity.
+
+> **`POST /graphql/rust` is opt-in (issue #365).** It is **off by default** — a route that
+> bypasses Python resolvers entirely should not exist unless the app asks for it. Enable it
+> with `enable_rust_endpoint=True` on `FraiseQLConfig` (or `FRAISEQL_ENABLE_RUST_ENDPOINT=true`).
+> When disabled the route is simply not mounted (a request 404s). When enabled it is still
+> authorization-gated as above; row scoping relies on session variables + RLS.
+>
+> **Behavior change:** apps that were calling `/graphql/rust` before this release must now set
+> `enable_rust_endpoint=True`, or the endpoint returns 404.
 
 ## Field-level authorization
 

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -180,6 +180,59 @@ byte-for-byte as before.
   per emitted event. Revoking a *live* stream when permissions change mid-flight (per-event
   re-checking) is a deliberate future opt-in, not part of this contract.
 
+## Decision caching (optional)
+
+An authorizer that issues a DB query or calls an external policy service adds latency to the
+hot path. You can **opt in** to memoizing its decisions so an identical
+`(principal, operation_type, operation_name, arguments)` is not re-evaluated within a short
+TTL:
+
+```python
+from fraiseql import create_fraiseql_app, AuthorizationCacheConfig
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[...], queries=[...], mutations=[...],
+    authorizer=MyAuthorizer(),
+    authorization_cache=AuthorizationCacheConfig(
+        principal_key=lambda ctx: ctx["user"]["id"],  # required: identify the principal
+        ttl_seconds=5.0,        # keep short — a stale *allow* is a security risk
+        max_entries=10_000,     # LRU bound
+    ),
+)
+```
+
+**Off by default.** Always-evaluate is the safe default; a stale *allow* briefly authorizes a
+now-revoked principal (a stale *deny* is only an availability nuisance). Caching is never
+implicit.
+
+**⚠️ Correctness contract — the authorizer must be a pure function of the key.** A cache hit
+replays a prior decision, so caching is only correct if the decision depends on **nothing
+outside** `(principal_key(context), operation_type, operation_name, arguments)`. An authorizer
+that also reads tenant, request IP, time-of-day, feature flags, or resource state from
+`context` will be served a **wrong** decision on a hit — including a *stale allow*. This is a
+correctness bug, **not** merely a TTL staleness window: such an authorizer is broken under
+caching regardless of how short the TTL is. Fold the extra inputs into `principal_key`, or
+leave caching off. The framework cannot detect a non-pure authorizer.
+
+Other guarantees:
+
+- **`principal_key` is required**, and a `None` return (anonymous/unknown principal) is
+  **never cached** — an entry is never shared across unidentified principals.
+- **Non-serializable arguments are never cached** — the call falls through to evaluate.
+- **The whole decision is cached, including `filters`** (they are principal- and
+  argument-derived, already in the key). Denies are cached too; the TTL bounds staleness.
+- **A raising authorizer is never cached.** It still hits the fail-closed branch, so a
+  transient policy-service error can neither pin a deny nor leak an allow.
+- **TTL-only invalidation.** There is **no active invalidation hook** in this version — keep
+  the TTL short. Revoke-on-event is a possible future extension.
+- The cache is process-global (held on the registry) and survives schema hot-reload, which is
+  exactly why `principal_key` must be present and correct.
+
+> Hit-rate note (not a defect): the resolver path keys on `info.field_name` + resolved kwargs
+> while the bypass gates derive the operation name and pass request variables, so the same
+> logical op keys differently per path. This is safe (no false sharing) — just a lower hit rate.
+
 ## Migration from the registry rewrite
 
 **Before** — coupling the security boundary to a private attribute:

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -149,13 +149,15 @@ from fraiseql.security import authorize_field, field_authorizer_adapter
 
 @field
 @authorize_field(field_authorizer_adapter(my_authorizer, field="User.email"))
-async def email(self, info) -> str | None:
+def email(self) -> str | None:
     return self._email
 ```
 
-> A field method combined with `@authorize_field` must take `info` (`async def
-> email(self, info)`): the check needs the request context, and an `async` resolver lets an
-> async authorizer run without the sync→async event-loop fallback.
+> `@field` and `@authorize_field` compose in **either order**, for any field-method shape
+> (`self`, `self, info`, sync or `async`). The permission check always receives the request
+> `info`; the field method itself only needs `info` if its own body uses it. A sync resolver
+> gated by an async authorizer (such as `field_authorizer_adapter`) works without warnings —
+> the check runs on the request's event loop.
 
 ### Automatic field gating (opt-in)
 

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -1,0 +1,176 @@
+# Operation Authorization
+
+FraiseQL provides a **first-class Policy Enforcement Point (PEP)** for operation-level
+authorization. The framework *enforces*; the *decision* is delegated to an application-supplied
+`Authorizer`. This replaces the fragile pattern of reaching into the private
+`SchemaRegistry._mutations` registry to bolt on a security boundary.
+
+> **Authentication vs. authorization.** Authentication (who the principal *is*) stays with
+> your `context_getter` / auth provider. This feature is about authorization (what an operation
+> is *allowed* to do). The authorizer is principal-agnostic: it reads everything it needs from
+> `context`, which your `context_getter` already populates.
+
+## Concepts
+
+### `AuthorizationDecision`
+
+An immutable value describing the outcome of a check:
+
+```python
+from fraiseql import AuthorizationDecision
+
+AuthorizationDecision.allow()                                  # allow
+AuthorizationDecision.allow(filters={"tenant_id": "t1"})       # allow + row scoping
+AuthorizationDecision.deny()                                   # deny, code "FORBIDDEN"
+AuthorizationDecision.deny(code="NO_MUTATIONS", message="read-only principal")
+```
+
+Fields: `allowed: bool`, `code: str | None`, `message: str | None`, `filters: dict | None`.
+
+### `Authorizer`
+
+A structural protocol — any object with an `authorize_operation` method qualifies:
+
+```python
+from fraiseql import Authorizer, AuthorizationDecision
+
+class TenantAuthorizer:
+    async def authorize_operation(
+        self, *, context, operation_type, operation_name, arguments
+    ) -> AuthorizationDecision | bool:
+        user = context.get("user")
+        if user is None:
+            return AuthorizationDecision.deny(message="authentication required")
+        # Scope every read to the principal's tenant.
+        if operation_type == "query":
+            return AuthorizationDecision.allow(filters={"tenant_id": user["tenant_id"]})
+        return AuthorizationDecision.allow()
+```
+
+- The return value may be a plain `bool` (`True` → allow, `False` → deny) or an
+  `AuthorizationDecision`.
+- The method may be **sync or async** — the framework awaits awaitables.
+- `operation_type` is `"query"` or `"mutation"`; `operation_name` is the GraphQL field name;
+  `arguments` are the (Python-named) operation arguments.
+
+## Wiring it up
+
+Pass `authorizer=` to the supported entry point. It gates every root query and mutation, the
+three resolver-bypass paths, and survives schema hot-reload:
+
+```python
+from fraiseql import create_fraiseql_app
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[...],
+    queries=[...],
+    mutations=[...],
+    authorizer=TenantAuthorizer(),   # global default
+)
+```
+
+With **no** `authorizer=`, behavior is byte-for-byte unchanged.
+
+### Per-operation override
+
+`@query` and `@mutation` accept a per-operation `authorizer=` that takes precedence over the
+global default for that operation only:
+
+```python
+@fraiseql.query(authorizer=AdminOnly())
+async def audit_log(info) -> list[AuditEntry]:
+    ...
+```
+
+> Per-operation overrides apply on the **resolver path** only. The resolver-bypass paths
+> (TurboRouter, `/graphql/rust`, APQ cache hits) consult the **global default** authorizer.
+
+## Fail-closed semantics
+
+Enforcement is fail-closed by construction, in a single helper every path shares:
+
+- An authorizer that **raises** denies the operation — it never falls through to "allow".
+- The raw exception is logged but **never** surfaced to the client (no internal leakage).
+- A deny becomes a `GraphQLError` with `extensions={"code": ...}` and a safe message.
+- An authorizer may raise its own `GraphQLError` to surface a custom error unchanged.
+
+## Filter injection (row scoping)
+
+A query authorizer can return `filters` to scope rows. They are AND-merged into the repository's
+existing `mandatory_filters` SQL primitive — column names are validated and values are always
+parameterized, so there is no injection surface.
+
+```python
+return AuthorizationDecision.allow(filters={"tenant_id": user["tenant_id"]})
+```
+
+Mechanism: `mandatory_filters` is a repository-method kwarg consumed in a *different call frame*
+than the resolver (your `@query` function sits in between), so the filter cannot ride resolver
+kwargs. Instead it rides the repository **context**, keyed by root field, and every read method
+(`find` / `find_one` / `count` / aggregates) merges it. If a caller's `mandatory_filters` and the
+authorization filters pin the **same column**, the conflict is rejected loudly rather than
+silently merged.
+
+## ⚠️ Bypass paths and their row-scoping caveat
+
+Three execution paths reach the database (or hand off to Rust) **without invoking a Python
+resolver**. All three are gated with the same fail-closed helper, but **per-row filter injection
+is impossible** on them:
+
+| Path | Gate | Row scoping |
+|------|------|-------------|
+| **TurboRouter / persisted queries** | enforced before the cached SQL template runs | session variables + database **RLS** |
+| **`POST /graphql/rust`** | enforced before the Rust pipeline is called | session variables + database **RLS** |
+| **APQ cached passthrough** | enforced before the cached response is served | a returned filter **bypasses the cache** and falls through to normal resolver execution (which applies the filter) |
+
+If an authorizer returns `filters` on the turbo or rust path, the filter is **logged, not
+silently dropped** — rely on session variables + RLS for row scoping there. For APQ, a returned
+filter is honored by skipping the (unscoped) cache entry. `filters` are also ignored (with a
+warning) on mutations and at field granularity.
+
+## Field-level authorization
+
+Field checks (`authorize_field`) speak the **same** contract: a `PermissionCheck` may return a
+`bool` (legacy, unchanged) or an `AuthorizationDecision`. A deny decision surfaces its
+`code`/`message`. One policy object can serve both layers via `field_authorizer_adapter`:
+
+```python
+from fraiseql.security import authorize_field, field_authorizer_adapter
+
+@field
+@authorize_field(field_authorizer_adapter(my_authorizer, field="email"))
+def email(self) -> str:
+    return self._email
+```
+
+## Migration from the registry rewrite
+
+**Before** — coupling the security boundary to a private attribute:
+
+```python
+registry = SchemaRegistry.get_instance()
+for name, fn in list(registry._mutations.items()):   # private — fragile
+    registry._mutations[name] = wrap_with_guard(fn)
+```
+
+**After** — the supported entry point:
+
+```python
+app = create_fraiseql_app(..., authorizer=MyAuthorizer())
+```
+
+The legacy registry rewrite keeps working during migration (the resolver wrap composes around
+whatever resolver is present at build time), but new code should use `authorizer=`.
+
+## Cross-version note
+
+The decision-function contract is intentionally **identical** to the v2 (Rust) counterpart
+([fraiseql/fraiseql#422](https://github.com/fraiseql/fraiseql/issues/422)). The runtimes are
+incompatible (v1 = Python objects + a mutable registry; v2 = Rust traits), so code cannot be
+shared — but a single policy implementation can serve both runtimes.
+
+## Out of scope
+
+- Subscriptions — operation-level gating for subscriptions is a follow-up.
+- A built-in policy DSL — only the enforcement point and decision contract are provided.

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -50,13 +50,13 @@ class TenantAuthorizer:
 - The return value may be a plain `bool` (`True` → allow, `False` → deny) or an
   `AuthorizationDecision`.
 - The method may be **sync or async** — the framework awaits awaitables.
-- `operation_type` is `"query"` or `"mutation"`; `operation_name` is the GraphQL field name;
-  `arguments` are the (Python-named) operation arguments.
+- `operation_type` is `"query"`, `"mutation"`, or `"subscription"`; `operation_name` is the
+  GraphQL field name; `arguments` are the (Python-named) operation arguments.
 
 ## Wiring it up
 
-Pass `authorizer=` to the supported entry point. It gates every root query and mutation, the
-three resolver-bypass paths, and survives schema hot-reload:
+Pass `authorizer=` to the supported entry point. It gates every root query, mutation, and
+subscription, the three resolver-bypass paths, and survives schema hot-reload:
 
 ```python
 from fraiseql import create_fraiseql_app
@@ -144,6 +144,33 @@ def email(self) -> str:
     return self._email
 ```
 
+## Subscriptions
+
+A subscription *is* an operation, so it is gated by the same PEP — enforced **once, at
+subscribe time**, before the event stream is created. graphql-core calls the subscription's
+`subscribe` resolver to obtain the stream; the authorizer runs there with
+`operation_type="subscription"`, so a deny raises a `GraphQLError` *during the subscribe
+call* and the inner generator — which is what would query the database — is never built.
+This covers both the schema execution path and the websocket transport (which routes through
+graphql-core's `subscribe`).
+
+```python
+@fraiseql.subscription(authorizer=AdminOnly())   # per-operation override
+async def audit_stream(info) -> AsyncGenerator[AuditEntry, None]:
+    ...
+```
+
+As with queries and mutations, a per-operation `@subscription(authorizer=...)` takes
+precedence over the global default; with no authorizer in effect, subscriptions stream
+byte-for-byte as before.
+
+- **Filters are ignored.** A subscription stream is not a single scoped read set, so a
+  returned `decision.filters` has no row-scoping meaning. It is **logged, not silently
+  dropped** (mirroring the mutation path) — rely on the stream source for any scoping.
+- **Subscribe-time only (for now).** Enforcement runs once, when the client subscribes — not
+  per emitted event. Revoking a *live* stream when permissions change mid-flight (per-event
+  re-checking) is a deliberate future opt-in, not part of this contract.
+
 ## Migration from the registry rewrite
 
 **Before** — coupling the security boundary to a private attribute:
@@ -172,5 +199,4 @@ shared — but a single policy implementation can serve both runtimes.
 
 ## Out of scope
 
-- Subscriptions — operation-level gating for subscriptions is a follow-up.
 - A built-in policy DSL — only the enforcement point and decision contract are provided.

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -153,6 +153,43 @@ def email(self) -> str:
     return self._email
 ```
 
+### Automatic field gating (opt-in)
+
+Instead of decorating each field by hand, a type can declare which fields the configured
+operation `Authorizer` should gate automatically (issue #366):
+
+```python
+@fraise_type(authorize_fields=["email", "ssn"])
+class User:
+    id: int
+    name: str          # ungated
+    email: str         # gated automatically
+    ssn: str           # gated automatically
+```
+
+Each listed field is checked with `operation_type="field"` and
+`operation_name="User.email"` (`"TypeName.fieldName"` — a stable identifier to write
+policies against) **before its resolver runs**, so a denial means the field body never
+executes. Guarantees:
+
+- **Narrow opt-in by design.** Only the declared fields are gated; everything else carries
+  zero extra cost. There is deliberately no "gate every field" switch (it would be a
+  performance and blast-radius footgun).
+- **No authorizer → unchanged.** The gate reads the global default authorizer live; with
+  none configured it is a true no-op.
+- **Fail-closed.** A raising field authorizer is normalized to a
+  `FIELD_AUTHORIZATION_ERROR` deny (parity with the operation path); `filters` are ignored
+  with a warning at field granularity.
+- **Precedence.** An explicit `@authorize_field` on a field is **AND-combined** with the
+  automatic gate — both must allow.
+
+> **⚠️ Performance: this fires per resolved object.** For a list of *N* objects each
+> exposing *M* gated fields, that is up to *N×M* authorizer calls. Keep the opt-in set
+> narrow, and enable **decision caching** (see below) — the same `(principal, "field",
+> "Type.field", arguments)` repeats across every object in a list, so a cache collapses the
+> *N* calls per field into one within the TTL. Measure the call volume for representative
+> nested-list queries before gating hot fields.
+
 ## Subscriptions
 
 A subscription *is* an operation, so it is gated by the same PEP — enforced **once, at

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -148,10 +148,14 @@ Field checks (`authorize_field`) speak the **same** contract: a `PermissionCheck
 from fraiseql.security import authorize_field, field_authorizer_adapter
 
 @field
-@authorize_field(field_authorizer_adapter(my_authorizer, field="email"))
-def email(self) -> str:
+@authorize_field(field_authorizer_adapter(my_authorizer, field="User.email"))
+async def email(self, info) -> str | None:
     return self._email
 ```
+
+> A field method combined with `@authorize_field` must take `info` (`async def
+> email(self, info)`): the check needs the request context, and an `async` resolver lets an
+> async authorizer run without the sync→async event-loop fallback.
 
 ### Automatic field gating (opt-in)
 

--- a/examples/authorization/README.md
+++ b/examples/authorization/README.md
@@ -1,0 +1,20 @@
+# Operation Authorization Example
+
+Shows the supported first-class authorization extension point (issue #362):
+
+- **`DenyMutationsAuthorizer`** — a cross-cutting policy ("read-only principals may not run
+  mutations"), expressed through `create_fraiseql_app(authorizer=...)` instead of rewriting the
+  private `SchemaRegistry._mutations` registry.
+- **`TenantScopeAuthorizer`** — per-row scoping: every query is transparently limited to the
+  principal's tenant via `AuthorizationDecision.allow(filters={"tenant_id": ...})`, AND-merged
+  into the repository's validated, parameterized `mandatory_filters`.
+
+The same authorizer also gates the resolver-bypass paths (TurboRouter, `POST /graphql/rust`, APQ
+cache hits) and survives schema hot-reload.
+
+```bash
+python examples/authorization/app.py
+```
+
+See [docs/security/authorization.md](../../docs/security/authorization.md) for the full guide,
+fail-closed semantics, and the bypass-path / RLS caveat.

--- a/examples/authorization/app.py
+++ b/examples/authorization/app.py
@@ -1,0 +1,97 @@
+"""First-class operation authorization example (issue #362).
+
+Demonstrates the supported `create_fraiseql_app(authorizer=...)` entry point with two
+authorizers:
+
+- ``DenyMutationsAuthorizer`` — a cross-cutting rule ("read-only principals may not run
+  mutations") expressed without touching any private registry attribute.
+- ``TenantScopeAuthorizer`` — row scoping: every read is transparently limited to the
+  principal's tenant via ``AuthorizationDecision.allow(filters=...)``.
+
+Run the file directly to print the resulting schema, or import ``build_app`` in a test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import fraiseql
+from fraiseql import AuthorizationDecision, create_fraiseql_app
+
+
+@fraiseql.type
+class Document:
+    """A tenant-scoped document."""
+
+    id: int
+    title: str
+
+
+@fraiseql.query
+async def documents(info) -> list[Document]:
+    """List documents (scoped to the principal's tenant by the authorizer)."""
+    db = info.context["db"]
+    # No tenant filter is hand-written here — the authorizer injects it.
+    return await db.find("v_document")
+
+
+@fraiseql.mutation
+async def create_document(info, title: str) -> Document:
+    """Create a document (blocked for read-only principals by the authorizer)."""
+    db = info.context["db"]
+    return await db.find_one("v_document", title=title)
+
+
+class DenyMutationsAuthorizer:
+    """Read-only principals may run queries but never mutations."""
+
+    async def authorize_operation(
+        self,
+        *,
+        context: dict[str, Any],
+        operation_type: str,
+        operation_name: str,
+        arguments: dict[str, Any],
+    ) -> AuthorizationDecision:
+        user = context.get("user") or {}
+        if operation_type == "mutation" and user.get("role") == "readonly":
+            return AuthorizationDecision.deny(
+                code="READ_ONLY_PRINCIPAL",
+                message="this principal may not run mutations",
+            )
+        return AuthorizationDecision.allow()
+
+
+class TenantScopeAuthorizer:
+    """Allow everything, but scope every read to the principal's tenant."""
+
+    async def authorize_operation(
+        self,
+        *,
+        context: dict[str, Any],
+        operation_type: str,
+        operation_name: str,
+        arguments: dict[str, Any],
+    ) -> AuthorizationDecision:
+        user = context.get("user")
+        if user is None:
+            return AuthorizationDecision.deny(message="authentication required")
+        if operation_type == "query":
+            return AuthorizationDecision.allow(filters={"tenant_id": user["tenant_id"]})
+        return AuthorizationDecision.allow()
+
+
+def build_app(*, authorizer: Any):
+    """Build a FraiseQL app gated by the given authorizer."""
+    return create_fraiseql_app(
+        database_url="postgresql://localhost/example",
+        types=[Document],
+        queries=[documents],
+        mutations=[create_document],
+        authorizer=authorizer,
+    )
+
+
+if __name__ == "__main__":
+    app = build_app(authorizer=DenyMutationsAuthorizer())
+    print(f"Built app with {len(app.routes)} routes and a deny-mutations authorizer.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
     - Security:
       - Security Model: architecture/security/security-model.md
       - Authentication: architecture/security/authentication-detailed.md
+      - Operation Authorization: security/authorization.md
     - Realtime:
       - Subscriptions: architecture/realtime/subscriptions.md
       - Subscriptions Architecture: architecture/realtime/subscriptions-corrected-architecture.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.23.1"
+version = "1.23.2"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.23.4"
+version = "1.23.5"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.23.3"
+version = "1.23.4"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.22.0"
+version = "1.23.0"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.23.2"
+version = "1.23.3"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.23.0"
+version = "1.23.1"
 
 [project.optional-dependencies]
 all = [

--- a/src/fraiseql/__init__.py
+++ b/src/fraiseql/__init__.py
@@ -46,6 +46,13 @@ _input_decorator = fraise_input  # For fraiseql.input access via __getattr__
 enum = fraise_enum
 interface = fraise_interface
 
+# Operation-level authorization (issue #362)
+from .security.authorization import (
+    AuthorizationDecision,
+    Authorizer,
+    normalize_decision,
+)
+
 # FastAPI integration (optional)
 try:
     from .fastapi import FraiseQLConfig, create_fraiseql_app
@@ -137,6 +144,8 @@ __all__ = [
     "Auth0Config",
     "Auth0Provider",
     "AuthProvider",
+    "AuthorizationDecision",
+    "Authorizer",
     "CQRSExecutor",
     "CQRSRepository",
     "Connection",
@@ -168,6 +177,7 @@ __all__ = [
     # "input",  # REMOVED: Shadows builtin - use fraiseql.input or fraise_input
     "interface",
     "mutation",
+    "normalize_decision",
     "query",
     "requires_auth",
     "requires_permission",

--- a/src/fraiseql/__init__.py
+++ b/src/fraiseql/__init__.py
@@ -52,6 +52,10 @@ from .security.authorization import (
     Authorizer,
     normalize_decision,
 )
+from .security.decision_cache import (
+    AuthorizationCacheConfig,
+    DecisionCache,
+)
 
 # FastAPI integration (optional)
 try:
@@ -144,12 +148,14 @@ __all__ = [
     "Auth0Config",
     "Auth0Provider",
     "AuthProvider",
+    "AuthorizationCacheConfig",
     "AuthorizationDecision",
     "Authorizer",
     "CQRSExecutor",
     "CQRSRepository",
     "Connection",
     "Date",
+    "DecisionCache",
     "Edge",
     "EmailAddress",
     "Error",

--- a/src/fraiseql/__init__.pyi
+++ b/src/fraiseql/__init__.pyi
@@ -15,6 +15,7 @@ def fraise_type_decorator(
     jsonb_column: str | None = None,
     implements: list[Type[Any]] | None = None,
     resolve_nested: bool = False,
+    authorize_fields: list[str] | None = None,
 ) -> Callable[[Type[_T]], Type[_T]]: ...
 def fraise_type_decorator(
     cls: Type[_T] | None = None,
@@ -23,6 +24,7 @@ def fraise_type_decorator(
     jsonb_column: str | None = None,
     implements: list[Type[Any]] | None = None,
     resolve_nested: bool = False,
+    authorize_fields: list[str] | None = None,
 ) -> Type[_T] | Callable[[Type[_T]], Type[_T]]: ...
 @overload
 def fraise_input_decorator(cls: Type[_T]) -> Type[_T]: ...

--- a/src/fraiseql/__init__.pyi
+++ b/src/fraiseql/__init__.pyi
@@ -230,6 +230,11 @@ class Auth0Config:
 class Auth0Provider(AuthProvider):
     def __init__(self, config: Auth0Config) -> None: ...
 
+# Operation-level authorization (issue #362)
+from .security.authorization import AuthorizationDecision as AuthorizationDecision
+from .security.authorization import Authorizer as Authorizer
+from .security.authorization import normalize_decision as normalize_decision
+
 # FastAPI integration (when available)
 try:
     from .fastapi import FraiseQLConfig as FraiseQLConfig
@@ -261,6 +266,9 @@ __all__ = [
     "Auth0Provider",
     # Auth (optional)
     "AuthProvider",
+    # Operation authorization (issue #362)
+    "AuthorizationDecision",
+    "Authorizer",
     "CQRSExecutor",
     # CQRS
     "CQRSRepository",
@@ -301,6 +309,7 @@ __all__ = [
     "input",
     "interface",
     "mutation",
+    "normalize_decision",
     "query",
     "requires_auth",
     "requires_permission",

--- a/src/fraiseql/core/graphql_type.py
+++ b/src/fraiseql/core/graphql_type.py
@@ -508,6 +508,19 @@ def convert_type_to_graphql_output(
                 # This allows the type to reference itself (e.g., Playlist with child_playlists)
                 def make_fields_thunk():
                     gql_fields = {}
+
+                    # Automatic field-level authorization opt-in (issue #366). Wrap only the
+                    # declared fields' resolvers; a no-op (returns the resolver unchanged) for
+                    # any field not in the set, so non-opted fields carry zero extra cost.
+                    _authorize_fields = getattr(typ, "__fraiseql_authorize_fields__", None)
+
+                    def _gate(resolver: Any, field_name: str) -> Any:
+                        if not _authorize_fields or field_name not in _authorize_fields:
+                            return resolver
+                        from fraiseql.security.field_auth import gate_field_resolver
+
+                        return gate_field_resolver(resolver, field=f"{typ.__name__}.{field_name}")
+
                     for name, field in fields.items():
                         field_type = field.field_type or type_hints.get(name)
                         if field_type is not None:
@@ -583,8 +596,9 @@ def convert_type_to_graphql_output(
                                     type_=gql_type,
                                     description=field.description,
                                     args=gql_args,
-                                    resolve=wrap_resolver_with_enum_serialization(
-                                        enhanced_resolver
+                                    resolve=_gate(
+                                        wrap_resolver_with_enum_serialization(enhanced_resolver),
+                                        name,
                                     ),
                                 )
                                 continue  # Skip other resolver creation
@@ -626,7 +640,10 @@ def convert_type_to_graphql_output(
                                 gql_fields[graphql_field_name] = GraphQLField(
                                     type_=gql_type,
                                     description=field.description,
-                                    resolve=wrap_resolver_with_enum_serialization(smart_resolver),
+                                    resolve=_gate(
+                                        wrap_resolver_with_enum_serialization(smart_resolver),
+                                        name,
+                                    ),
                                 )
                                 continue  # Skip the regular resolver creation
 
@@ -767,8 +784,11 @@ def convert_type_to_graphql_output(
                             gql_fields[graphql_field_name] = GraphQLField(
                                 type_=gql_type,
                                 description=field.description,
-                                resolve=wrap_resolver_with_enum_serialization(
-                                    make_field_resolver(name, field_type)
+                                resolve=_gate(
+                                    wrap_resolver_with_enum_serialization(
+                                        make_field_resolver(name, field_type)
+                                    ),
+                                    name,
                                 ),
                             )
 
@@ -860,7 +880,7 @@ def convert_type_to_graphql_output(
 
                                 gql_fields[graphql_field_name] = GraphQLField(
                                     type_=cast("GraphQLOutputType", gql_return_type),
-                                    resolve=wrapped_resolver,
+                                    resolve=_gate(wrapped_resolver, attr_name),
                                     description=description,
                                 )
 

--- a/src/fraiseql/core/resolver_invocation.py
+++ b/src/fraiseql/core/resolver_invocation.py
@@ -1,0 +1,107 @@
+"""One canonical convention for invoking a field resolver.
+
+Both ``@field`` and ``@authorize_field`` wrap field methods, and historically each decided
+*how* to call what it wrapped independently — duplicated, and subtly disagreeing. That
+disagreement is the field-authorization signature-adaptation bug: an outer decorator would
+call an inner wrapper with the wrong number of arguments.
+
+This module is the single source of truth. :func:`resolver_call_spec` inspects a target
+*once*; :func:`invoke_resolver` calls it with the arguments its real signature expects.
+Kept dependency-light on purpose (only :mod:`inspect`/:mod:`functools`) so the decorator and
+security layers can both depend on it without import cycles.
+
+Detection rules, in priority order:
+
+1. ``__fraiseql_field__`` — the target is an already-normalized ``@field`` wrapper that
+   self-adapts; call it ``target(root, info, *args, **kwargs)``. This rule is what makes the
+   two decorator orders behave identically.
+2. bound method (``__self__``) — ``self`` is already bound; pass ``info`` only if declared.
+3. otherwise inspect the target's *own* parameters: a leading ``self`` takes ``root``; an
+   ``info`` parameter takes ``info``.
+
+The target is **always inspected itself** — never via ``__fraiseql_original_func__``.
+Falling back to the original function's arity would re-derive a ``self``-only shape for a
+wrapper whose real interface is ``(root, info, *args, **kwargs)``, re-introducing the very
+"missing ``info``" bug this convention removes. Any wrapper that genuinely self-adapts
+already carries ``__fraiseql_field__`` and is caught by rule 1.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class CallSpec(NamedTuple):
+    """How a resolver target wants to be called (computed once, then dispatched)."""
+
+    is_field_wrapper: bool
+    is_bound: bool
+    has_self: bool
+    expects_info: bool
+
+
+def _compute_call_spec(target: Callable[..., Any]) -> CallSpec:
+    if getattr(target, "__fraiseql_field__", False):
+        return CallSpec(is_field_wrapper=True, is_bound=False, has_self=False, expects_info=False)
+
+    is_bound = hasattr(target, "__self__")
+    try:
+        params = list(inspect.signature(target).parameters.keys())
+    except (TypeError, ValueError):
+        params = []
+    return CallSpec(
+        is_field_wrapper=False,
+        is_bound=is_bound,
+        has_self="self" in params,
+        expects_info="info" in params,
+    )
+
+
+@functools.lru_cache(maxsize=1024)
+def _cached_call_spec(target: Callable[..., Any]) -> CallSpec:
+    return _compute_call_spec(target)
+
+
+def resolver_call_spec(target: Callable[..., Any]) -> CallSpec:
+    """Return how ``target`` should be called, memoized on the (stable) target identity.
+
+    Resolvers are decorated once and called many times, so the inspection is cached. An
+    unhashable target falls back to recomputing each call instead of raising.
+    """
+    try:
+        return _cached_call_spec(target)
+    except TypeError:
+        return _compute_call_spec(target)
+
+
+def invoke_resolver(
+    target: Callable[..., Any],
+    root: Any,
+    info: Any,
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Call ``target`` with the arguments its real signature expects.
+
+    Returns the target's result directly — a coroutine if the target is async (the caller
+    awaits it), a plain value otherwise. Argument adaptation only; the permission-check
+    contract lives in the security layer and is untouched here.
+    """
+    spec = resolver_call_spec(target)
+    if spec.is_field_wrapper:
+        return target(root, info, *args, **kwargs)
+    if spec.is_bound:
+        if spec.expects_info:
+            return target(info, *args, **kwargs)
+        return target(*args, **kwargs)
+    if spec.has_self:
+        if spec.expects_info:
+            return target(root, info, *args, **kwargs)
+        return target(root, *args, **kwargs)
+    return target(root, info, *args, **kwargs)

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -822,6 +822,37 @@ class FraiseQLRepository:
         # Cache for type names to avoid repeated registry lookups
         self._type_name_cache: dict[str, Optional[str]] = {}
 
+    def _consume_mandatory_filters(self, kwargs: dict[str, Any]) -> dict[str, Any] | None:
+        """Pop the caller's ``mandatory_filters`` and AND-merge authorization filters.
+
+        Operation-level authorization (issue #362) writes row-scoping filters into the
+        repository context, keyed by the current root field, via the query resolver.
+        This helper merges them with any explicit ``mandatory_filters`` the caller passed,
+        so every read method applies both. Column safety and parameterization remain in
+        :func:`_make_mandatory_conditions`.
+
+        Overlapping columns between the caller's filters and the authorization filters
+        are rejected loudly — silently overwriting one with the other would quietly widen
+        or contradict an authorization scope.
+
+        Returns:
+            The merged ``{column: value}`` dict, or ``None`` when neither source applies.
+        """
+        explicit = kwargs.pop("mandatory_filters", None) or {}
+        auth = (self.context.get("_fraiseql_auth_filters") or {}).get(
+            self.context.get("graphql_field_name")
+        ) or {}
+        if not auth:
+            return explicit or None
+        overlap = set(explicit) & set(auth)
+        if overlap:
+            from graphql import GraphQLError
+
+            msg = f"authorization filter conflicts with caller mandatory_filters: {sorted(overlap)}"
+            raise GraphQLError(msg)
+        merged = {**explicit, **auth}
+        return merged or None
+
     def _get_cached_type_name(self, view_name: str) -> Optional[str]:
         """Get cached type name for a view, or lookup and cache it if not found.
 
@@ -1269,7 +1300,7 @@ class FraiseQLRepository:
             info = self.context["graphql_info"]
 
         # Extract mandatory_filters before any dispatch path (#344)
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         mandatory_parts, mandatory_params = (
             _make_mandatory_conditions(mandatory_filters) if mandatory_filters else ([], [])
         )
@@ -1521,7 +1552,7 @@ class FraiseQLRepository:
             info = self.context["graphql_info"]
 
         # Extract mandatory_filters before it reaches kwargs (#344)
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             mandatory_parts, mandatory_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = mandatory_parts
@@ -1652,7 +1683,7 @@ class FraiseQLRepository:
         from psycopg.sql import SQL, Composed, Identifier
 
         # Extract mandatory_filters before _build_where_clause (#344)
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             mandatory_parts, mandatory_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = mandatory_parts
@@ -1724,7 +1755,7 @@ class FraiseQLRepository:
         from psycopg.sql import SQL, Composed, Identifier
 
         # Extract mandatory_filters before _build_where_clause (#344)
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             mandatory_parts, mandatory_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = mandatory_parts
@@ -1794,7 +1825,7 @@ class FraiseQLRepository:
         from psycopg.sql import SQL, Composed, Identifier
 
         # Extract mandatory_filters before _build_where_clause (#344)
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             mandatory_parts, mandatory_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = mandatory_parts
@@ -1857,7 +1888,7 @@ class FraiseQLRepository:
         """
         from psycopg.sql import SQL, Composed, Identifier
 
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             m_parts, m_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = m_parts
@@ -1916,7 +1947,7 @@ class FraiseQLRepository:
         """
         from psycopg.sql import SQL, Composed, Identifier
 
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             m_parts, m_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = m_parts
@@ -1971,7 +2002,7 @@ class FraiseQLRepository:
         """
         from psycopg.sql import SQL, Composed, Identifier
 
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             m_parts, m_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = m_parts
@@ -2030,7 +2061,7 @@ class FraiseQLRepository:
         """
         from psycopg.sql import SQL, Composed, Identifier
 
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             m_parts, m_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = m_parts
@@ -2098,7 +2129,7 @@ class FraiseQLRepository:
         """
         from psycopg.sql import SQL, Composed, Identifier
 
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             m_parts, m_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = m_parts
@@ -2177,7 +2208,7 @@ class FraiseQLRepository:
         if not aggregations:
             return {}
 
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             m_parts, m_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = m_parts
@@ -2251,7 +2282,7 @@ class FraiseQLRepository:
         if not ids:
             return {}
 
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             m_parts, m_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = m_parts
@@ -2524,7 +2555,7 @@ class FraiseQLRepository:
         from psycopg.sql import SQL, Composed, Identifier, Literal
 
         # Convert mandatory_filters to internal parts if passed directly (#344)
-        mandatory_filters = kwargs.pop("mandatory_filters", None)
+        mandatory_filters = self._consume_mandatory_filters(kwargs)
         if mandatory_filters:
             m_parts, m_params = _make_mandatory_conditions(mandatory_filters)
             kwargs["_mandatory_parts"] = m_parts

--- a/src/fraiseql/decorators.py
+++ b/src/fraiseql/decorators.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, TypeVar, overload
 
 from graphql import GraphQLResolveInfo
 
+from fraiseql.core.resolver_invocation import invoke_resolver
 from fraiseql.gql.schema_builder import SchemaRegistry
 from fraiseql.types.generic import Connection
 
@@ -491,21 +492,10 @@ def field(
     """
 
     def decorator(func: F) -> F:
-        # Determine if the function is async
+        # Determine if the function is async; that selects the wrapper variant. How the
+        # resolver is actually called is delegated to invoke_resolver (the shared
+        # convention), so @field and @authorize_field never disagree on argument shape.
         is_async = asyncio.iscoroutinefunction(func)
-
-        # Inspect the function signature to determine how to call it
-        import inspect
-
-        sig = inspect.signature(func)
-        params = list(sig.parameters.keys())
-
-        # Determine the expected number of arguments
-        # For methods: self is first, then optionally info
-        # For functions: root is first, then info
-        has_self = "self" in params
-        expects_info = "info" in params
-        len(params)
 
         if is_async:
 
@@ -519,23 +509,7 @@ def field(
                 if detector and detector.enabled:
                     start_time = time.time()
                     try:
-                        # Call the original method based on its signature
-                        if hasattr(func, "__self__"):
-                            # Bound method - self is already bound
-                            if expects_info:
-                                result = await func(info, *args, **kwargs)
-                            else:
-                                result = await func(*args, **kwargs)
-                        # Unbound method or function
-                        elif has_self:
-                            # Method expects self as first arg
-                            if expects_info:
-                                result = await func(root, info, *args, **kwargs)
-                            else:
-                                result = await func(root, *args, **kwargs)
-                        else:
-                            # Regular function
-                            result = await func(root, info, *args, **kwargs)
+                        result = await invoke_resolver(func, root, info, *args, **kwargs)
                         execution_time = time.time() - start_time
                         # Track field resolution without blocking
                         # Using create_task is safe here as detector manages its own lifecycle
@@ -552,21 +526,8 @@ def field(
                         )
                         task.add_done_callback(lambda t: t.exception() if t.done() else None)
                         raise
-                # Call the original method based on its signature
-                elif hasattr(func, "__self__"):
-                    # Bound method - self is already bound
-                    if expects_info:
-                        return await func(info, *args, **kwargs)
-                    return await func(*args, **kwargs)
-                # Unbound method or function
-                elif has_self:
-                    # Method expects self as first arg
-                    if expects_info:
-                        return await func(root, info, *args, **kwargs)
-                    return await func(root, *args, **kwargs)
-                else:
-                    # Regular function
-                    return await func(root, info, *args, **kwargs)
+                # No N+1 tracking: call through the shared invocation convention.
+                return await invoke_resolver(func, root, info, *args, **kwargs)
 
             wrapped_func = async_wrapped_resolver
 
@@ -582,23 +543,7 @@ def field(
                 if detector and detector.enabled:
                     start_time = time.time()
                     try:
-                        # Call the original method based on its signature
-                        if hasattr(func, "__self__"):
-                            # Bound method - self is already bound
-                            if expects_info:
-                                result = func(info, *args, **kwargs)
-                            else:
-                                result = func(*args, **kwargs)
-                        # Unbound method or function
-                        elif has_self:
-                            # Method expects self as first arg
-                            if expects_info:
-                                result = func(root, info, *args, **kwargs)
-                            else:
-                                result = func(root, *args, **kwargs)
-                        else:
-                            # Regular function
-                            result = func(root, info, *args, **kwargs)
+                        result = invoke_resolver(func, root, info, *args, **kwargs)
                         execution_time = time.time() - start_time
                         # Track field resolution without blocking
                         # For sync resolvers, we need to handle async tracking differently
@@ -637,21 +582,8 @@ def field(
                             # No event loop - skip tracking for now
                             pass
                         raise
-                # Call the original method based on its signature
-                elif hasattr(func, "__self__"):
-                    # Bound method - self is already bound
-                    if expects_info:
-                        return func(info, *args, **kwargs)
-                    return func(*args, **kwargs)
-                # Unbound method or function
-                elif has_self:
-                    # Method expects self as first arg
-                    if expects_info:
-                        return func(root, info, *args, **kwargs)
-                    return func(root, *args, **kwargs)
-                else:
-                    # Regular function
-                    return func(root, info, *args, **kwargs)
+                # No N+1 tracking: call through the shared invocation convention.
+                return invoke_resolver(func, root, info, *args, **kwargs)
 
             wrapped_func = sync_wrapped_resolver
 

--- a/src/fraiseql/decorators.py
+++ b/src/fraiseql/decorators.py
@@ -192,10 +192,10 @@ def subscription(fn: F) -> F: ...
 
 
 @overload
-def subscription() -> Callable[[F], F]: ...
+def subscription(*, authorizer: Any | None = None) -> Callable[[F], F]: ...
 
 
-def subscription(fn: F | None = None) -> F | Callable[[F], F]:
+def subscription(fn: F | None = None, *, authorizer: Any | None = None) -> F | Callable[[F], F]:
     """Decorator to mark a function as a GraphQL subscription.
 
     This decorator automatically registers the function with the GraphQL schema
@@ -204,6 +204,9 @@ def subscription(fn: F | None = None) -> F | Callable[[F], F]:
 
     Args:
         fn: The subscription function to decorate (when used without parentheses)
+        authorizer: Optional per-operation :class:`~fraiseql.security.Authorizer`
+            override (issue #364). It takes precedence over the global default
+            authorizer for this subscription only, enforced once at subscribe time.
 
     Returns:
         The decorated async generator function with GraphQL subscription metadata
@@ -302,6 +305,9 @@ def subscription(fn: F | None = None) -> F | Callable[[F], F]:
         # Register with schema
         registry = SchemaRegistry.get_instance()
         registry.register_subscription(func)
+        # Per-operation authorizer override (issue #364); None falls back to the
+        # registry default at subscribe time via resolve_authorizer.
+        func.__fraiseql_authorizer__ = authorizer
         return func
 
     if fn is None:

--- a/src/fraiseql/decorators.py
+++ b/src/fraiseql/decorators.py
@@ -19,10 +19,10 @@ def query(fn: F) -> F: ...
 
 
 @overload
-def query() -> Callable[[F], F]: ...
+def query(*, authorizer: Any | None = None) -> Callable[[F], F]: ...
 
 
-def query(fn: F | None = None) -> F | Callable[[F], F]:
+def query(fn: F | None = None, *, authorizer: Any | None = None) -> F | Callable[[F], F]:
     """Decorator to mark a function as a GraphQL query.
 
     This decorator automatically registers the function with the GraphQL schema,
@@ -30,6 +30,9 @@ def query(fn: F | None = None) -> F | Callable[[F], F]:
 
     Args:
         fn: The query function to decorate (when used without parentheses)
+        authorizer: Optional per-operation :class:`~fraiseql.security.Authorizer`
+            override (issue #362). It takes precedence over the global default
+            authorizer for this query only.
 
     Returns:
         The decorated function with GraphQL query metadata
@@ -164,6 +167,10 @@ def query(fn: F | None = None) -> F | Callable[[F], F]:
                 return func(*args, **kwargs)
 
             wrapper = sync_wrapper
+
+        # Per-operation authorizer override (issue #362); None falls back to the
+        # registry default at resolve time.
+        wrapper.__fraiseql_authorizer__ = authorizer
 
         # Register the wrapper (not the original function)
         registry.register_query(wrapper)

--- a/src/fraiseql/fastapi/app.py
+++ b/src/fraiseql/fastapi/app.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import psycopg_pool
 from fastapi import FastAPI, Request
@@ -25,6 +25,9 @@ from fraiseql.fastapi.turbo import TurboRegistry
 from fraiseql.gql.schema_builder import build_fraiseql_schema
 from fraiseql.introspection import AutoDiscovery
 from fraiseql.utils import normalize_database_url
+
+if TYPE_CHECKING:
+    from fraiseql.security.authorization import Authorizer
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +189,8 @@ def create_fraiseql_app(
     enable_schema_registry: bool = True,
     # FastAPI app to extend (optional)
     app: FastAPI | None = None,
+    # Operation authorization (issue #362)
+    authorizer: "Authorizer | None" = None,
 ) -> FastAPI:
     """Create a FastAPI application with FraiseQL GraphQL endpoint.
 
@@ -211,6 +216,10 @@ def create_fraiseql_app(
         connection_pool_recycle: Seconds before recycling idle connections (default: 3600)
         enable_schema_registry: Whether to initialize Rust schema registry (default: True)
         app: Existing FastAPI app to extend (creates new if None)
+        authorizer: Optional global default operation authorizer (issue #362). When
+            provided it gates every root query/mutation and the three resolver-bypass
+            paths (TurboRouter, /graphql/rust, APQ cache hits), and survives schema
+            hot-reload. With no authorizer, behavior is byte-for-byte unchanged.
 
     Returns:
         Configured FastAPI application
@@ -488,6 +497,7 @@ def create_fraiseql_app(
         query_types=all_query_types,
         mutation_resolvers=all_mutations,
         camel_case_fields=config.auto_camel_case,
+        authorizer=authorizer,
     )
 
     # Store configuration for potential schema refresh
@@ -501,8 +511,12 @@ def create_fraiseql_app(
         "enable_schema_registry": enable_schema_registry,
         "config": config,
         "auth_provider": auth_provider,
+        # Re-applied on hot-reload so the authorizer survives a schema rebuild (#362).
+        "authorizer": authorizer,
     }
     app.state.graphql_schema = schema
+    # Expose the configured authorizer for the bypass gates / reload closure (#362).
+    app.state._fraiseql_authorizer = authorizer
 
     # Initialize Rust schema registry for type resolution
     # This enables correct __typename for nested JSONB objects and field aliasing
@@ -803,6 +817,9 @@ def create_fraiseql_app(
             query_types=all_query_types,
             mutation_resolvers=all_mutations,
             camel_case_fields=refresh_config["camel_case_fields"],
+            # Re-apply the authorizer so it survives hot-reload, re-installing it on the
+            # registry slot that the rebuilt resolver wrap and bypass gates read (#362).
+            authorizer=refresh_config.get("authorizer"),
         )
         logger.debug(f"Rebuilt schema with {len(new_schema.type_map)} types")
 

--- a/src/fraiseql/fastapi/app.py
+++ b/src/fraiseql/fastapi/app.py
@@ -28,6 +28,7 @@ from fraiseql.utils import normalize_database_url
 
 if TYPE_CHECKING:
     from fraiseql.security.authorization import Authorizer
+    from fraiseql.security.decision_cache import AuthorizationCacheConfig
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +192,8 @@ def create_fraiseql_app(
     app: FastAPI | None = None,
     # Operation authorization (issue #362)
     authorizer: "Authorizer | None" = None,
+    # Optional authorization decision caching (issue #367)
+    authorization_cache: "AuthorizationCacheConfig | None" = None,
 ) -> FastAPI:
     """Create a FastAPI application with FraiseQL GraphQL endpoint.
 
@@ -220,6 +223,11 @@ def create_fraiseql_app(
             provided it gates every root query/mutation and the three resolver-bypass
             paths (TurboRouter, /graphql/rust, APQ cache hits), and survives schema
             hot-reload. With no authorizer, behavior is byte-for-byte unchanged.
+        authorization_cache: Optional :class:`AuthorizationCacheConfig` enabling opt-in
+            TTL+LRU memoization of authorization decisions (issue #367). Off by default
+            (always-evaluate is the safe default). Enable only if the authorizer is a pure
+            function of principal + operation + arguments; see ``docs/security/authorization.md``.
+            Survives schema hot-reload like ``authorizer``.
 
     Returns:
         Configured FastAPI application
@@ -493,11 +501,20 @@ def create_fraiseql_app(
     all_query_types = list(types) + list(queries) + auto_types + auto_queries
     all_mutations = list(mutations) + auto_mutations
 
+    # Build the optional decision cache once (issue #367) so it (and its entries) survive
+    # hot-reload, mirroring how the authorizer instance is re-applied.
+    decision_cache = None
+    if authorization_cache is not None:
+        from fraiseql.security.decision_cache import DecisionCache
+
+        decision_cache = DecisionCache(authorization_cache)
+
     schema = build_fraiseql_schema(
         query_types=all_query_types,
         mutation_resolvers=all_mutations,
         camel_case_fields=config.auto_camel_case,
         authorizer=authorizer,
+        decision_cache=decision_cache,
     )
 
     # Store configuration for potential schema refresh
@@ -513,10 +530,14 @@ def create_fraiseql_app(
         "auth_provider": auth_provider,
         # Re-applied on hot-reload so the authorizer survives a schema rebuild (#362).
         "authorizer": authorizer,
+        # Same instance re-applied on hot-reload so the cache survives a rebuild (#367).
+        "decision_cache": decision_cache,
     }
     app.state.graphql_schema = schema
     # Expose the configured authorizer for the bypass gates / reload closure (#362).
     app.state._fraiseql_authorizer = authorizer
+    # Expose the configured decision cache for the reload closure (#367).
+    app.state._fraiseql_decision_cache = decision_cache
 
     # Initialize Rust schema registry for type resolution
     # This enables correct __typename for nested JSONB objects and field aliasing
@@ -820,6 +841,8 @@ def create_fraiseql_app(
             # Re-apply the authorizer so it survives hot-reload, re-installing it on the
             # registry slot that the rebuilt resolver wrap and bypass gates read (#362).
             authorizer=refresh_config.get("authorizer"),
+            # Likewise re-apply the decision cache (same instance) so it survives reload (#367).
+            decision_cache=refresh_config.get("decision_cache"),
         )
         logger.debug(f"Rebuilt schema with {len(new_schema.type_map)} types")
 

--- a/src/fraiseql/fastapi/config.py
+++ b/src/fraiseql/fastapi/config.py
@@ -150,6 +150,7 @@ class FraiseQLConfig(BaseSettings):
         complexity_enabled: Enable query complexity analysis (default: True)
         rate_limit_enabled: Enable rate limiting (default: True)
         cors_enabled: Enable CORS (default: False - use reverse proxy)
+        enable_rust_endpoint: Mount POST /graphql/rust resolver-bypass route (default: False)
 
     Example:
         ```python
@@ -282,6 +283,12 @@ class FraiseQLConfig(BaseSettings):
     # Execution settings (Rust-first: single execution path)
     execution_timeout_ms: int = 30000  # 30 seconds
     include_execution_metadata: bool = False  # Include timing in response
+
+    enable_rust_endpoint: bool = False
+    """Mount POST /graphql/rust (Rust passthrough, bypasses Python resolvers).
+
+    Off by default: a resolver-bypass route should not exist unless explicitly enabled.
+    The route is still authorization-gated when mounted (issue #362)."""
 
     # Default schema settings
     default_mutation_schema: str = "public"  # Default schema for mutations when not specified

--- a/src/fraiseql/fastapi/routers.py
+++ b/src/fraiseql/fastapi/routers.py
@@ -1713,75 +1713,80 @@ def create_graphql_router(
 
         return await graphql_endpoint(request_obj, http_request, context)
 
-    # Phase 9: Add simplified unified Rust pipeline endpoint
-    @router.post("/graphql/rust", response_class=Response)
-    async def graphql_endpoint_rust(
-        request: GraphQLRequest,
-        http_request: Request,
-        context: dict[str, Any] = context_dependency,
-    ) -> Response:
-        """Execute GraphQL query using unified Rust pipeline (Phase 9).
+    # Phase 9: simplified unified Rust pipeline endpoint. Opt-in (issue #365): this is a
+    # resolver-bypass route, so it is mounted only when explicitly enabled. It is still
+    # authorization-gated when present (issue #362); when disabled it simply does not exist
+    # (a request 404s), keeping the route allow-list the single source of truth.
+    if config.enable_rust_endpoint:
 
-        This endpoint demonstrates the dramatic simplification achieved by
-        moving all database operations to Rust. All work happens in a
-        single Rust function call.
-        """
-        # Operation authorization gate (issue #362). This endpoint hands off to Rust
-        # and never runs a Python resolver, so enforcement happens here, before the
-        # Rust call. Per-operation decorator overrides do not apply on this path.
-        authorizer = _registry_default_authorizer()
-        if authorizer is not None:
-            from graphql import GraphQLError
+        @router.post("/graphql/rust", response_class=Response)
+        async def graphql_endpoint_rust(
+            request: GraphQLRequest,
+            http_request: Request,
+            context: dict[str, Any] = context_dependency,
+        ) -> Response:
+            """Execute GraphQL query using unified Rust pipeline (Phase 9).
 
-            from fraiseql.security.authorization import enforce_operation_value
+            This endpoint demonstrates the dramatic simplification achieved by
+            moving all database operations to Rust. All work happens in a
+            single Rust function call.
+            """
+            # Operation authorization gate (issue #362). This endpoint hands off to Rust
+            # and never runs a Python resolver, so enforcement happens here, before the
+            # Rust call. Per-operation decorator overrides do not apply on this path.
+            authorizer = _registry_default_authorizer()
+            if authorizer is not None:
+                from graphql import GraphQLError
 
-            op_type, op_name = _derive_operation_info(request.query)
-            try:
-                decision = await enforce_operation_value(
-                    authorizer=authorizer,
-                    context=context,
-                    operation_type=op_type,
-                    operation_name=op_name,
-                    arguments=request.variables or {},
-                )
-            except GraphQLError as exc:
-                # Deny short-circuits: the Rust pipeline is never invoked.
-                return Response(
-                    content=json.dumps(_forbidden_error_payload(exc)).encode(),
-                    media_type="application/json",
-                )
-            if decision.filters:
-                # Per-row filters are impossible (work happens in Rust) → rely on
-                # session variables + RLS for row scoping; never silently drop them.
-                logger.warning(
-                    "authorization filters are ignored on the /graphql/rust path; "
-                    "rely on session variables + RLS for row scoping"
-                )
+                from fraiseql.security.authorization import enforce_operation_value
 
-        # Import the unified Rust function
-        from fraiseql._fraiseql_rs import execute_graphql_query
+                op_type, op_name = _derive_operation_info(request.query)
+                try:
+                    decision = await enforce_operation_value(
+                        authorizer=authorizer,
+                        context=context,
+                        operation_type=op_type,
+                        operation_name=op_name,
+                        arguments=request.variables or {},
+                    )
+                except GraphQLError as exc:
+                    # Deny short-circuits: the Rust pipeline is never invoked.
+                    return Response(
+                        content=json.dumps(_forbidden_error_payload(exc)).encode(),
+                        media_type="application/json",
+                    )
+                if decision.filters:
+                    # Per-row filters are impossible (work happens in Rust) → rely on
+                    # session variables + RLS for row scoping; never silently drop them.
+                    logger.warning(
+                        "authorization filters are ignored on the /graphql/rust path; "
+                        "rely on session variables + RLS for row scoping"
+                    )
 
-        # Extract user context for authorization. ``context["user"]`` is None for
-        # unauthenticated requests, so guard before attribute access.
-        user = context.get("user") or {}
-        user_context = {
-            "user_id": user.get("id"),
-            "permissions": user.get("permissions", []),
-            "roles": user.get("roles", []),
-        }
+            # Import the unified Rust function
+            from fraiseql._fraiseql_rs import execute_graphql_query
 
-        # Call unified Rust pipeline - all work done in Rust!
-        result_bytes = await execute_graphql_query(
-            query_string=request.query or "",
-            variables=request.variables or {},
-            user_context=user_context,
-        )
+            # Extract user context for authorization. ``context["user"]`` is None for
+            # unauthenticated requests, so guard before attribute access.
+            user = context.get("user") or {}
+            user_context = {
+                "user_id": user.get("id"),
+                "permissions": user.get("permissions", []),
+                "roles": user.get("roles", []),
+            }
 
-        # Return bytes directly (no Python JSON processing)
-        return Response(
-            content=result_bytes,
-            media_type="application/json",
-        )
+            # Call unified Rust pipeline - all work done in Rust!
+            result_bytes = await execute_graphql_query(
+                query_string=request.query or "",
+                variables=request.variables or {},
+                user_context=user_context,
+            )
+
+            # Return bytes directly (no Python JSON processing)
+            return Response(
+                content=result_bytes,
+                media_type="application/json",
+            )
 
     # Add metrics endpoint if enabled
     if hasattr(unified_executor, "get_metrics") and not is_production_env:

--- a/src/fraiseql/fastapi/routers.py
+++ b/src/fraiseql/fastapi/routers.py
@@ -1761,11 +1761,13 @@ def create_graphql_router(
         # Import the unified Rust function
         from fraiseql._fraiseql_rs import execute_graphql_query
 
-        # Extract user context for authorization
+        # Extract user context for authorization. ``context["user"]`` is None for
+        # unauthenticated requests, so guard before attribute access.
+        user = context.get("user") or {}
         user_context = {
-            "user_id": context.get("user", {}).get("id"),
-            "permissions": context.get("user", {}).get("permissions", []),
-            "roles": context.get("user", {}).get("roles", []),
+            "user_id": user.get("id"),
+            "permissions": user.get("permissions", []),
+            "roles": user.get("roles", []),
         }
 
         # Call unified Rust pipeline - all work done in Rust!

--- a/src/fraiseql/fastapi/routers.py
+++ b/src/fraiseql/fastapi/routers.py
@@ -1123,6 +1123,17 @@ def _registry_default_authorizer() -> Any:
     return SchemaRegistry.get_instance().default_authorizer
 
 
+def _registry_decision_cache() -> Any:
+    """Return the optional decision cache from the registry (issue #367).
+
+    Read live, like :func:`_registry_default_authorizer`, so a configured cache reaches the
+    bypass gates without per-request plumbing. ``None`` means always-evaluate.
+    """
+    from fraiseql.gql.builders import SchemaRegistry
+
+    return SchemaRegistry.get_instance().decision_cache
+
+
 def _forbidden_error_payload(exc: Any) -> dict[str, Any]:
     """Shape a denied :class:`GraphQLError` into a GraphQL error response body."""
     return {
@@ -1187,9 +1198,12 @@ def create_graphql_router(
     if turbo_registry is not None:
         try:
             logger.info(f"Creating TurboRouter with registry: {turbo_registry}")
-            # Thread the global default authorizer into the bypass gate (issue #362).
+            # Thread the global default authorizer and the optional decision cache into the
+            # bypass gate (issues #362, #367).
             turbo_router = TurboRouter(
-                turbo_registry, default_authorizer=_registry_default_authorizer()
+                turbo_registry,
+                default_authorizer=_registry_default_authorizer(),
+                decision_cache=_registry_decision_cache(),
             )
             logger.info(f"TurboRouter created successfully: {turbo_router}")
         except Exception:
@@ -1355,6 +1369,7 @@ def create_graphql_router(
                                 operation_type=op_type,
                                 operation_name=op_name,
                                 arguments=request.variables or {},
+                                cache=_registry_decision_cache(),
                             )
                         except GraphQLError as exc:
                             # Deny short-circuits: the cached response is never served.
@@ -1748,6 +1763,7 @@ def create_graphql_router(
                         operation_type=op_type,
                         operation_name=op_name,
                         arguments=request.variables or {},
+                        cache=_registry_decision_cache(),
                     )
                 except GraphQLError as exc:
                     # Deny short-circuits: the Rust pipeline is never invoked.

--- a/src/fraiseql/fastapi/routers.py
+++ b/src/fraiseql/fastapi/routers.py
@@ -1008,6 +1008,13 @@ async def execute_multi_field_query(
                 "path": [response_key],
             }
 
+            # Preserve GraphQLError extensions (e.g. authorization deny carries
+            # extensions={"code": "FORBIDDEN"}) so the deny shape is consistent with
+            # the other execution paths (issue #362).
+            error_extensions = getattr(e, "extensions", None)
+            if error_extensions:
+                error_dict["extensions"] = error_extensions
+
             # Add location info if available
             location = _extract_field_location(field_node)
             if location:

--- a/src/fraiseql/fastapi/routers.py
+++ b/src/fraiseql/fastapi/routers.py
@@ -1089,6 +1089,52 @@ class GraphQLRequest(BaseModel):
         return v
 
 
+def _derive_operation_info(query_string: str | None) -> tuple[str, str]:
+    """Best-effort ``(operation_type, root_field_name)`` from a query string.
+
+    The resolver-bypass authorization gates (``/graphql/rust`` and the APQ cache hit)
+    have no ``GraphQLResolveInfo``, so they derive the operation identity from the raw
+    query. Defaults to ``("query", "")`` when the document cannot be parsed.
+    """
+    if not query_string:
+        return "query", ""
+    try:
+        document = parse(query_string)
+    except Exception:
+        return "query", ""
+    for definition in document.definitions:
+        if isinstance(definition, OperationDefinitionNode):
+            op_type = definition.operation.value
+            for selection in definition.selection_set.selections:
+                if isinstance(selection, FieldNode):
+                    return op_type, selection.name.value
+            return op_type, ""
+    return "query", ""
+
+
+def _registry_default_authorizer() -> Any:
+    """Return the global default operation authorizer from the registry (issue #362).
+
+    The bypass gates read this live so a configured authorizer (set at build time or
+    re-applied on hot-reload) reaches them without per-request plumbing.
+    """
+    from fraiseql.gql.builders import SchemaRegistry
+
+    return SchemaRegistry.get_instance().default_authorizer
+
+
+def _forbidden_error_payload(exc: Any) -> dict[str, Any]:
+    """Shape a denied :class:`GraphQLError` into a GraphQL error response body."""
+    return {
+        "errors": [
+            {
+                "message": getattr(exc, "message", str(exc)),
+                "extensions": getattr(exc, "extensions", None) or {"code": "FORBIDDEN"},
+            }
+        ]
+    }
+
+
 def create_graphql_router(
     schema: GraphQLSchema,
     config: FraiseQLConfig,
@@ -1141,7 +1187,10 @@ def create_graphql_router(
     if turbo_registry is not None:
         try:
             logger.info(f"Creating TurboRouter with registry: {turbo_registry}")
-            turbo_router = TurboRouter(turbo_registry)
+            # Thread the global default authorizer into the bypass gate (issue #362).
+            turbo_router = TurboRouter(
+                turbo_registry, default_authorizer=_registry_default_authorizer()
+            )
             logger.info(f"TurboRouter created successfully: {turbo_router}")
         except Exception:
             logger.exception("Failed to create TurboRouter")
@@ -1285,8 +1334,43 @@ def create_graphql_router(
                     request, apq_backend, config, context=context
                 )
                 if cached_response:
-                    logger.debug(f"APQ cache hit: {sha256_hash[:8]}...")
-                    return cached_response
+                    # Operation authorization gate (issue #362): a cached (baked)
+                    # response cannot be re-scoped per principal, so enforce BEFORE
+                    # serving it. This path bypasses GraphQLField.resolve.
+                    serve_cached = True
+                    authorizer = _registry_default_authorizer()
+                    if authorizer is not None:
+                        from graphql import GraphQLError
+
+                        from fraiseql.security.authorization import enforce_operation_value
+
+                        persisted_text = (
+                            apq_backend.get_persisted_query(sha256_hash) if apq_backend else None
+                        )
+                        op_type, op_name = _derive_operation_info(persisted_text)
+                        try:
+                            decision = await enforce_operation_value(
+                                authorizer=authorizer,
+                                context=context,
+                                operation_type=op_type,
+                                operation_name=op_name,
+                                arguments=request.variables or {},
+                            )
+                        except GraphQLError as exc:
+                            # Deny short-circuits: the cached response is never served.
+                            return _forbidden_error_payload(exc)
+                        if decision.filters:
+                            # A baked cached response cannot honor per-row filters →
+                            # skip the cache and fall through to normal resolver
+                            # execution (which applies the filter on the read path).
+                            logger.info(
+                                "APQ cache skipped due to authorization scoping filters; "
+                                "falling through to normal execution"
+                            )
+                            serve_cached = False
+                    if serve_cached:
+                        logger.debug(f"APQ cache hit: {sha256_hash[:8]}...")
+                        return cached_response
 
                 # 2. Fallback to query resolution from backend
                 persisted_query_text = None
@@ -1642,6 +1726,38 @@ def create_graphql_router(
         moving all database operations to Rust. All work happens in a
         single Rust function call.
         """
+        # Operation authorization gate (issue #362). This endpoint hands off to Rust
+        # and never runs a Python resolver, so enforcement happens here, before the
+        # Rust call. Per-operation decorator overrides do not apply on this path.
+        authorizer = _registry_default_authorizer()
+        if authorizer is not None:
+            from graphql import GraphQLError
+
+            from fraiseql.security.authorization import enforce_operation_value
+
+            op_type, op_name = _derive_operation_info(request.query)
+            try:
+                decision = await enforce_operation_value(
+                    authorizer=authorizer,
+                    context=context,
+                    operation_type=op_type,
+                    operation_name=op_name,
+                    arguments=request.variables or {},
+                )
+            except GraphQLError as exc:
+                # Deny short-circuits: the Rust pipeline is never invoked.
+                return Response(
+                    content=json.dumps(_forbidden_error_payload(exc)).encode(),
+                    media_type="application/json",
+                )
+            if decision.filters:
+                # Per-row filters are impossible (work happens in Rust) → rely on
+                # session variables + RLS for row scoping; never silently drop them.
+                logger.warning(
+                    "authorization filters are ignored on the /graphql/rust path; "
+                    "rely on session variables + RLS for row scoping"
+                )
+
         # Import the unified Rust function
         from fraiseql._fraiseql_rs import execute_graphql_query
 

--- a/src/fraiseql/fastapi/turbo.py
+++ b/src/fraiseql/fastapi/turbo.py
@@ -4,12 +4,45 @@ TurboRouter bypasses GraphQL parsing and validation for registered queries
 by directly executing pre-validated SQL templates.
 """
 
+from __future__ import annotations
+
 import hashlib
+import logging
+import re
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from psycopg import AsyncConnection
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+    from fraiseql.security.authorization import Authorizer
+
+logger = logging.getLogger(__name__)
+
+
+def _turbo_operation_name(query_str: str) -> str:
+    """Extract the root field name from a GraphQL query, handling fragments.
+
+    Used as the ``operation_name`` for the TurboRouter authorization gate. Returns
+    an empty string if no root field can be parsed.
+    """
+    clean_query = re.sub(r"#.*", "", query_str)
+    clean_query = " ".join(clean_query.split())
+
+    named_query_match = re.search(r"query\s+\w+[^{]*{\s*(\w+)", clean_query, re.DOTALL)
+    if named_query_match:
+        return named_query_match.group(1)
+
+    anonymous_query_match = re.search(r"^\s*{\s*(\w+)", clean_query)
+    if anonymous_query_match:
+        return anonymous_query_match.group(1)
+
+    fallback_match = re.search(r"query\s*{\s*(\w+)", clean_query)
+    if fallback_match:
+        return fallback_match.group(1)
+
+    return ""
 
 
 @dataclass
@@ -258,15 +291,24 @@ class TurboRegistry:
 class TurboRouter:
     """High-performance router for registered GraphQL queries."""
 
-    def __init__(self, registry: TurboRegistry | None) -> None:
+    def __init__(
+        self,
+        registry: TurboRegistry | None,
+        default_authorizer: Authorizer | None = None,
+    ) -> None:
         """Initialize the router with a registry.
 
         Args:
             registry: TurboRegistry containing registered queries
+            default_authorizer: Optional global operation authorizer (issue #362).
+                TurboRouter bypasses ``GraphQLField.resolve``, so this gate is the only
+                authorization point on the persisted-query path. Per-operation decorator
+                overrides do not apply here — only the global default.
         """
         if registry is None:
             raise ValueError("TurboRouter requires a non-None TurboRegistry")
         self.registry = registry
+        self.default_authorizer = default_authorizer
 
     async def execute(
         self,
@@ -288,6 +330,27 @@ class TurboRouter:
         turbo_query = self.registry.get(query)
         if turbo_query is None:
             return None
+
+        # Operation authorization gate (issue #362). This path bypasses
+        # GraphQLField.resolve, so enforcement happens here, fail-closed, before any
+        # SQL is built or executed. enforce_operation_value raises GraphQLError on deny.
+        if self.default_authorizer is not None:
+            from fraiseql.security.authorization import enforce_operation_value
+
+            decision = await enforce_operation_value(
+                authorizer=self.default_authorizer,
+                context=context,
+                operation_type="query",
+                operation_name=_turbo_operation_name(query),
+                arguments=variables or {},
+            )
+            if decision.filters:
+                # Per-row filter injection is impossible against a fixed SQL template;
+                # row scoping on this path relies on session variables + database RLS.
+                logger.warning(
+                    "authorization filters are ignored on the TurboRouter path "
+                    "(fixed SQL template); rely on session variables + RLS for row scoping"
+                )
 
         # Get database from context
         db = context.get("db")
@@ -354,33 +417,6 @@ class TurboRouter:
 
                 # Determine the root field name from the query
                 # Handle queries with fragments by looking for the actual query operation
-                import re
-
-                def extract_root_field_name(query_str: str) -> str | None:
-                    """Extract the root field name from a GraphQL query, handling fragments."""
-                    # Remove comments and normalize whitespace
-                    clean_query = re.sub(r"#.*", "", query_str)
-                    clean_query = " ".join(clean_query.split())
-
-                    # Pattern 1: Named query (handles fragments before query)
-                    named_query_match = re.search(
-                        r"query\s+\w+[^{]*{\s*(\w+)", clean_query, re.DOTALL
-                    )
-                    if named_query_match:
-                        return named_query_match.group(1)
-
-                    # Pattern 2: Anonymous query starting with {
-                    anonymous_query_match = re.search(r"^\s*{\s*(\w+)", clean_query)
-                    if anonymous_query_match:
-                        return anonymous_query_match.group(1)
-
-                    # Pattern 3: Query keyword without name
-                    fallback_match = re.search(r"query\s*{\s*(\w+)", clean_query)
-                    if fallback_match:
-                        return fallback_match.group(1)
-
-                    return None
-
                 def process_turbo_result(data: any, root_field: str) -> dict[str, any]:
                     """Process TurboRouter result with smart GraphQL response detection."""
                     # Case 1: Data is already a complete GraphQL response
@@ -405,7 +441,7 @@ class TurboRouter:
                     # Case 3: Raw data - wrap normally
                     return {"data": {root_field: data}}
 
-                root_field = extract_root_field_name(query)
+                root_field = _turbo_operation_name(query)
                 if root_field:
                     return process_turbo_result(data, root_field)
 

--- a/src/fraiseql/fastapi/turbo.py
+++ b/src/fraiseql/fastapi/turbo.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from psycopg import AsyncConnection
 
     from fraiseql.security.authorization import Authorizer
+    from fraiseql.security.decision_cache import DecisionCache
 
 logger = logging.getLogger(__name__)
 
@@ -295,6 +296,7 @@ class TurboRouter:
         self,
         registry: TurboRegistry | None,
         default_authorizer: Authorizer | None = None,
+        decision_cache: DecisionCache | None = None,
     ) -> None:
         """Initialize the router with a registry.
 
@@ -304,11 +306,14 @@ class TurboRouter:
                 TurboRouter bypasses ``GraphQLField.resolve``, so this gate is the only
                 authorization point on the persisted-query path. Per-operation decorator
                 overrides do not apply here — only the global default.
+            decision_cache: Optional authorization decision cache (issue #367); when set,
+                identical ``(principal, query, variables)`` checks are memoized within its TTL.
         """
         if registry is None:
             raise ValueError("TurboRouter requires a non-None TurboRegistry")
         self.registry = registry
         self.default_authorizer = default_authorizer
+        self.decision_cache = decision_cache
 
     async def execute(
         self,
@@ -343,6 +348,7 @@ class TurboRouter:
                 operation_type="query",
                 operation_name=_turbo_operation_name(query),
                 arguments=variables or {},
+                cache=self.decision_cache,
             )
             if decision.filters:
                 # Per-row filter injection is impossible against a fixed SQL template;

--- a/src/fraiseql/fastapi/turbo_enhanced.py
+++ b/src/fraiseql/fastapi/turbo_enhanced.py
@@ -20,6 +20,8 @@ from fraiseql.fastapi.turbo import TurboQuery, TurboRegistry, TurboRouter
 if TYPE_CHECKING:
     from graphql import GraphQLSchema
 
+    from fraiseql.security.authorization import Authorizer
+
 
 @dataclass
 class EnhancedTurboQuery(TurboQuery):
@@ -260,13 +262,20 @@ class EnhancedTurboRegistry(TurboRegistry):
 class EnhancedTurboRouter(TurboRouter):
     """TurboRouter with complexity analysis and adaptive caching."""
 
-    def __init__(self, registry: EnhancedTurboRegistry) -> None:
+    def __init__(
+        self,
+        registry: EnhancedTurboRegistry,
+        default_authorizer: Authorizer | None = None,
+    ) -> None:
         """Initialize the enhanced router.
 
         Args:
             registry: EnhancedTurboRegistry with complexity analysis
+            default_authorizer: Optional global operation authorizer (issue #362),
+                passed through to the base TurboRouter so a single gate in
+                ``TurboRouter.execute`` covers both routers.
         """
-        super().__init__(registry)
+        super().__init__(registry, default_authorizer=default_authorizer)
         self.registry: EnhancedTurboRegistry = registry  # Type hint override
 
     async def execute(

--- a/src/fraiseql/gql/builders/mutation_builder.py
+++ b/src/fraiseql/gql/builders/mutation_builder.py
@@ -28,8 +28,27 @@ from fraiseql.utils.naming import snake_to_camel
 
 if TYPE_CHECKING:
     from fraiseql.gql.builders.registry import SchemaRegistry
+    from fraiseql.security.authorization import AuthorizationDecision
 
 logger = logging.getLogger(__name__)
+
+
+def _warn_filters_ignored_on_mutation(
+    decision: AuthorizationDecision,
+    root: Any,
+    info: GraphQLResolveInfo,
+    kwargs: dict[str, Any],
+) -> None:
+    """Mutations have no row-scoping semantics, so a returned ``filters`` is ignored.
+
+    Never silently drop it — warn so the misuse is visible (issue #362).
+    """
+    if decision.filters:
+        logger.warning(
+            "authorization filters are ignored on mutations (no row-scoping semantics); "
+            "operation=%s",
+            getattr(info, "field_name", "<unknown>"),
+        )
 
 
 class MutationTypeBuilder:
@@ -168,6 +187,7 @@ class MutationTypeBuilder:
                     fn=fn,
                     registry=self.registry,
                     operation_type="mutation",
+                    on_decision=_warn_filters_ignored_on_mutation,
                 )
 
             return async_resolver
@@ -191,6 +211,7 @@ class MutationTypeBuilder:
                 fn=fn,
                 registry=self.registry,
                 operation_type="mutation",
+                on_decision=_warn_filters_ignored_on_mutation,
             )
 
         return sync_resolver

--- a/src/fraiseql/gql/builders/mutation_builder.py
+++ b/src/fraiseql/gql/builders/mutation_builder.py
@@ -22,6 +22,7 @@ from fraiseql.core.graphql_type import (
     convert_type_to_graphql_output,
 )
 from fraiseql.mutations.decorators import resolve_union_annotation
+from fraiseql.security.authorization import enforce_around_async, enforce_around_sync
 from fraiseql.types.coercion import wrap_resolver_with_input_coercion
 from fraiseql.utils.naming import snake_to_camel
 
@@ -157,7 +158,17 @@ class MutationTypeBuilder:
                         mapped_kwargs[python_name] = value
                     kwargs = mapped_kwargs
 
-                return await coerced_fn(root, info, **kwargs)
+                # Operation authorization (issue #362): enforce after arg-name mapping,
+                # before the resolver body, fail-closed.
+                return await enforce_around_async(
+                    coerced_fn,
+                    root,
+                    info,
+                    kwargs,
+                    fn=fn,
+                    registry=self.registry,
+                    operation_type="mutation",
+                )
 
             return async_resolver
 
@@ -170,6 +181,16 @@ class MutationTypeBuilder:
                     mapped_kwargs[python_name] = value
                 kwargs = mapped_kwargs
 
-            return coerced_fn(root, info, **kwargs)
+            # Operation authorization (issue #362): when an authorizer is in effect this
+            # returns a coroutine that enforces before the body; otherwise pure-sync.
+            return enforce_around_sync(
+                coerced_fn,
+                root,
+                info,
+                kwargs,
+                fn=fn,
+                registry=self.registry,
+                operation_type="mutation",
+            )
 
         return sync_resolver

--- a/src/fraiseql/gql/builders/query_builder.py
+++ b/src/fraiseql/gql/builders/query_builder.py
@@ -26,6 +26,7 @@ from fraiseql.core.graphql_type import (
     convert_type_to_graphql_output,
 )
 from fraiseql.gql.enum_serializer import wrap_resolver_with_enum_serialization
+from fraiseql.security.authorization import enforce_around_async, enforce_around_sync
 from fraiseql.types.coercion import wrap_resolver_with_input_coercion
 from fraiseql.utils.naming import snake_to_camel
 
@@ -406,7 +407,17 @@ class QueryTypeBuilder:
                         mapped_kwargs[python_name] = value
                     kwargs = mapped_kwargs
 
-                return await coerced_fn(root, info, **kwargs)
+                # Operation authorization (issue #362): enforce after WHERE/pagination
+                # validation and arg-name mapping, before the resolver body.
+                return await enforce_around_async(
+                    coerced_fn,
+                    root,
+                    info,
+                    kwargs,
+                    fn=fn,
+                    registry=self.registry,
+                    operation_type="query",
+                )
 
             return async_resolver
 
@@ -440,7 +451,17 @@ class QueryTypeBuilder:
                     mapped_kwargs[python_name] = value
                 kwargs = mapped_kwargs
 
-            return coerced_fn(root, info, **kwargs)
+            # Operation authorization (issue #362): when an authorizer is in effect this
+            # returns a coroutine that enforces before the body; otherwise pure-sync.
+            return enforce_around_sync(
+                coerced_fn,
+                root,
+                info,
+                kwargs,
+                fn=fn,
+                registry=self.registry,
+                operation_type="query",
+            )
 
         return sync_resolver
 

--- a/src/fraiseql/gql/builders/query_builder.py
+++ b/src/fraiseql/gql/builders/query_builder.py
@@ -32,8 +32,35 @@ from fraiseql.utils.naming import snake_to_camel
 
 if TYPE_CHECKING:
     from fraiseql.gql.builders.registry import SchemaRegistry
+    from fraiseql.security.authorization import AuthorizationDecision
 
 logger = logging.getLogger(__name__)
+
+
+def _write_auth_filters_to_context(
+    decision: AuthorizationDecision,
+    root: Any,
+    info: GraphQLResolveInfo,
+    kwargs: dict[str, Any],
+) -> None:
+    """Write authorization row-scoping filters into the repository context (issue #362).
+
+    ``mandatory_filters`` is a repository-method kwarg consumed in a *different* call
+    frame than the resolver (the user's ``@query`` function sits in between), so the
+    filter cannot ride resolver kwargs. Instead it rides the repository context — keyed
+    by root field name — where ``FraiseQLRepository._consume_mandatory_filters`` merges
+    it into every read. Nothing is added to ``kwargs``.
+    """
+    if not decision.filters:
+        return
+    context = getattr(info, "context", None)
+    if not context or "db" not in context:
+        return
+    db = context["db"]
+    if not hasattr(db, "context"):
+        return
+    buckets = db.context.setdefault("_fraiseql_auth_filters", {})
+    buckets[info.field_name] = decision.filters
 
 
 class QueryTypeBuilder:
@@ -417,6 +444,7 @@ class QueryTypeBuilder:
                     fn=fn,
                     registry=self.registry,
                     operation_type="query",
+                    on_decision=_write_auth_filters_to_context,
                 )
 
             return async_resolver
@@ -461,6 +489,7 @@ class QueryTypeBuilder:
                 fn=fn,
                 registry=self.registry,
                 operation_type="query",
+                on_decision=_write_auth_filters_to_context,
             )
 
         return sync_resolver

--- a/src/fraiseql/gql/builders/registry.py
+++ b/src/fraiseql/gql/builders/registry.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from graphql import GraphQLEnumType, GraphQLScalarType
 
     from fraiseql.security.authorization import Authorizer
+    from fraiseql.security.decision_cache import DecisionCache
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,9 @@ class SchemaRegistry:
         # Global default operation authorizer (issue #362). Enforcement reads this
         # slot live at resolve time; the bypass gates source it at construction.
         self._default_authorizer: Authorizer | None = None
+        # Optional decision cache (issue #367). Read live by enforcement and the bypass
+        # gates, the same way as the default authorizer. ``None`` means always-evaluate.
+        self._decision_cache: DecisionCache | None = None
 
     @classmethod
     def get_instance(cls) -> SchemaRegistry:
@@ -68,6 +72,7 @@ class SchemaRegistry:
         self._type_map.clear()
         self.config = None
         self._default_authorizer = None
+        self._decision_cache = None
         logger.debug("Registry after clearing: %s", list(self._types.keys()))
 
         # Clear mutation decorator registries
@@ -355,3 +360,17 @@ class SchemaRegistry:
         authorizer covers every execution path.
         """
         self._default_authorizer = authorizer
+
+    @property
+    def decision_cache(self) -> DecisionCache | None:
+        """The optional authorization decision cache, or ``None`` if unset (issue #367)."""
+        return self._decision_cache
+
+    def set_decision_cache(self, cache: DecisionCache | None) -> None:
+        """Set (or clear) the optional authorization decision cache.
+
+        Enforcement and the resolver-bypass gates read this slot the same way they read
+        :attr:`default_authorizer`, so one cache covers every execution path. ``None``
+        restores the always-evaluate default.
+        """
+        self._decision_cache = cache

--- a/src/fraiseql/gql/builders/registry.py
+++ b/src/fraiseql/gql/builders/registry.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
     from graphql import GraphQLEnumType, GraphQLScalarType
 
+    from fraiseql.security.authorization import Authorizer
+
 logger = logging.getLogger(__name__)
 
 
@@ -31,6 +33,9 @@ class SchemaRegistry:
         self._scalars: dict[str, GraphQLScalarType] = {}  # NEW: Custom scalar registry
         self._type_map: dict[str, Any] = {}  # GraphQL types cache for Connection/Edge/PageInfo
         self.config: Any = None  # FraiseQLConfig instance
+        # Global default operation authorizer (issue #362). Enforcement reads this
+        # slot live at resolve time; the bypass gates source it at construction.
+        self._default_authorizer: Authorizer | None = None
 
     @classmethod
     def get_instance(cls) -> SchemaRegistry:
@@ -62,6 +67,7 @@ class SchemaRegistry:
         self._interfaces.clear()
         self._type_map.clear()
         self.config = None
+        self._default_authorizer = None
         logger.debug("Registry after clearing: %s", list(self._types.keys()))
 
         # Clear mutation decorator registries
@@ -335,3 +341,17 @@ class SchemaRegistry:
     def scalars(self) -> dict[str, GraphQLScalarType]:
         """Get registered scalars."""
         return self._scalars
+
+    @property
+    def default_authorizer(self) -> Authorizer | None:
+        """The global default operation authorizer, or ``None`` if unset (issue #362)."""
+        return self._default_authorizer
+
+    def set_default_authorizer(self, authorizer: Authorizer | None) -> None:
+        """Set (or clear) the global default operation authorizer.
+
+        Enforcement reads this slot at resolve time, and the resolver-bypass gates
+        (TurboRouter, ``/graphql/rust``, APQ) source it as well, so one configured
+        authorizer covers every execution path.
+        """
+        self._default_authorizer = authorizer

--- a/src/fraiseql/gql/builders/subscription_builder.py
+++ b/src/fraiseql/gql/builders/subscription_builder.py
@@ -143,6 +143,7 @@ class SubscriptionTypeBuilder:
                 operation_name=getattr(info, "field_name", ""),
                 arguments=kwargs,
                 authorizer=authorizer,
+                cache=self.registry.decision_cache,
             )
             if decision.filters:
                 # A subscription stream is not a single scoped read set, so row-scoping

--- a/src/fraiseql/gql/builders/subscription_builder.py
+++ b/src/fraiseql/gql/builders/subscription_builder.py
@@ -16,6 +16,7 @@ from graphql import (
 
 from fraiseql.config.schema_config import SchemaConfig
 from fraiseql.core.graphql_type import convert_type_to_graphql_input, convert_type_to_graphql_output
+from fraiseql.security.authorization import enforce_operation, resolve_authorizer
 from fraiseql.utils.naming import snake_to_camel
 
 if TYPE_CHECKING:
@@ -102,27 +103,57 @@ class SubscriptionTypeBuilder:
     ) -> Callable[..., Any]:
         """Create a GraphQL subscription from an async generator function.
 
+        The outer ``subscribe`` is a plain coroutine (not an async generator) so the
+        configured authorizer runs **once, at subscribe time**, before the event stream
+        is created (issue #364). graphql-core awaits the ``subscribe`` resolver to obtain
+        the stream; a denied decision raises a ``GraphQLError`` *during that await*, so
+        the inner generator — which is what would query the database — is never built.
+        This covers both the schema path and the websocket path, which routes through
+        graphql-core's ``subscribe`` (``websocket.py:256``).
+
         Args:
             fn: The async generator function to wrap as a GraphQL subscription.
             arg_name_mapping: Mapping from GraphQL argument names to Python parameter names.
 
         Returns:
-            A GraphQL-compatible subscription function.
+            A GraphQL-compatible subscription resolver.
         """
+
+        async def _stream(info: GraphQLResolveInfo, kwargs: dict[str, Any]) -> AsyncGenerator[Any]:
+            # The original subscription body, built only after an allow decision: call the
+            # user generator (without the root argument) and forward every yielded value.
+            async for value in fn(info, **kwargs):
+                yield value
 
         async def subscribe(
             root: Any, info: GraphQLResolveInfo, **kwargs: Any
         ) -> AsyncGenerator[Any]:
-            # Map GraphQL argument names to Python parameter names
+            # Map GraphQL argument names to Python parameter names.
             if arg_name_mapping:
-                mapped_kwargs = {}
-                for gql_name, value in kwargs.items():
-                    python_name = arg_name_mapping.get(gql_name, gql_name)
-                    mapped_kwargs[python_name] = value
-                kwargs = mapped_kwargs
+                kwargs = {arg_name_mapping.get(name, name): value for name, value in kwargs.items()}
 
-            # Call the original function without the root argument
-            async for value in fn(info, **kwargs):
-                yield value
+            # Enforce once, at subscribe time (issue #364). Fail-closed is inherited from
+            # the shared enforcement core: a deny — or a raising authorizer — raises a
+            # GraphQLError here, before _stream (and the database) is ever reached. A
+            # missing authorizer is the no-op fast path (no authorizer call).
+            authorizer = resolve_authorizer(fn, self.registry)
+            decision = await enforce_operation(
+                info=info,
+                operation_type="subscription",
+                operation_name=getattr(info, "field_name", ""),
+                arguments=kwargs,
+                authorizer=authorizer,
+            )
+            if decision.filters:
+                # A subscription stream is not a single scoped read set, so row-scoping
+                # filters have no meaning here. Never silently drop them — warn so the
+                # misuse is visible (mirrors the mutation path, issue #362).
+                logger.warning(
+                    "authorization filters are ignored on subscriptions (no row-scoping "
+                    "semantics); operation=%s",
+                    getattr(info, "field_name", "<unknown>"),
+                )
+
+            return _stream(info, kwargs)
 
         return subscribe

--- a/src/fraiseql/gql/graphql_entrypoint.py
+++ b/src/fraiseql/gql/graphql_entrypoint.py
@@ -2,7 +2,7 @@
 
 import json
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from graphql import GraphQLSchema
 from starlette.requests import Request
@@ -13,6 +13,9 @@ from fraiseql.core.rust_pipeline import RustResponseBytes
 from fraiseql.fastapi.json_encoder import FraiseQLJSONResponse, clean_unset_values
 from fraiseql.gql.schema_builder import SchemaRegistry
 from fraiseql.graphql.execute import execute_graphql
+
+if TYPE_CHECKING:
+    from fraiseql.security.authorization import Authorizer
 
 
 class GraphNoteRouter(Router):
@@ -118,17 +121,22 @@ def build_fraiseql_schema(
     *,
     query_types: Sequence[type] = (),
     mutation_resolvers: Sequence[Callable[..., Any]] = (),
+    authorizer: "Authorizer | None" = None,
 ) -> GraphQLSchema:
     """Compose a GraphQL schema from provided query types and mutation resolvers.
 
     Args:
         query_types: Iterable of Python dataclasses decorated as GraphNote types.
         mutation_resolvers: Iterable of async resolver callables for mutations.
+        authorizer: Optional global default operation authorizer (issue #362),
+            installed as ``SchemaRegistry.default_authorizer``. ``None`` leaves the
+            slot cleared (behavior unchanged).
 
     Returns:
         GraphQLSchema object with query and mutation types built.
     """
     registry = SchemaRegistry.get_instance()
+    registry.set_default_authorizer(authorizer)
 
     for typ in query_types:
         registry.register_type(typ)

--- a/src/fraiseql/gql/schema_builder.py
+++ b/src/fraiseql/gql/schema_builder.py
@@ -23,6 +23,8 @@ from fraiseql.gql.builders import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from fraiseql.security.authorization import Authorizer
+
 logger = logging.getLogger(__name__)
 
 # The SchemaRegistry is imported from builders module
@@ -34,6 +36,7 @@ def build_fraiseql_schema(
     mutation_resolvers: list[type | Callable[..., Any]] | None = None,
     subscription_resolvers: list[Callable[..., Any]] | None = None,
     camel_case_fields: bool = True,
+    authorizer: Authorizer | None = None,
 ) -> GraphQLSchema:
     """Compose a full GraphQL schema from query types, mutation resolvers, and subscriptions.
 
@@ -42,6 +45,10 @@ def build_fraiseql_schema(
         mutation_resolvers: Optional list of mutation classes or resolver functions.
         subscription_resolvers: Optional list of subscription functions to register.
         camel_case_fields: Whether to convert snake_case field names to camelCase in GraphQL schema.
+        authorizer: Optional global default operation authorizer (issue #362). When
+            provided, it is installed as ``SchemaRegistry.default_authorizer`` and
+            enforced around every root query/mutation operation. ``None`` leaves the
+            slot cleared, so behavior is byte-for-byte unchanged.
 
     Returns:
         A GraphQLSchema combining the registered query, mutation, and subscription types.
@@ -62,6 +69,7 @@ def build_fraiseql_schema(
     _graphql_type_cache.clear()
 
     registry = SchemaRegistry.get_instance()
+    registry.set_default_authorizer(authorizer)
 
     for typ in query_types:
         if callable(typ) and not isinstance(typ, type):

--- a/src/fraiseql/gql/schema_builder.py
+++ b/src/fraiseql/gql/schema_builder.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from fraiseql.security.authorization import Authorizer
+    from fraiseql.security.decision_cache import DecisionCache
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ def build_fraiseql_schema(
     subscription_resolvers: list[Callable[..., Any]] | None = None,
     camel_case_fields: bool = True,
     authorizer: Authorizer | None = None,
+    decision_cache: DecisionCache | None = None,
 ) -> GraphQLSchema:
     """Compose a full GraphQL schema from query types, mutation resolvers, and subscriptions.
 
@@ -49,6 +51,9 @@ def build_fraiseql_schema(
             provided, it is installed as ``SchemaRegistry.default_authorizer`` and
             enforced around every root query/mutation operation. ``None`` leaves the
             slot cleared, so behavior is byte-for-byte unchanged.
+        decision_cache: Optional authorization decision cache (issue #367). Installed as
+            ``SchemaRegistry.decision_cache`` and consulted by enforcement and the bypass
+            gates. ``None`` leaves the slot cleared (always-evaluate, today's behavior).
 
     Returns:
         A GraphQLSchema combining the registered query, mutation, and subscription types.
@@ -70,6 +75,7 @@ def build_fraiseql_schema(
 
     registry = SchemaRegistry.get_instance()
     registry.set_default_authorizer(authorizer)
+    registry.set_decision_cache(decision_cache)
 
     for typ in query_types:
         if callable(typ) and not isinstance(typ, type):

--- a/src/fraiseql/mutations/mutation_decorator.py
+++ b/src/fraiseql/mutations/mutation_decorator.py
@@ -904,6 +904,7 @@ def mutation(
     context_params: dict[str, str] | None = None,
     error_config: MutationErrorConfig | None = None,
     enable_cascade: bool = False,
+    authorizer: Any | None = None,
 ) -> type[T] | Callable[[type[T]], type[T]] | Callable[..., Any]:
     """Decorator to define GraphQL mutations with PostgreSQL function backing.
 
@@ -918,6 +919,9 @@ def mutation(
         context_params: Maps GraphQL context keys to PostgreSQL function parameter names
         error_config: Optional configuration for error detection behavior
         enable_cascade: Enable GraphQL cascade functionality to include side effects in response
+        authorizer: Optional per-operation :class:`~fraiseql.security.Authorizer`
+            override (issue #362). It takes precedence over the global default
+            authorizer for this mutation only.
 
     Returns:
         Decorated mutation with automatic PostgreSQL function integration
@@ -1249,6 +1253,8 @@ def mutation(
             # Store metadata for schema building
             fn.__fraiseql_mutation__ = True
             fn.__fraiseql_resolver__ = fn
+            # Per-operation authorizer override (issue #362).
+            fn.__fraiseql_authorizer__ = authorizer
 
             # Auto-register with schema
             registry.register_mutation(fn)
@@ -1267,6 +1273,9 @@ def mutation(
 
         # Create and store resolver
         cls.__fraiseql_resolver__ = definition.create_resolver()
+        # Per-operation authorizer override (issue #362) — set on the resolver fn the
+        # registry stores, so resolve_authorizer can read it at resolve time.
+        cls.__fraiseql_resolver__.__fraiseql_authorizer__ = authorizer
 
         # Auto-register with schema
         registry.register_mutation(cls)

--- a/src/fraiseql/security/__init__.py
+++ b/src/fraiseql/security/__init__.py
@@ -32,6 +32,13 @@ from fastapi import FastAPI
 
 logger = logging.getLogger(__name__)
 
+# Operation-level authorization (issue #362)
+from .authorization import (
+    AuthorizationDecision,
+    Authorizer,
+    normalize_decision,
+)
+
 # CSRF protection
 from .csrf_protection import (
     CSRFConfig,
@@ -90,6 +97,9 @@ from .validators import (
 )
 
 __all__ = [
+    # Operation-level authorization (issue #362)
+    "AuthorizationDecision",
+    "Authorizer",
     "CSPDirective",
     # CSRF protection
     "CSRFConfig",
@@ -129,6 +139,7 @@ __all__ = [
     "create_production_csrf_config",
     "create_production_security_config",
     "create_strict_csp",
+    "normalize_decision",
     "setup_csrf_protection",
     "setup_rate_limiting",
     # Main setup function

--- a/src/fraiseql/security/__init__.py
+++ b/src/fraiseql/security/__init__.py
@@ -52,6 +52,12 @@ from .csrf_protection import (
     setup_csrf_protection,
 )
 
+# Optional decision caching (issue #367)
+from .decision_cache import (
+    AuthorizationCacheConfig,
+    DecisionCache,
+)
+
 # Field-level authorization
 from .field_auth import (
     FieldAuthorizationError,
@@ -98,6 +104,8 @@ from .validators import (
 )
 
 __all__ = [
+    # Optional decision caching (issue #367)
+    "AuthorizationCacheConfig",
     # Operation-level authorization (issue #362)
     "AuthorizationDecision",
     "Authorizer",
@@ -109,6 +117,7 @@ __all__ = [
     "CSRFTokenGenerator",
     "CSRFTokenStorage",
     "ContentSecurityPolicy",
+    "DecisionCache",
     # Field-level authorization
     "FieldAuthorizationError",
     "FrameOptions",

--- a/src/fraiseql/security/__init__.py
+++ b/src/fraiseql/security/__init__.py
@@ -58,6 +58,7 @@ from .field_auth import (
     any_permission,
     authorize_field,
     combine_permissions,
+    field_authorizer_adapter,
 )
 
 # Rate limiting
@@ -139,6 +140,7 @@ __all__ = [
     "create_production_csrf_config",
     "create_production_security_config",
     "create_strict_csp",
+    "field_authorizer_adapter",
     "normalize_decision",
     "setup_csrf_protection",
     "setup_rate_limiting",

--- a/src/fraiseql/security/authorization.py
+++ b/src/fraiseql/security/authorization.py
@@ -1,0 +1,86 @@
+"""First-class operation authorization contract for FraiseQL (issue #362).
+
+This module defines the supported Policy Enforcement Point (PEP) for
+operation-level authorization. The framework *enforces*; the *decision* is
+delegated to an app-supplied :class:`Authorizer`, which reads everything it
+needs from ``context`` (populated by the app's ``context_getter``) and is
+therefore principal-agnostic.
+
+The contract deliberately mirrors the v2 (Rust) counterpart so a single policy
+implementation can serve both runtimes. The module is kept dependency-light (no
+``graphql`` / ``fastapi`` imports at top level) so it can be reused by
+v2-aligned tooling and tested headless.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+OperationType = str  # "query" | "mutation" (| "subscription" later)
+
+# Shared defaults so every enforcement site denies with the same shape.
+DEFAULT_DENY_CODE = "FORBIDDEN"
+DEFAULT_DENY_MESSAGE = "Operation not authorized"
+
+
+@dataclass(frozen=True)
+class AuthorizationDecision:
+    """The result of an authorization check.
+
+    Decisions are immutable values. ``filters`` are row-scoping filters that are
+    AND-ed into the repository's ``mandatory_filters`` on the read path (see the
+    filter-injection mechanism); they are ignored on mutations and bypass paths.
+    """
+
+    allowed: bool
+    code: str | None = None
+    message: str | None = None
+    filters: dict[str, Any] | None = None
+
+    @classmethod
+    def allow(cls, *, filters: dict[str, Any] | None = None) -> AuthorizationDecision:
+        """Return an allow decision, optionally carrying row-scoping filters."""
+        return cls(allowed=True, filters=filters)
+
+    @classmethod
+    def deny(
+        cls,
+        *,
+        code: str = DEFAULT_DENY_CODE,
+        message: str | None = None,
+    ) -> AuthorizationDecision:
+        """Return a deny decision with a stable ``code`` surfaced as a GraphQL extension."""
+        return cls(allowed=False, code=code, message=message)
+
+
+@runtime_checkable
+class Authorizer(Protocol):
+    """Structural protocol for an operation authorizer.
+
+    Implementations decide whether a top-level GraphQL operation may run. The
+    return value may be a plain ``bool`` (sugar) or an :class:`AuthorizationDecision`.
+    Implementations may be sync or async; the enforcement layer awaits awaitables.
+    """
+
+    async def authorize_operation(
+        self,
+        *,
+        context: dict[str, Any],
+        operation_type: OperationType,
+        operation_name: str,
+        arguments: dict[str, Any],
+    ) -> AuthorizationDecision | bool:
+        """Decide whether the named operation may run for the given context."""
+        ...
+
+
+def normalize_decision(result: AuthorizationDecision | bool) -> AuthorizationDecision:
+    """Coerce an authorizer result into a canonical :class:`AuthorizationDecision`.
+
+    ``True`` -> ``allow()``; ``False`` -> ``deny()``; an existing decision passes
+    through unchanged.
+    """
+    if isinstance(result, AuthorizationDecision):
+        return result
+    return AuthorizationDecision.allow() if result else AuthorizationDecision.deny()

--- a/src/fraiseql/security/authorization.py
+++ b/src/fraiseql/security/authorization.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
     from fraiseql.gql.builders.registry import SchemaRegistry
+    from fraiseql.security.decision_cache import DecisionCache
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,18 @@ def resolve_authorizer(fn: Any, registry: SchemaRegistry) -> Authorizer | None:
     return getattr(fn, "__fraiseql_authorizer__", None) or registry.default_authorizer
 
 
+def _raise_on_deny(decision: AuthorizationDecision) -> AuthorizationDecision:
+    """Raise a ``GraphQLError`` (with a stable ``code``) if ``decision`` denies; else return it."""
+    if not decision.allowed:
+        from graphql import GraphQLError
+
+        raise GraphQLError(
+            decision.message or DEFAULT_DENY_MESSAGE,
+            extensions={"code": decision.code or DEFAULT_DENY_CODE},
+        )
+    return decision
+
+
 async def enforce_operation_value(
     *,
     authorizer: Authorizer | None,
@@ -112,6 +125,7 @@ async def enforce_operation_value(
     operation_type: str,
     operation_name: str,
     arguments: dict[str, Any],
+    cache: DecisionCache | None = None,
 ) -> AuthorizationDecision:
     """Run the authorizer and enforce its decision, fail-closed.
 
@@ -125,12 +139,26 @@ async def enforce_operation_value(
       raw exception is logged but never surfaced to the client.
     - Deny -> ``GraphQLError`` carrying ``extensions={"code": ...}``.
 
+    When a :class:`DecisionCache` is supplied (issue #367), a fresh hit replays the prior
+    decision **without calling the authorizer**; a clean authorizer return (allow *or* deny)
+    is cached. An authorizer that *raises* hits the fail-closed branch and is **never**
+    cached, so a transient error can neither pin a deny nor leak an allow. With ``cache=None``
+    behavior is byte-for-byte unchanged.
+
     Returns the (allow) decision so callers can read ``decision.filters``.
     """
     if authorizer is None:
         return AuthorizationDecision.allow()
 
     from graphql import GraphQLError
+
+    key = None
+    if cache is not None:
+        key = cache.make_key(context, operation_type, operation_name, arguments)
+        if key is not None:
+            cached = cache.get(key)
+            if cached is not None:
+                return _raise_on_deny(cached)
 
     try:
         raw = authorizer.authorize_operation(
@@ -141,18 +169,17 @@ async def enforce_operation_value(
         )
         raw = await raw if inspect.isawaitable(raw) else raw
         decision = normalize_decision(raw)
+        # Cache only on a clean return (allow or deny); the except branch below never
+        # reaches this, so a raising authorizer is never cached.
+        if cache is not None and key is not None:
+            cache.put(key, decision)
     except GraphQLError:
         raise
     except Exception as exc:  # FAIL CLOSED: any error denies, never allows.
         logger.warning("authorizer raised; denying operation", exc_info=exc)
         decision = AuthorizationDecision.deny(code=DEFAULT_DENY_CODE)
 
-    if not decision.allowed:
-        raise GraphQLError(
-            decision.message or DEFAULT_DENY_MESSAGE,
-            extensions={"code": decision.code or DEFAULT_DENY_CODE},
-        )
-    return decision
+    return _raise_on_deny(decision)
 
 
 async def enforce_operation(
@@ -162,11 +189,12 @@ async def enforce_operation(
     operation_name: str,
     arguments: dict[str, Any],
     authorizer: Authorizer | None,
+    cache: DecisionCache | None = None,
 ) -> AuthorizationDecision:
     """Resolver-side wrapper around :func:`enforce_operation_value`.
 
     Reads ``context`` from the GraphQL resolve info; otherwise identical semantics
-    (including fail-closed). Returns the decision.
+    (including fail-closed and the optional decision ``cache``). Returns the decision.
     """
     context = getattr(info, "context", None) or {}
     return await enforce_operation_value(
@@ -175,6 +203,7 @@ async def enforce_operation(
         operation_type=operation_type,
         operation_name=operation_name,
         arguments=arguments,
+        cache=cache,
     )
 
 
@@ -203,6 +232,7 @@ async def enforce_around_async(
         operation_name=getattr(info, "field_name", ""),
         arguments=kwargs,
         authorizer=authorizer,
+        cache=registry.decision_cache,
     )
     if on_decision is not None:
         on_decision(decision, root, info, kwargs)
@@ -239,6 +269,7 @@ def enforce_around_sync(
             operation_name=getattr(info, "field_name", ""),
             arguments=kwargs,
             authorizer=authorizer,
+            cache=registry.decision_cache,
         )
         if on_decision is not None:
             on_decision(decision, root, info, kwargs)

--- a/src/fraiseql/security/authorization.py
+++ b/src/fraiseql/security/authorization.py
@@ -14,8 +14,17 @@ v2-aligned tooling and tested headless.
 
 from __future__ import annotations
 
+import inspect
+import logging
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
+    from fraiseql.gql.builders.registry import SchemaRegistry
+
+logger = logging.getLogger(__name__)
 
 OperationType = str  # "query" | "mutation" (| "subscription" later)
 
@@ -84,3 +93,158 @@ def normalize_decision(result: AuthorizationDecision | bool) -> AuthorizationDec
     if isinstance(result, AuthorizationDecision):
         return result
     return AuthorizationDecision.allow() if result else AuthorizationDecision.deny()
+
+
+def resolve_authorizer(fn: Any, registry: SchemaRegistry) -> Authorizer | None:
+    """Resolve the effective authorizer: a per-operation override beats the global default.
+
+    The per-operation override is attached by ``@query(authorizer=...)`` /
+    ``@mutation(authorizer=...)`` as ``fn.__fraiseql_authorizer__``; it is read
+    defensively (the attribute may be absent).
+    """
+    return getattr(fn, "__fraiseql_authorizer__", None) or registry.default_authorizer
+
+
+async def enforce_operation_value(
+    *,
+    authorizer: Authorizer | None,
+    context: dict[str, Any],
+    operation_type: str,
+    operation_name: str,
+    arguments: dict[str, Any],
+) -> AuthorizationDecision:
+    """Run the authorizer and enforce its decision, fail-closed.
+
+    This is the single place the fail-closed semantic lives, so every enforcement
+    site — the resolver wrap *and* the three resolver-bypass gates — inherits it:
+
+    - No authorizer configured -> ``allow()`` (no-op fast path).
+    - Sync or async authorizer -> awaited as needed.
+    - Authorizer raises a ``GraphQLError`` -> propagated unchanged.
+    - Authorizer raises anything else -> denied (never falls through to allow); the
+      raw exception is logged but never surfaced to the client.
+    - Deny -> ``GraphQLError`` carrying ``extensions={"code": ...}``.
+
+    Returns the (allow) decision so callers can read ``decision.filters``.
+    """
+    if authorizer is None:
+        return AuthorizationDecision.allow()
+
+    from graphql import GraphQLError
+
+    try:
+        raw = authorizer.authorize_operation(
+            context=context,
+            operation_type=operation_type,
+            operation_name=operation_name,
+            arguments=arguments,
+        )
+        raw = await raw if inspect.isawaitable(raw) else raw
+        decision = normalize_decision(raw)
+    except GraphQLError:
+        raise
+    except Exception as exc:  # FAIL CLOSED: any error denies, never allows.
+        logger.warning("authorizer raised; denying operation", exc_info=exc)
+        decision = AuthorizationDecision.deny(code=DEFAULT_DENY_CODE)
+
+    if not decision.allowed:
+        raise GraphQLError(
+            decision.message or DEFAULT_DENY_MESSAGE,
+            extensions={"code": decision.code or DEFAULT_DENY_CODE},
+        )
+    return decision
+
+
+async def enforce_operation(
+    *,
+    info: GraphQLResolveInfo,
+    operation_type: str,
+    operation_name: str,
+    arguments: dict[str, Any],
+    authorizer: Authorizer | None,
+) -> AuthorizationDecision:
+    """Resolver-side wrapper around :func:`enforce_operation_value`.
+
+    Reads ``context`` from the GraphQL resolve info; otherwise identical semantics
+    (including fail-closed). Returns the decision.
+    """
+    context = getattr(info, "context", None) or {}
+    return await enforce_operation_value(
+        authorizer=authorizer,
+        context=context,
+        operation_type=operation_type,
+        operation_name=operation_name,
+        arguments=arguments,
+    )
+
+
+# Callback invoked after enforcement (and before the resolver body) with the decision,
+# used by the query builder to inject filters and by the mutation builder to warn on
+# meaningless filters. Signature: (decision, root, info, kwargs) -> None.
+OnDecision = Callable[[AuthorizationDecision, Any, "GraphQLResolveInfo", dict[str, Any]], None]
+
+
+async def enforce_around_async(
+    coerced_fn: Callable[..., Any],
+    root: Any,
+    info: GraphQLResolveInfo,
+    kwargs: dict[str, Any],
+    *,
+    fn: Any,
+    registry: SchemaRegistry,
+    operation_type: str,
+    on_decision: OnDecision | None = None,
+) -> Any:
+    """Enforce, then run an async resolver body. Shared by the query and mutation builders."""
+    authorizer = resolve_authorizer(fn, registry)
+    decision = await enforce_operation(
+        info=info,
+        operation_type=operation_type,
+        operation_name=getattr(info, "field_name", ""),
+        arguments=kwargs,
+        authorizer=authorizer,
+    )
+    if on_decision is not None:
+        on_decision(decision, root, info, kwargs)
+    return await coerced_fn(root, info, **kwargs)
+
+
+def enforce_around_sync(
+    coerced_fn: Callable[..., Any],
+    root: Any,
+    info: GraphQLResolveInfo,
+    kwargs: dict[str, Any],
+    *,
+    fn: Any,
+    registry: SchemaRegistry,
+    operation_type: str,
+    on_decision: OnDecision | None = None,
+) -> Any:
+    """Enforce around a sync resolver body, shared by the query and mutation builders.
+
+    When no authorizer is in effect (resolved live), the pure-sync path is left
+    untouched. When an authorizer is in effect, a coroutine is returned that awaits
+    enforcement before running the sync body — graphql-core awaits returned coroutines.
+    """
+    authorizer = resolve_authorizer(fn, registry)
+    if authorizer is None:
+        if on_decision is not None:
+            on_decision(AuthorizationDecision.allow(), root, info, kwargs)
+        return coerced_fn(root, info, **kwargs)
+
+    async def _run() -> Any:
+        decision = await enforce_operation(
+            info=info,
+            operation_type=operation_type,
+            operation_name=getattr(info, "field_name", ""),
+            arguments=kwargs,
+            authorizer=authorizer,
+        )
+        if on_decision is not None:
+            on_decision(decision, root, info, kwargs)
+        result = coerced_fn(root, info, **kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    return _run()

--- a/src/fraiseql/security/authorization.py
+++ b/src/fraiseql/security/authorization.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-OperationType = str  # "query" | "mutation" (| "subscription" later)
+OperationType = str  # "query" | "mutation" | "subscription"
 
 # Shared defaults so every enforcement site denies with the same shape.
 DEFAULT_DENY_CODE = "FORBIDDEN"

--- a/src/fraiseql/security/decision_cache.py
+++ b/src/fraiseql/security/decision_cache.py
@@ -1,0 +1,130 @@
+"""Optional TTL+LRU memoization of authorization decisions (issue #367).
+
+**Opt-in.** The always-evaluate default is the safe one — a stale *allow* briefly authorizes
+a now-revoked principal — so caching is never implicit. The module is kept dependency-light
+(no ``graphql`` / ``fastapi`` imports) like :mod:`fraiseql.security.authorization`, so it can
+be reused and tested headless.
+
+CORRECTNESS CONTRACT (read before enabling): a cache hit replays a prior decision, so caching
+is only correct if the authorizer is a **pure function of the key** — ``(principal_key(context),
+operation_type, operation_name, arguments)``. An authorizer that also reads tenant, request IP,
+time-of-day, feature flags, or resource state from ``context`` (anything beyond what
+``principal_key`` captures) will be served a **wrong** decision on a hit — including a *stale
+allow*, the cardinal risk. This is a correctness bug, not merely a TTL staleness window: a
+non-pure authorizer is broken under caching regardless of how short the TTL is. Fold the extra
+inputs into ``principal_key``, or leave caching off.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Hashable
+
+if TYPE_CHECKING:
+    from fraiseql.security.authorization import AuthorizationDecision
+
+
+@dataclass(frozen=True)
+class AuthorizationCacheConfig:
+    """Configuration for opt-in authorization decision caching (issue #367).
+
+    Attributes:
+        principal_key: Extracts a stable, hashable principal identity from the opaque
+            ``context`` dict (e.g. ``lambda ctx: ctx["user"]["id"]``). The framework cannot
+            derive this itself — ``context`` is unhashable and request-specific. Return
+            ``None`` for an anonymous/unknown principal; such calls are **never cached** (an
+            entry must never be shared across unidentified principals).
+        ttl_seconds: How long a cached decision stays fresh. Keep it short (e.g. 1-30s): a
+            stale *allow* is a security risk, a stale *deny* only an availability nuisance.
+        max_entries: LRU bound on the number of cached decisions.
+        clock: Monotonic time source, injectable for deterministic tests. Defaults to
+            :func:`time.monotonic`; never read wall-clock directly in the cache.
+
+    Enable caching only if your ``Authorizer`` is a **pure function of principal + operation +
+    arguments** (see the module docstring's correctness contract); otherwise a cache hit
+    returns a wrong decision.
+    """
+
+    principal_key: Callable[[dict[str, Any]], Hashable | None]
+    ttl_seconds: float = 5.0
+    max_entries: int = 10_000
+    clock: Callable[[], float] = time.monotonic
+
+
+def _stable_arguments_hash(arguments: dict[str, Any]) -> str | None:
+    """Canonical JSON (``sort_keys=True``) → sha256 hex of ``arguments``.
+
+    Returns ``None`` if ``arguments`` is not JSON-serializable, which disables caching for
+    that call (the caller falls through to evaluate). Canonicalization makes dict ordering
+    irrelevant so logically identical argument sets key identically.
+    """
+    try:
+        canonical = json.dumps(arguments, sort_keys=True)
+    except (TypeError, ValueError):
+        return None
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+class DecisionCache:
+    """Opt-in TTL+LRU memoization of :class:`AuthorizationDecision`s.
+
+    Not installed by default. The whole (frozen, immutable) decision is cached — including
+    row-scoping ``filters``, which are principal- and argument-derived and therefore already
+    captured by the key. Denies are cached too (TTL bounds the staleness); only an authorizer
+    that *raises* is never cached, so a transient PDP error can neither pin a deny nor leak an
+    allow.
+    """
+
+    def __init__(self, config: AuthorizationCacheConfig) -> None:
+        """Initialize an empty cache governed by ``config``."""
+        self._config = config
+        # key -> (expires_at, decision). OrderedDict insertion order is the LRU order.
+        self._entries: OrderedDict[Hashable, tuple[float, AuthorizationDecision]] = OrderedDict()
+
+    def make_key(
+        self,
+        context: dict[str, Any],
+        operation_type: str,
+        operation_name: str,
+        arguments: dict[str, Any],
+    ) -> Hashable | None:
+        """Build the cache key, or ``None`` when the call must not be cached.
+
+        Returns ``None`` if ``principal_key(context)`` is ``None`` (anonymous/unknown — never
+        share an entry across unidentified principals) or if ``arguments`` is not
+        JSON-serializable. Otherwise returns
+        ``(principal, operation_type, operation_name, stable_hash(arguments))``.
+        """
+        principal = self._config.principal_key(context)
+        if principal is None:
+            return None
+        args_hash = _stable_arguments_hash(arguments)
+        if args_hash is None:
+            return None
+        return (principal, operation_type, operation_name, args_hash)
+
+    def get(self, key: Hashable) -> AuthorizationDecision | None:
+        """Return the cached decision for ``key``, or ``None`` on a miss or expiry.
+
+        TTL is checked lazily: an expired entry is dropped and reported as a miss.
+        """
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        expires_at, decision = entry
+        if self._config.clock() >= expires_at:
+            del self._entries[key]
+            return None
+        self._entries.move_to_end(key)
+        return decision
+
+    def put(self, key: Hashable, decision: AuthorizationDecision) -> None:
+        """Store ``decision`` under ``key`` with a fresh TTL; evict LRU entries past the bound."""
+        self._entries[key] = (self._config.clock() + self._config.ttl_seconds, decision)
+        self._entries.move_to_end(key)
+        while len(self._entries) > self._config.max_entries:
+            self._entries.popitem(last=False)

--- a/src/fraiseql/security/field_auth.py
+++ b/src/fraiseql/security/field_auth.py
@@ -9,31 +9,77 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar, Union
 
 from graphql import GraphQLError, GraphQLResolveInfo
 
+from fraiseql.security.authorization import AuthorizationDecision, normalize_decision
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
 
 T = TypeVar("T")
 
+_DEFAULT_FIELD_CODE = "FIELD_AUTHORIZATION_ERROR"
+
 
 class FieldAuthorizationError(GraphQLError):
     """Raised when field authorization fails."""
 
-    def __init__(self, message: str = "Not authorized to access this field") -> None:
-        super().__init__(message, extensions={"code": "FIELD_AUTHORIZATION_ERROR"})
+    def __init__(
+        self,
+        message: str = "Not authorized to access this field",
+        *,
+        code: str = _DEFAULT_FIELD_CODE,
+    ) -> None:
+        super().__init__(message, extensions={"code": code})
 
 
 class PermissionCheck(Protocol):
-    """Protocol for permission check functions."""
+    """Protocol for permission check functions.
+
+    A check may return a plain ``bool`` (legacy) or an
+    :class:`~fraiseql.security.AuthorizationDecision` (issue #362), sync or async.
+    """
 
     def __call__(
         self,
         info: GraphQLResolveInfo,
         *args: Any,
         **kwargs: Any,
-    ) -> Union[bool, Awaitable[bool]]:
+    ) -> Union[bool, AuthorizationDecision, Awaitable[Union[bool, AuthorizationDecision]]]:
         """Check if the field access is authorized."""
         ...
+
+
+def _enforce_field_decision(
+    authorized: bool | AuthorizationDecision,
+    *,
+    error_message: str | None,
+    info: GraphQLResolveInfo,
+) -> None:
+    """Raise :class:`FieldAuthorizationError` if the check denied access (issue #362).
+
+    Accepts both the legacy ``bool`` and an ``AuthorizationDecision``. A decision's
+    ``code``/``message`` are surfaced on the error; a plain ``bool`` keeps the original
+    ``FIELD_AUTHORIZATION_ERROR`` code so existing checks are unchanged. ``filters`` have
+    no meaning at field granularity and are ignored with a warning.
+    """
+    decision = normalize_decision(authorized)
+    if decision.filters:
+        warnings.warn(
+            "authorization filters are ignored at field granularity",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    if decision.allowed:
+        return
+
+    field_name = getattr(info, "field_name", "field")
+    default_message = error_message or f"Not authorized to access field '{field_name}'"
+    if isinstance(authorized, AuthorizationDecision):
+        raise FieldAuthorizationError(
+            authorized.message or default_message,
+            code=authorized.code or _DEFAULT_FIELD_CODE,
+        )
+    raise FieldAuthorizationError(default_message)
 
 
 def authorize_field(
@@ -111,11 +157,7 @@ def authorize_field(
                 else:
                     authorized = permission_check(info, *args, **kwargs)
 
-                if not authorized:
-                    field_name = getattr(info, "field_name", "field")
-                    raise FieldAuthorizationError(
-                        error_message or f"Not authorized to access field '{field_name}'",
-                    )
+                _enforce_field_decision(authorized, error_message=error_message, info=info)
 
                 # Call the original function
                 return await func(root, info, *args, **kwargs)
@@ -179,11 +221,7 @@ def authorize_field(
             else:
                 authorized = permission_check(info, *args, **kwargs)
 
-            if not authorized:
-                field_name = getattr(info, "field_name", "field")
-                raise FieldAuthorizationError(
-                    error_message or f"Not authorized to access field '{field_name}'",
-                )
+            _enforce_field_decision(authorized, error_message=error_message, info=info)
 
             # Call the original function
             return func(root, info, *args, **kwargs)
@@ -315,3 +353,24 @@ def any_permission(*checks: PermissionCheck) -> PermissionCheck:
     if any(asyncio.iscoroutinefunction(check) for check in checks):
         return async_any_check
     return sync_any_check
+
+
+def field_authorizer_adapter(authorizer: Any, *, field: str) -> PermissionCheck:
+    """Adapt an operation-style ``Authorizer`` into a field :class:`PermissionCheck`.
+
+    Lets one policy object serve both operation-level and field-level authorization
+    (issue #362): the returned check calls ``authorizer.authorize_operation`` with
+    ``operation_type="field"`` and returns its decision, which ``authorize_field``
+    enforces. ``filters`` are ignored at field granularity.
+    """
+
+    async def _check(info: GraphQLResolveInfo, *args: Any, **kwargs: Any) -> AuthorizationDecision:
+        context = getattr(info, "context", None) or {}
+        return await authorizer.authorize_operation(
+            context=context,
+            operation_type="field",
+            operation_name=field,
+            arguments=kwargs,
+        )
+
+    return _check

--- a/src/fraiseql/security/field_auth.py
+++ b/src/fraiseql/security/field_auth.py
@@ -160,11 +160,10 @@ def authorize_field(
         if hasattr(func, "__fraiseql_original_func__"):
             actual_func = func.__fraiseql_original_func__
 
-        is_async = asyncio.iscoroutinefunction(actual_func)
+        is_async_resolver = asyncio.iscoroutinefunction(actual_func)
+        is_async_check = asyncio.iscoroutinefunction(permission_check)
 
         # Inspect permission check signature to see if it expects root
-        import inspect
-
         perm_sig = inspect.signature(permission_check)
         perm_params = list(perm_sig.parameters.keys())
         # Skip 'self' if it's a method
@@ -172,13 +171,17 @@ def authorize_field(
             perm_params = perm_params[1:]
         expects_root = len(perm_params) >= 2
 
-        if is_async:
+        # Present an async wrapper whenever the resolver OR the check is async, so graphql-core
+        # awaits the whole thing. An async check no longer has to be driven from a sync
+        # resolver (which warned and could deadlock under a running loop); an async wrapper
+        # around a sync inner resolver simply returns the plain value.
+        if is_async_resolver or is_async_check:
 
             async def async_auth_wrapper(
                 root: Any, info: GraphQLResolveInfo, *args: Any, **kwargs: Any
             ) -> Any:
-                # Check permission first
-                if asyncio.iscoroutinefunction(permission_check):
+                # Check permission first (await the check if it is async).
+                if is_async_check:
                     if expects_root:
                         authorized = await permission_check(info, root, *args, **kwargs)
                     else:
@@ -191,52 +194,23 @@ def authorize_field(
                 _enforce_field_decision(authorized, error_message=error_message, info=info)
 
                 # Call the wrapped resolver via the shared convention so the call adapts to
-                # whatever func is (a @field wrapper in order A, a raw method in order B).
-                return await invoke_resolver(func, root, info, *args, **kwargs)
+                # whatever func is (a @field wrapper in order A, a raw method in order B). The
+                # wrapper may be async only because the *check* is async, so the inner resolver
+                # can still be sync — await only if it actually returned an awaitable.
+                result = invoke_resolver(func, root, info, *args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
 
             _copy_resolver_metadata(async_auth_wrapper, func)
             return async_auth_wrapper  # type: ignore[return-value]
 
+        # Reached only when both the resolver and the check are sync.
         def sync_auth_wrapper(
             root: Any, info: GraphQLResolveInfo, *args: Any, **kwargs: Any
         ) -> Any:
-            # Check permission first
-            if asyncio.iscoroutinefunction(permission_check):
-                # Warn about using async permission check with sync resolver
-                warnings.warn(
-                    f"Using async permission check with sync resolver '{func.__name__}'. "
-                    "Consider making the resolver async for better performance.",
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
-
-                # Handle async permission check in sync context
-                try:
-                    loop = asyncio.get_event_loop()
-                    if loop.is_running():
-                        # We're in an async context, create a task
-                        # Store reference to avoid RUF006
-                        asyncio.ensure_future(permission_check(info, *args, **kwargs))  # noqa: RUF006
-                        # This is not ideal but necessary for sync resolvers
-                        authorized = asyncio.run_coroutine_threadsafe(
-                            permission_check(info, *args, **kwargs),
-                            loop,
-                        ).result()
-                    else:
-                        # No running loop, use run_until_complete
-                        authorized = loop.run_until_complete(
-                            permission_check(info, *args, **kwargs),
-                        )
-                except RuntimeError:
-                    # No event loop, create a new one
-                    loop = asyncio.new_event_loop()
-                    try:
-                        authorized = loop.run_until_complete(
-                            permission_check(info, *args, **kwargs),
-                        )
-                    finally:
-                        loop.close()
-            elif expects_root:
+            # Check permission first (always sync here).
+            if expects_root:
                 authorized = permission_check(info, root, *args, **kwargs)
             else:
                 authorized = permission_check(info, *args, **kwargs)

--- a/src/fraiseql/security/field_auth.py
+++ b/src/fraiseql/security/field_auth.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import inspect
+import logging
 import warnings
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, Union
 
@@ -14,6 +16,8 @@ from fraiseql.security.authorization import AuthorizationDecision, normalize_dec
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -362,15 +366,89 @@ def field_authorizer_adapter(authorizer: Any, *, field: str) -> PermissionCheck:
     (issue #362): the returned check calls ``authorizer.authorize_operation`` with
     ``operation_type="field"`` and returns its decision, which ``authorize_field``
     enforces. ``filters`` are ignored at field granularity.
+
+    Fail-closed (issue #366): a ``GraphQLError`` raised by the authorizer propagates
+    unchanged, but any other exception is normalized to a deny (never falls through to
+    allow), mirroring ``enforce_operation_value`` on the operation path.
     """
 
-    async def _check(info: GraphQLResolveInfo, *args: Any, **kwargs: Any) -> AuthorizationDecision:
+    async def _check(
+        info: GraphQLResolveInfo, *args: Any, **kwargs: Any
+    ) -> AuthorizationDecision | bool:
         context = getattr(info, "context", None) or {}
-        return await authorizer.authorize_operation(
-            context=context,
-            operation_type="field",
-            operation_name=field,
-            arguments=kwargs,
-        )
+        try:
+            return await authorizer.authorize_operation(
+                context=context,
+                operation_type="field",
+                operation_name=field,
+                arguments=kwargs,
+            )
+        except GraphQLError:
+            raise
+        except Exception as exc:  # FAIL CLOSED: any error denies, never allows.
+            logger.warning("field authorizer raised; denying field access", exc_info=exc)
+            return AuthorizationDecision.deny(code=_DEFAULT_FIELD_CODE)
 
     return _check
+
+
+async def _auto_field_authorization(
+    info: GraphQLResolveInfo, *, field: str, arguments: dict[str, Any]
+) -> bool | AuthorizationDecision:
+    """Evaluate the registry's default authorizer for one field (issue #366).
+
+    Reads ``SchemaRegistry.default_authorizer`` **live** so default apps (no authorizer)
+    are byte-for-byte unaffected — ``None`` returns an allow. Otherwise runs the authorizer
+    with ``operation_type="field"`` through the fail-closed :func:`field_authorizer_adapter`,
+    consulting the optional decision cache (issue #367). A bare ``False`` deny is given the
+    field error code so denials shape consistently with or without a cache hit.
+    """
+    from fraiseql.gql.builders import SchemaRegistry
+
+    registry = SchemaRegistry.get_instance()
+    authorizer = registry.default_authorizer
+    if authorizer is None:
+        return True
+
+    cache = registry.decision_cache
+    context = getattr(info, "context", None) or {}
+    key = cache.make_key(context, "field", field, arguments) if cache is not None else None
+    if cache is not None and key is not None:
+        cached = cache.get(key)
+        if cached is not None:
+            return cached
+
+    raw = await field_authorizer_adapter(authorizer, field=field)(info, **arguments)
+    if isinstance(raw, AuthorizationDecision):
+        decision = raw
+    else:
+        decision = (
+            AuthorizationDecision.allow()
+            if raw
+            else AuthorizationDecision.deny(code=_DEFAULT_FIELD_CODE)
+        )
+    if cache is not None and key is not None:
+        cache.put(key, decision)
+    return decision
+
+
+def gate_field_resolver(resolver: Callable[..., Any], *, field: str) -> Callable[..., Any]:
+    """Compose automatic field-level authorization around a built field resolver (issue #366).
+
+    Always async so a sync inner resolver composes cleanly with an async authorizer under
+    graphql-core. The gate runs *before* the resolver, so a denial means the field body never
+    executes (no data leaks). It is fail-closed and reuses :func:`_enforce_field_decision` for
+    ``code``/``message`` shaping and the filters-ignored warning. Wrapping an already
+    ``@authorize_field``-decorated resolver AND-composes the two checks (both must allow).
+    """
+
+    @functools.wraps(resolver)
+    async def _gated(root: Any, info: GraphQLResolveInfo, **kwargs: Any) -> Any:
+        decision = await _auto_field_authorization(info, field=field, arguments=kwargs)
+        _enforce_field_decision(decision, error_message=None, info=info)
+        result = resolver(root, info, **kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    return _gated

--- a/src/fraiseql/security/field_auth.py
+++ b/src/fraiseql/security/field_auth.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar, Union
 
 from graphql import GraphQLError, GraphQLResolveInfo
 
+from fraiseql.core.resolver_invocation import invoke_resolver
 from fraiseql.security.authorization import AuthorizationDecision, normalize_decision
 
 if TYPE_CHECKING:
@@ -86,6 +87,33 @@ def _enforce_field_decision(
     raise FieldAuthorizationError(default_message)
 
 
+def _copy_resolver_metadata(wrapper: Any, func: Any) -> None:
+    """Copy resolver metadata onto an auth wrapper **without** setting ``__wrapped__``.
+
+    Mirrors ``@field``'s manual metadata copy (``decorators.py``) instead of using
+    ``functools.wraps``. ``functools.wraps`` sets ``wrapper.__wrapped__ = func``, and
+    ``inspect.signature`` follows ``__wrapped__`` by default — so an outer ``@field`` would
+    read the *inner* method's signature (e.g. ``(self)``) rather than the wrapper's real
+    ``(root, info, *args, **kwargs)`` interface, then call the wrapper with too few arguments.
+    That signature leak is the root of the decorator-order composition bug. Copying metadata
+    by hand keeps the wrapper signature-faithful.
+    """
+    wrapper.__name__ = getattr(func, "__name__", wrapper.__name__)
+    wrapper.__doc__ = func.__doc__
+    if hasattr(func, "__annotations__"):
+        wrapper.__annotations__ = func.__annotations__.copy()
+    if hasattr(func, "__fraiseql_field__"):
+        wrapper.__fraiseql_field__ = func.__fraiseql_field__
+        wrapper.__fraiseql_field_resolver__ = func.__fraiseql_field_resolver__
+        wrapper.__fraiseql_field_description__ = getattr(
+            func,
+            "__fraiseql_field_description__",
+            None,
+        )
+    if hasattr(func, "__fraiseql_original_func__"):
+        wrapper.__fraiseql_original_func__ = func.__fraiseql_original_func__
+
+
 def authorize_field(
     permission_check: PermissionCheck,
     *,
@@ -146,7 +174,6 @@ def authorize_field(
 
         if is_async:
 
-            @functools.wraps(func)
             async def async_auth_wrapper(
                 root: Any, info: GraphQLResolveInfo, *args: Any, **kwargs: Any
             ) -> Any:
@@ -163,24 +190,13 @@ def authorize_field(
 
                 _enforce_field_decision(authorized, error_message=error_message, info=info)
 
-                # Call the original function
-                return await func(root, info, *args, **kwargs)
+                # Call the wrapped resolver via the shared convention so the call adapts to
+                # whatever func is (a @field wrapper in order A, a raw method in order B).
+                return await invoke_resolver(func, root, info, *args, **kwargs)
 
-            # Preserve field metadata
-            if hasattr(func, "__fraiseql_field__"):
-                async_auth_wrapper.__fraiseql_field__ = func.__fraiseql_field__
-                async_auth_wrapper.__fraiseql_field_resolver__ = func.__fraiseql_field_resolver__
-                async_auth_wrapper.__fraiseql_field_description__ = getattr(
-                    func,
-                    "__fraiseql_field_description__",
-                    None,
-                )
-                if hasattr(func, "__fraiseql_original_func__"):
-                    async_auth_wrapper.__fraiseql_original_func__ = func.__fraiseql_original_func__
-
+            _copy_resolver_metadata(async_auth_wrapper, func)
             return async_auth_wrapper  # type: ignore[return-value]
 
-        @functools.wraps(func)
         def sync_auth_wrapper(
             root: Any, info: GraphQLResolveInfo, *args: Any, **kwargs: Any
         ) -> Any:
@@ -227,21 +243,11 @@ def authorize_field(
 
             _enforce_field_decision(authorized, error_message=error_message, info=info)
 
-            # Call the original function
-            return func(root, info, *args, **kwargs)
+            # Call the wrapped resolver via the shared convention so the call adapts to
+            # whatever func is (a @field wrapper in order A, a raw method in order B).
+            return invoke_resolver(func, root, info, *args, **kwargs)
 
-        # Preserve field metadata
-        if hasattr(func, "__fraiseql_field__"):
-            sync_auth_wrapper.__fraiseql_field__ = func.__fraiseql_field__
-            sync_auth_wrapper.__fraiseql_field_resolver__ = func.__fraiseql_field_resolver__
-            sync_auth_wrapper.__fraiseql_field_description__ = getattr(
-                func,
-                "__fraiseql_field_description__",
-                None,
-            )
-            if hasattr(func, "__fraiseql_original_func__"):
-                sync_auth_wrapper.__fraiseql_original_func__ = func.__fraiseql_original_func__
-
+        _copy_resolver_metadata(sync_auth_wrapper, func)
         return sync_auth_wrapper  # type: ignore[return-value]
 
     return decorator

--- a/src/fraiseql/subscriptions/decorator.py
+++ b/src/fraiseql/subscriptions/decorator.py
@@ -2,15 +2,30 @@
 
 import inspect
 from collections.abc import AsyncGenerator, Callable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 
 from fraiseql.core.types import SubscriptionField
 
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def subscription(fn: F) -> F:
+@overload
+def subscription(fn: F) -> F: ...
+
+
+@overload
+def subscription(*, authorizer: Any | None = None) -> Callable[[F], F]: ...
+
+
+def subscription(fn: F | None = None, *, authorizer: Any | None = None) -> F | Callable[[F], F]:
     """Decorator to mark a function as a GraphQL subscription.
+
+    Args:
+        fn: The subscription function to decorate (when used without parentheses).
+        authorizer: Optional per-operation :class:`~fraiseql.security.Authorizer`
+            override (issue #364). It takes precedence over the global default
+            authorizer for this subscription only, and is enforced once at subscribe
+            time (mirroring ``@query`` / ``@mutation``).
 
     Example:
         @subscription
@@ -18,43 +33,52 @@ def subscription(fn: F) -> F:
             async for task in watch_project_tasks(project_id):
                 yield task
     """
-    if not inspect.isasyncgenfunction(fn):
-        msg = (
-            f"Subscription {fn.__name__} must be an async generator function "
-            f"(use 'async def' and 'yield')"
+
+    def decorator(func: F) -> F:
+        if not inspect.isasyncgenfunction(func):
+            msg = (
+                f"Subscription {func.__name__} must be an async generator function "
+                f"(use 'async def' and 'yield')"
+            )
+            raise TypeError(
+                msg,
+            )
+
+        # Extract type hints
+        hints = inspect.get_annotations(func)
+        return_type = hints.get("return", Any)
+
+        # Parse AsyncGenerator type
+        if hasattr(return_type, "__origin__") and return_type.__origin__ is AsyncGenerator:
+            yield_type = return_type.__args__[0] if return_type.__args__ else Any
+        else:
+            # Try to infer from first yield
+            yield_type = Any
+
+        # Create subscription field
+        field = SubscriptionField(
+            name=func.__name__,
+            resolver=func,
+            return_type=yield_type,
+            args=hints,
+            description=func.__doc__,
         )
-        raise TypeError(
-            msg,
-        )
 
-    # Extract type hints
-    hints = inspect.get_annotations(fn)
-    return_type = hints.get("return", Any)
+        # Register with schema builder
+        from fraiseql.gql.schema_builder import SchemaRegistry
 
-    # Parse AsyncGenerator type
-    if hasattr(return_type, "__origin__") and return_type.__origin__ is AsyncGenerator:
-        yield_type = return_type.__args__[0] if return_type.__args__ else Any
-    else:
-        # Try to infer from first yield
-        yield_type = Any
+        schema_registry = SchemaRegistry.get_instance()
+        schema_registry.register_subscription(func)
 
-    # Create subscription field
-    field = SubscriptionField(
-        name=fn.__name__,
-        resolver=fn,
-        return_type=yield_type,
-        args=hints,
-        description=fn.__doc__,
-    )
+        # Add metadata
+        func.__fraiseql_subscription__ = True
+        func._field_def = field
+        # Per-operation authorizer override (issue #364); None falls back to the
+        # registry default at subscribe time via resolve_authorizer.
+        func.__fraiseql_authorizer__ = authorizer
 
-    # Register with schema builder
-    from fraiseql.gql.schema_builder import SchemaRegistry
+        return func
 
-    schema_registry = SchemaRegistry.get_instance()
-    schema_registry.register_subscription(fn)
-
-    # Add metadata
-    fn.__fraiseql_subscription__ = True
-    fn._field_def = field
-
-    return fn
+    if fn is None:
+        return decorator
+    return decorator(fn)

--- a/src/fraiseql/types/fraise_type.py
+++ b/src/fraiseql/types/fraise_type.py
@@ -23,6 +23,7 @@ def fraise_type(
     jsonb_column: str | None = ...,  # Use ... as sentinel for "not specified"
     implements: list[type] | None = None,
     resolve_nested: bool = False,
+    authorize_fields: list[str] | None = None,
 ) -> Callable[[T], T]: ...
 
 
@@ -37,6 +38,7 @@ def fraise_type(  # type: ignore[misc]
     jsonb_column: str | None = ...,  # Use ... as sentinel for "not specified"
     implements: list[type] | None = None,
     resolve_nested: bool = False,
+    authorize_fields: list[str] | None = None,
 ) -> T | Callable[[T], T]:
     """Decorator to define a FraiseQL GraphQL output type.
 
@@ -56,6 +58,12 @@ def fraise_type(  # type: ignore[misc]
             type, FraiseQL will attempt to resolve it via a separate query to its
             sql_source. If False (default), assumes the data is embedded in the
             parent's JSONB and won't create a separate resolver.
+        authorize_fields: Optional list of field names to gate automatically with the
+            configured operation ``Authorizer`` (issue #366), e.g. ``["email", "phone"]``.
+            Each listed field is checked with ``operation_type="field"`` and
+            ``operation_name="TypeName.fieldName"`` before its resolver runs. Off by
+            default (empty), and a no-op unless an authorizer is configured. Narrow opt-in
+            by design — fires per resolved object, so pair with decision caching (#367).
 
     Returns:
         The decorated class enhanced with FraiseQL capabilities.
@@ -150,6 +158,11 @@ def fraise_type(  # type: ignore[misc]
         # Infer kind: treat no SQL source as a pure type
         inferred_kind = "type" if sql_source is None else "output"
         cls = define_fraiseql_type(cls, kind=inferred_kind)
+
+        # Automatic field-level authorization opt-in (issue #366). Read live at the
+        # resolver build site; empty/absent means no field is auto-gated.
+        if authorize_fields:
+            cls.__fraiseql_authorize_fields__ = frozenset(authorize_fields)
 
         if sql_source:
             cls.__gql_table__ = sql_source

--- a/tests/integration/fastapi/test_app_authorizer.py
+++ b/tests/integration/fastapi/test_app_authorizer.py
@@ -57,10 +57,6 @@ async def _noop_lifespan(app: FastAPI):
     yield
 
 
-async def _user_ctx(request) -> dict[str, Any]:
-    return {"user": {"id": "u1", "permissions": [], "roles": []}}
-
-
 @pytest.fixture(autouse=True)
 def _clean_registry():
     registry = SchemaRegistry.get_instance()
@@ -98,7 +94,6 @@ def _build_app(*, authorizer=None, apq=False) -> FastAPI:
         queries=[widgets],
         mutations=[make_widget],
         lifespan=_noop_lifespan,
-        context_getter=_user_ctx,
         authorizer=authorizer,
     )
 
@@ -172,7 +167,6 @@ def test_apq_cache_hit_gated_through_app() -> None:
         queries=[widgets],
         mutations=[make_widget],
         lifespan=_noop_lifespan,
-        context_getter=_user_ctx,
         authorizer=DenyAll(),
     )
     query = "{ widgets { id } }"

--- a/tests/integration/fastapi/test_app_authorizer.py
+++ b/tests/integration/fastapi/test_app_authorizer.py
@@ -82,11 +82,12 @@ def _clean_registry():
     _ran.clear()
 
 
-def _build_app(*, authorizer=None, apq=False) -> FastAPI:
+def _build_app(*, authorizer=None, apq=False, rust=False) -> FastAPI:
     config = FraiseQLConfig(
         database_url="postgresql://test:test@localhost/test",
         environment="development",
         apq_cache_responses=apq,
+        enable_rust_endpoint=rust,  # opt-in route (issue #365)
     )
     return create_fraiseql_app(
         config=config,
@@ -140,7 +141,7 @@ def test_no_authorizer_is_baseline() -> None:
 
 
 def test_rust_endpoint_gated_through_app() -> None:
-    app = _build_app(authorizer=DenyAll())
+    app = _build_app(authorizer=DenyAll(), rust=True)
     calls: list[Any] = []
 
     async def _spy(*a: Any, **k: Any) -> bytes:

--- a/tests/integration/fastapi/test_app_authorizer.py
+++ b/tests/integration/fastapi/test_app_authorizer.py
@@ -1,0 +1,264 @@
+"""End-to-end app-level authorization wiring (issue #362, phase 6)."""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+from graphql import GraphQLError
+
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.fastapi.config import FraiseQLConfig
+from fraiseql.gql.builders import SchemaRegistry
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+pytestmark = pytest.mark.integration
+
+_ran: list[str] = []
+
+
+@fraiseql.type
+class Widget:
+    id: int
+    name: str
+
+
+@fraiseql.query
+async def widgets(info) -> list[Widget]:
+    _ran.append("widgets")
+    return [Widget(id=1, name="live")]
+
+
+@fraiseql.mutation
+async def make_widget(info, name: str) -> Widget:
+    _ran.append("make_widget")
+    return Widget(id=2, name=name)
+
+
+class DenyAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return False
+
+
+class AllowAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+@asynccontextmanager
+async def _noop_lifespan(app: FastAPI):
+    yield
+
+
+async def _user_ctx(request) -> dict[str, Any]:
+    return {"user": {"id": "u1", "permissions": [], "roles": []}}
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    import fraiseql.fastapi.app as app_mod
+    import fraiseql.fastapi.dependencies as deps
+
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+    _ran.clear()
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+    _ran.clear()
+
+
+def _build_app(*, authorizer=None, apq=False) -> FastAPI:
+    config = FraiseQLConfig(
+        database_url="postgresql://test:test@localhost/test",
+        environment="development",
+        apq_cache_responses=apq,
+    )
+    return create_fraiseql_app(
+        config=config,
+        types=[Widget],
+        queries=[widgets],
+        mutations=[make_widget],
+        lifespan=_noop_lifespan,
+        context_getter=_user_ctx,
+        authorizer=authorizer,
+    )
+
+
+def _is_forbidden(body: dict[str, Any]) -> bool:
+    return any(
+        (e.get("extensions") or {}).get("code") == "FORBIDDEN" for e in (body.get("errors") or [])
+    )
+
+
+# --- Cycle 1: app-level gate, end to end -------------------------------------------
+
+
+def test_deny_all_blocks_query_and_mutation() -> None:
+    app = _build_app(authorizer=DenyAll())
+    with TestClient(app) as c:
+        q = c.post("/graphql", json={"query": "{ widgets { id } }"}).json()
+        m = c.post("/graphql", json={"query": 'mutation { makeWidget(name: "x") { id } }'}).json()
+    assert _is_forbidden(q)
+    assert _is_forbidden(m)
+    assert _ran == []
+
+
+def test_allow_all_runs_query_and_mutation() -> None:
+    app = _build_app(authorizer=AllowAll())
+    with TestClient(app) as c:
+        q = c.post("/graphql", json={"query": "{ widgets { id name } }"}).json()
+        m = c.post("/graphql", json={"query": 'mutation { makeWidget(name: "x") { id } }'}).json()
+    assert not _is_forbidden(q)
+    assert not _is_forbidden(m)
+    assert "widgets" in _ran
+    assert "make_widget" in _ran
+
+
+def test_no_authorizer_is_baseline() -> None:
+    app = _build_app()
+    with TestClient(app) as c:
+        q = c.post("/graphql", json={"query": "{ widgets { id } }"}).json()
+    assert not _is_forbidden(q)
+    assert "widgets" in _ran
+
+
+# --- Cycle 2: bypass paths gated through the app ------------------------------------
+
+
+def test_rust_endpoint_gated_through_app() -> None:
+    app = _build_app(authorizer=DenyAll())
+    calls: list[Any] = []
+
+    async def _spy(*a: Any, **k: Any) -> bytes:
+        calls.append(1)
+        return b'{"data": {}}'
+
+    with mock.patch("fraiseql._fraiseql_rs.execute_graphql_query", new=_spy), TestClient(app) as c:
+        body = c.post("/graphql/rust", json={"query": "{ widgets { id } }"}).json()
+    assert _is_forbidden(body)
+    assert calls == []
+
+
+def test_apq_cache_hit_gated_through_app() -> None:
+    from fraiseql.middleware.apq_caching import compute_response_cache_key, get_apq_backend
+
+    config = FraiseQLConfig(
+        database_url="postgresql://test:test@localhost/test",
+        environment="development",
+        apq_cache_responses=True,
+    )
+    app = create_fraiseql_app(
+        config=config,
+        types=[Widget],
+        queries=[widgets],
+        mutations=[make_widget],
+        lifespan=_noop_lifespan,
+        context_getter=_user_ctx,
+        authorizer=DenyAll(),
+    )
+    query = "{ widgets { id } }"
+    sha = hashlib.sha256(query.encode()).hexdigest()
+    backend = get_apq_backend(config)
+    backend.store_persisted_query(sha, query)
+    backend.store_cached_response(
+        compute_response_cache_key(sha), {"data": {"widgets": [{"id": 99}]}}
+    )
+
+    with TestClient(app) as c:
+        body = c.post(
+            "/graphql",
+            json={"extensions": {"persistedQuery": {"version": 1, "sha256Hash": sha}}},
+        ).json()
+    assert _is_forbidden(body)
+    assert (body.get("data") or {}).get("widgets") != [{"id": 99}]
+
+
+def test_turbo_router_wired_with_app_authorizer() -> None:
+    # TurboRouter sources its gate from the registry default authorizer at construction;
+    # create_fraiseql_app installs the app authorizer there.
+    deny = DenyAll()
+    _build_app(authorizer=deny)
+    assert SchemaRegistry.get_instance().default_authorizer is deny
+
+
+# --- Cycle 3: survives hot-reload (real reload against a container) -----------------
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_authorizer_survives_hot_reload(postgres_url) -> None:
+    deny = DenyAll()
+    config = FraiseQLConfig(database_url=postgres_url, environment="development")
+    app = create_fraiseql_app(
+        database_url=postgres_url,  # refresh_schema reads this top-level value
+        config=config,
+        types=[Widget],
+        queries=[widgets],
+        mutations=[make_widget],
+        lifespan=_noop_lifespan,
+        authorizer=deny,
+    )
+    assert SchemaRegistry.get_instance().default_authorizer is deny
+
+    # A naive rebuild without re-threading would reset the registry slot to None.
+    await app.refresh_schema()
+
+    # The reload re-applies the configured authorizer to the registry slot that every
+    # gate reads, so the guard is not lost on schema rebuild.
+    assert SchemaRegistry.get_instance().default_authorizer is deny
+
+
+# --- Cycle 4: legacy registry-rewrite migration still works ------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_registry_rewrite_still_enforced() -> None:
+    # The pre-#362 pattern wrapped resolvers via the private registry before building the
+    # schema. With no app-level authorizer the new enforce wrap is a no-op and composes
+    # around whatever resolver is present at build time — so the legacy guard still fires.
+    from graphql import graphql
+
+    from fraiseql.gql.schema_builder import build_fraiseql_schema
+
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+
+    @fraiseql.mutation
+    async def legacy_mut(info, name: str) -> Widget:
+        _ran.append("legacy_mut")
+        return Widget(id=3, name=name)
+
+    async def guarded(info, name: str) -> Widget:
+        raise GraphQLError("legacy guard", extensions={"code": "FORBIDDEN"})
+
+    # Legacy migration: overwrite the registry slot before the schema is built.
+    registry._mutations["legacy_mut"] = guarded
+
+    schema = build_fraiseql_schema(query_types=[Widget, widgets])
+
+    result = await graphql(schema, 'mutation { legacyMut(name: "x") { id } }')
+    assert result.errors
+    assert result.errors[0].extensions["code"] == "FORBIDDEN"
+    assert "legacy_mut" not in _ran

--- a/tests/integration/fastapi/test_apq_authorization.py
+++ b/tests/integration/fastapi/test_apq_authorization.py
@@ -1,0 +1,135 @@
+"""APQ cached-passthrough authorization gate (issue #362, phase 4 part C)."""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.fastapi.config import FraiseQLConfig
+from fraiseql.gql.schema_builder import SchemaRegistry
+from fraiseql.middleware.apq_caching import compute_response_cache_key, get_apq_backend
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+pytestmark = pytest.mark.integration
+
+_QUERY = "{ widgets { id } }"
+_CACHED = {"data": {"widgets": [{"id": 99}]}}
+
+
+@fraiseql.type
+class Widget:
+    id: int
+    name: str
+
+
+@fraiseql.query
+async def widgets(info) -> list[Widget]:
+    return [Widget(id=1, name="live")]
+
+
+class DenyAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return False
+
+
+class AllowAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+class AllowWithFilters:
+    async def authorize_operation(self, **_: Any) -> Any:
+        from fraiseql.security.authorization import AuthorizationDecision
+
+        return AuthorizationDecision.allow(filters={"tenant_id": "t1"})
+
+
+@asynccontextmanager
+async def _noop_lifespan(app: FastAPI):
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    import fraiseql.fastapi.app as app_mod
+    import fraiseql.fastapi.dependencies as deps
+
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+
+
+def _build_app_and_seed_cache() -> tuple[FastAPI, str]:
+    config = FraiseQLConfig(
+        database_url="postgresql://test:test@localhost/test",
+        environment="development",
+        apq_cache_responses=True,
+    )
+    app = create_fraiseql_app(
+        config=config, types=[Widget], queries=[widgets], lifespan=_noop_lifespan
+    )
+    sha = hashlib.sha256(_QUERY.encode()).hexdigest()
+    backend = get_apq_backend(config)
+    backend.store_persisted_query(sha, _QUERY)
+    backend.store_cached_response(compute_response_cache_key(sha), dict(_CACHED))
+    return app, sha
+
+
+def _apq_request(sha: str) -> dict[str, Any]:
+    return {"extensions": {"persistedQuery": {"version": 1, "sha256Hash": sha}}}
+
+
+def test_deny_all_blocks_apq_cache_hit() -> None:
+    app, sha = _build_app_and_seed_cache()
+    SchemaRegistry.get_instance().set_default_authorizer(DenyAll())
+    with TestClient(app) as c:
+        body = c.post("/graphql", json=_apq_request(sha)).json()
+    assert body["errors"][0]["extensions"]["code"] == "FORBIDDEN"
+    assert "data" not in body or body.get("data") is None
+
+
+def test_allow_all_serves_cached_response() -> None:
+    app, sha = _build_app_and_seed_cache()
+    SchemaRegistry.get_instance().set_default_authorizer(AllowAll())
+    with TestClient(app) as c:
+        body = c.post("/graphql", json=_apq_request(sha)).json()
+    assert body["data"]["widgets"] == [{"id": 99}]
+
+
+def test_no_authorizer_serves_cached_response() -> None:
+    app, sha = _build_app_and_seed_cache()
+    with TestClient(app) as c:
+        body = c.post("/graphql", json=_apq_request(sha)).json()
+    assert body["data"]["widgets"] == [{"id": 99}]
+
+
+def test_allow_with_filters_skips_cache_and_falls_through() -> None:
+    app, sha = _build_app_and_seed_cache()
+    SchemaRegistry.get_instance().set_default_authorizer(AllowWithFilters())
+    with TestClient(app) as c:
+        body = c.post("/graphql", json=_apq_request(sha)).json()
+    # Cache is bypassed (its baked id=99 is NOT served); normal execution runs the
+    # live resolver instead (id=1). Either way the cached blob must not be returned.
+    widgets_data = (body.get("data") or {}).get("widgets")
+    assert widgets_data != [{"id": 99}]

--- a/tests/integration/fastapi/test_rust_endpoint_authorization.py
+++ b/tests/integration/fastapi/test_rust_endpoint_authorization.py
@@ -77,13 +77,6 @@ def _clean_registry():
     app_mod._global_turbo_registry = None
 
 
-async def _ctx_getter(request) -> dict[str, Any]:
-    # graphql_endpoint_rust reads context["user"].get(...) when building user_context;
-    # supply a user so the allow path reaches the Rust call (the deny path short-circuits
-    # before it regardless).
-    return {"user": {"id": "u1", "permissions": [], "roles": []}}
-
-
 def _build_app() -> FastAPI:
     config = FraiseQLConfig(
         database_url="postgresql://test:test@localhost/test",
@@ -94,7 +87,6 @@ def _build_app() -> FastAPI:
         types=[Widget],
         queries=[widgets],
         lifespan=_noop_lifespan,
-        context_getter=_ctx_getter,
     )
 
 

--- a/tests/integration/fastapi/test_rust_endpoint_authorization.py
+++ b/tests/integration/fastapi/test_rust_endpoint_authorization.py
@@ -1,0 +1,152 @@
+"""`/graphql/rust` bypass-path authorization gate (issue #362, phase 4 part B)."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.fastapi.config import FraiseQLConfig
+from fraiseql.gql.schema_builder import SchemaRegistry
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+pytestmark = pytest.mark.integration
+
+
+@fraiseql.type
+class Widget:
+    id: int
+    name: str
+
+
+@fraiseql.query
+async def widgets(info) -> list[Widget]:
+    return [Widget(id=1, name="a")]
+
+
+class DenyAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return False
+
+
+class AllowAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+class AllowWithFilters:
+    async def authorize_operation(self, **_: Any) -> Any:
+        from fraiseql.security.authorization import AuthorizationDecision
+
+        return AuthorizationDecision.allow(filters={"tenant_id": "t1"})
+
+
+@asynccontextmanager
+async def _noop_lifespan(app: FastAPI):
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    import fraiseql.fastapi.app as app_mod
+    import fraiseql.fastapi.dependencies as deps
+
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+
+
+async def _ctx_getter(request) -> dict[str, Any]:
+    # graphql_endpoint_rust reads context["user"].get(...) when building user_context;
+    # supply a user so the allow path reaches the Rust call (the deny path short-circuits
+    # before it regardless).
+    return {"user": {"id": "u1", "permissions": [], "roles": []}}
+
+
+def _build_app() -> FastAPI:
+    config = FraiseQLConfig(
+        database_url="postgresql://test:test@localhost/test",
+        environment="development",
+    )
+    return create_fraiseql_app(
+        config=config,
+        types=[Widget],
+        queries=[widgets],
+        lifespan=_noop_lifespan,
+        context_getter=_ctx_getter,
+    )
+
+
+def _spy():
+    calls: list[Any] = []
+
+    async def _execute(*args: Any, **kwargs: Any) -> bytes:
+        calls.append((args, kwargs))
+        return b'{"data": {"widgets": []}}'
+
+    return calls, _execute
+
+
+def test_deny_all_blocks_rust_endpoint_no_rust_call() -> None:
+    app = _build_app()
+    SchemaRegistry.get_instance().set_default_authorizer(DenyAll())
+    calls, spy = _spy()
+    with mock.patch("fraiseql._fraiseql_rs.execute_graphql_query", new=spy), TestClient(app) as c:
+        response = c.post("/graphql/rust", json={"query": "{ widgets { id } }"})
+    body = response.json()
+    assert body["errors"][0]["extensions"]["code"] == "FORBIDDEN"
+    assert calls == [], "Rust pipeline was invoked despite a deny-all authorizer"
+
+
+def test_allow_all_invokes_rust_endpoint() -> None:
+    app = _build_app()
+    SchemaRegistry.get_instance().set_default_authorizer(AllowAll())
+    calls, spy = _spy()
+    with mock.patch("fraiseql._fraiseql_rs.execute_graphql_query", new=spy), TestClient(app) as c:
+        response = c.post("/graphql/rust", json={"query": "{ widgets { id } }"})
+    assert response.status_code == 200
+    assert len(calls) == 1
+
+
+def test_no_authorizer_keeps_today_behavior() -> None:
+    app = _build_app()
+    calls, spy = _spy()
+    with mock.patch("fraiseql._fraiseql_rs.execute_graphql_query", new=spy), TestClient(app) as c:
+        c.post("/graphql/rust", json={"query": "{ widgets { id } }"})
+    assert len(calls) == 1
+
+
+def test_filters_on_rust_warn_and_do_not_scope(caplog) -> None:
+    app = _build_app()
+    SchemaRegistry.get_instance().set_default_authorizer(AllowWithFilters())
+    calls, spy = _spy()
+    with (
+        caplog.at_level(logging.WARNING),
+        mock.patch("fraiseql._fraiseql_rs.execute_graphql_query", new=spy),
+        TestClient(app) as c,
+    ):
+        c.post("/graphql/rust", json={"query": "{ widgets { id } }"})
+    # Rust still runs (no per-row scoping), but the filter limitation is logged.
+    assert len(calls) == 1
+    assert any("filter" in record.message.lower() for record in caplog.records)

--- a/tests/integration/fastapi/test_rust_endpoint_authorization.py
+++ b/tests/integration/fastapi/test_rust_endpoint_authorization.py
@@ -81,6 +81,7 @@ def _build_app() -> FastAPI:
     config = FraiseQLConfig(
         database_url="postgresql://test:test@localhost/test",
         environment="development",
+        enable_rust_endpoint=True,  # opt-in route under test (issue #365)
     )
     return create_fraiseql_app(
         config=config,

--- a/tests/integration/security/test_authorization_paths.py
+++ b/tests/integration/security/test_authorization_paths.py
@@ -307,21 +307,9 @@ _CASES = [
     pytest.param(_run_single_query, id="single-field-query"),  # gated in Phase 3
     pytest.param(_run_multi_field, id="multi-field-query"),  # gated in Phase 3
     pytest.param(_run_get_query, id="get-query"),  # gated in Phase 3
-    pytest.param(
-        _run_turbo,
-        id="turbo",
-        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 4"),
-    ),
-    pytest.param(
-        _run_rust,
-        id="graphql-rust",
-        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 4"),
-    ),
-    pytest.param(
-        _run_apq,
-        id="apq-cache-hit",
-        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 4"),
-    ),
+    pytest.param(_run_turbo, id="turbo"),  # gated in Phase 4 (part A)
+    pytest.param(_run_rust, id="graphql-rust"),  # gated in Phase 4 (part B)
+    pytest.param(_run_apq, id="apq-cache-hit"),  # gated in Phase 4 (part C)
 ]
 
 

--- a/tests/integration/security/test_authorization_paths.py
+++ b/tests/integration/security/test_authorization_paths.py
@@ -303,11 +303,7 @@ def _run_apq() -> tuple[bool, bool]:
 
 
 _CASES = [
-    pytest.param(
-        _run_mutation,
-        id="mutation",
-        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 2"),
-    ),
+    pytest.param(_run_mutation, id="mutation"),  # gated in Phase 2
     pytest.param(
         _run_single_query,
         id="single-field-query",

--- a/tests/integration/security/test_authorization_paths.py
+++ b/tests/integration/security/test_authorization_paths.py
@@ -32,7 +32,10 @@ removed exactly when its phase completes (and turning any *new* ungated path red
 from __future__ import annotations
 
 import asyncio
+import inspect
+from collections.abc import AsyncGenerator  # noqa: TC003 — runtime hint for get_type_hints
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest import mock
 
@@ -42,7 +45,7 @@ from fastapi.testclient import TestClient
 import fraiseql
 from fraiseql.fastapi import create_fraiseql_app
 from fraiseql.fastapi.config import FraiseQLConfig
-from fraiseql.gql.schema_builder import SchemaRegistry
+from fraiseql.gql.schema_builder import SchemaRegistry, build_fraiseql_schema
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -90,6 +93,13 @@ async def create_user(info, name: str) -> User:
     """Create a user (records execution)."""
     _executions.append("create_user")
     return User(id=2, name=name)
+
+
+@fraiseql.subscription
+async def message_stream(info) -> AsyncGenerator[Post]:
+    """Stream messages (records execution before the first yield)."""
+    _executions.append("message_stream")
+    yield Post(id=201, title="streamed")
 
 
 class DenyAll:
@@ -302,6 +312,44 @@ def _run_apq() -> tuple[bool, bool]:
     return _is_forbidden(body), served_cached
 
 
+def _run_subscription() -> tuple[bool, bool]:
+    """Drive the Subscription field's ``subscribe`` directly under a deny-all authorizer.
+
+    Mirrors ``_run_turbo``: exercise the resolver as a unit via ``asyncio.run``. The
+    websocket manager (``websocket.py:256``) drives graphql-core's ``subscribe``, which
+    invokes this same field resolver, so a single gate here covers the websocket path too.
+    """
+    from graphql import GraphQLError
+
+    _executions.clear()
+    schema = build_fraiseql_schema(
+        query_types=[User, Post, users, posts],
+        subscription_resolvers=[message_stream],
+    )
+    _set_default_authorizer(DenyAll())
+
+    field = next(iter(schema.subscription_type.fields.values()))
+    subscribe = field.subscribe
+    info = SimpleNamespace(context={}, field_name="messageStream")
+
+    async def _drive() -> None:
+        # Phase 1 makes ``subscribe`` a plain ``async def``: awaiting it enforces (raising
+        # on deny) *before* the inner generator is created. Today it is an async generator
+        # function, so calling it returns a generator whose body runs only on iteration.
+        result = subscribe(None, info)
+        if inspect.isawaitable(result):
+            result = await result
+        async for _value in result:
+            break
+
+    forbidden = False
+    try:
+        asyncio.run(_drive())
+    except GraphQLError as exc:
+        forbidden = (exc.extensions or {}).get("code") == "FORBIDDEN"
+    return forbidden, bool(_executions)
+
+
 _CASES = [
     pytest.param(_run_mutation, id="mutation"),  # gated in Phase 2
     pytest.param(_run_single_query, id="single-field-query"),  # gated in Phase 3
@@ -310,6 +358,14 @@ _CASES = [
     pytest.param(_run_turbo, id="turbo"),  # gated in Phase 4 (part A)
     pytest.param(_run_rust, id="graphql-rust"),  # gated in Phase 4 (part B)
     pytest.param(_run_apq, id="apq-cache-hit"),  # gated in Phase 4 (part C)
+    pytest.param(
+        _run_subscription,
+        id="subscription",
+        marks=pytest.mark.xfail(
+            strict=True,
+            reason="#364: subscribe-time gate not yet landed",
+        ),
+    ),
 ]
 
 

--- a/tests/integration/security/test_authorization_paths.py
+++ b/tests/integration/security/test_authorization_paths.py
@@ -304,21 +304,9 @@ def _run_apq() -> tuple[bool, bool]:
 
 _CASES = [
     pytest.param(_run_mutation, id="mutation"),  # gated in Phase 2
-    pytest.param(
-        _run_single_query,
-        id="single-field-query",
-        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 3"),
-    ),
-    pytest.param(
-        _run_multi_field,
-        id="multi-field-query",
-        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 3"),
-    ),
-    pytest.param(
-        _run_get_query,
-        id="get-query",
-        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 3"),
-    ),
+    pytest.param(_run_single_query, id="single-field-query"),  # gated in Phase 3
+    pytest.param(_run_multi_field, id="multi-field-query"),  # gated in Phase 3
+    pytest.param(_run_get_query, id="get-query"),  # gated in Phase 3
     pytest.param(
         _run_turbo,
         id="turbo",

--- a/tests/integration/security/test_authorization_paths.py
+++ b/tests/integration/security/test_authorization_paths.py
@@ -358,14 +358,7 @@ _CASES = [
     pytest.param(_run_turbo, id="turbo"),  # gated in Phase 4 (part A)
     pytest.param(_run_rust, id="graphql-rust"),  # gated in Phase 4 (part B)
     pytest.param(_run_apq, id="apq-cache-hit"),  # gated in Phase 4 (part C)
-    pytest.param(
-        _run_subscription,
-        id="subscription",
-        marks=pytest.mark.xfail(
-            strict=True,
-            reason="#364: subscribe-time gate not yet landed",
-        ),
-    ),
+    pytest.param(_run_subscription, id="subscription"),  # gated in #364 (subscribe-time)
 ]
 
 

--- a/tests/integration/security/test_authorization_paths.py
+++ b/tests/integration/security/test_authorization_paths.py
@@ -150,11 +150,12 @@ def _clean_registry():
     app_mod._global_turbo_registry = None
 
 
-def _build_app() -> FastAPI:
+def _build_app(*, enable_rust_endpoint: bool = False) -> FastAPI:
     config = FraiseQLConfig(
         database_url="postgresql://test:test@localhost/test",
         environment="development",
         apq_cache_responses=True,
+        enable_rust_endpoint=enable_rust_endpoint,
     )
     return create_fraiseql_app(
         config=config,
@@ -256,7 +257,9 @@ def _run_turbo() -> tuple[bool, bool]:
 
 
 def _run_rust() -> tuple[bool, bool]:
-    app = _build_app()
+    # The /graphql/rust route is opt-in (issue #365); the deny-all gate must still hold
+    # when the route exists.
+    app = _build_app(enable_rust_endpoint=True)
     _set_default_authorizer(DenyAll())
 
     calls: list[Any] = []
@@ -370,17 +373,27 @@ def test_deny_all_blocks_every_path(runner) -> None:
     assert not executed, "operation reached the database/Rust despite a deny-all authorizer"
 
 
-def test_graphql_post_routes_are_a_known_allow_list() -> None:
-    """Freeze the set of POST routes under /graphql*.
-
-    A newly added POST route (a potential resolver-bypass) breaks this test until it is
-    added to the matrix above *and* gated in the parametrized spec.
-    """
-    app = _build_app()
-    post_routes = {
+def _graphql_post_routes(app: FastAPI) -> set[str]:
+    """The set of POST routes under /graphql* mounted on ``app``."""
+    return {
         route.path
         for route in app.routes
         if getattr(route, "path", "").startswith("/graphql")
         and "POST" in getattr(route, "methods", set())
     }
-    assert post_routes == {"/graphql", "/graphql/rust"}
+
+
+@pytest.mark.xfail(strict=True, reason="#365: enable_rust_endpoint default-off not yet landed")
+def test_default_app_has_no_rust_post_route() -> None:
+    """By default the resolver-bypass /graphql/rust route is not mounted (issue #365).
+
+    A newly added POST route (a potential resolver-bypass) breaks this test until it is
+    added to the matrix above *and* gated in the parametrized spec.
+    """
+    assert _graphql_post_routes(_build_app()) == {"/graphql"}
+
+
+def test_enable_rust_endpoint_mounts_rust_post_route() -> None:
+    """With ``enable_rust_endpoint=True`` the gated Rust passthrough is mounted (issue #365)."""
+    app = _build_app(enable_rust_endpoint=True)
+    assert _graphql_post_routes(app) == {"/graphql", "/graphql/rust"}

--- a/tests/integration/security/test_authorization_paths.py
+++ b/tests/integration/security/test_authorization_paths.py
@@ -383,7 +383,6 @@ def _graphql_post_routes(app: FastAPI) -> set[str]:
     }
 
 
-@pytest.mark.xfail(strict=True, reason="#365: enable_rust_endpoint default-off not yet landed")
 def test_default_app_has_no_rust_post_route() -> None:
     """By default the resolver-bypass /graphql/rust route is not mounted (issue #365).
 

--- a/tests/integration/security/test_authorization_paths.py
+++ b/tests/integration/security/test_authorization_paths.py
@@ -1,0 +1,365 @@
+"""Cross-path authorization spec (Issue #362, Phase 0).
+
+This module is the *specification* the operation-authorization work must satisfy:
+a single deny-all assertion run across every execution path a GraphQL request can take.
+If any path reaches the database/Rust without consulting the configured authorizer, its
+case fails here.
+
+Execution-path inventory (verified against the tree on 2026-06-06).
+Columns: path | entry point | resolver-honoring? | gate phase.
+
+1. Single-field query   | POST /graphql -> execute_graphql            | yes | P3
+2. Mutation             | POST /graphql -> execute_graphql            | yes | P2
+3. Multi-field merge    | routers.py:1358 execute_multi_field_query   | yes | P3
+                          (field_def.resolve per field, routers.py:867)
+4. TurboRouter          | turbo.py:271 TurboRouter.execute            | no  | P4
+5. POST /graphql/rust   | routers.py:1626 -> Rust execute_graphql_query | no | P4
+6. APQ cache passthrough| routers.py:1280 cache hit                   | no  | P4
+7. GET /graphql         | routers.py:1586 -> graphql_endpoint         | 1/3 | P2/P3
+
+Drift note: ``TurboRouter.execute`` is not wired into the live HTTP dispatch in this
+release (``UnifiedExecutor`` holds the turbo router for metrics only and always calls
+``execute_graphql``). Case 4 therefore exercises ``TurboRouter.execute`` directly as a
+unit; the Phase 4 gate is defense-in-depth.
+
+The authorizer is configured through the registry funnel
+(``SchemaRegistry.set_default_authorizer``) — the same slot the resolver wrap and the
+bypass gates read. Each case is decorated ``xfail(strict=True)`` until its gate lands; the
+strict marker turns the case red the moment it starts passing, forcing the xfail to be
+removed exactly when its phase completes (and turning any *new* ungated path red).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.fastapi.config import FraiseQLConfig
+from fraiseql.gql.schema_builder import SchemaRegistry
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+pytestmark = pytest.mark.integration
+
+# Records every resolver body that actually executes. A denied operation must leave this
+# empty — the resolver body is what would reach the database, so "body ran" is our proxy
+# for "the database was touched" on the resolver-honoring paths.
+_executions: list[str] = []
+
+
+@fraiseql.type
+class User:
+    """User type for cross-path authorization testing."""
+
+    id: int
+    name: str
+
+
+@fraiseql.type
+class Post:
+    """Post type for cross-path authorization testing."""
+
+    id: int
+    title: str
+
+
+@fraiseql.query
+async def users(info) -> list[User]:
+    """Return users (records execution)."""
+    _executions.append("users")
+    return [User(id=1, name="Alice")]
+
+
+@fraiseql.query
+async def posts(info) -> list[Post]:
+    """Return posts (records execution)."""
+    _executions.append("posts")
+    return [Post(id=101, title="First")]
+
+
+@fraiseql.mutation
+async def create_user(info, name: str) -> User:
+    """Create a user (records execution)."""
+    _executions.append("create_user")
+    return User(id=2, name=name)
+
+
+class DenyAll:
+    """A deny-all authorizer: every operation is forbidden."""
+
+    async def authorize_operation(
+        self,
+        *,
+        context: dict[str, Any],
+        operation_type: str,
+        operation_name: str,
+        arguments: dict[str, Any],
+    ) -> bool:
+        return False
+
+
+@asynccontextmanager
+async def _noop_lifespan(app: FastAPI):
+    """No-op lifespan so the app needs no live database."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate the singleton registry (and global deps) around each test."""
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+
+    import fraiseql.fastapi.app as app_mod
+    import fraiseql.fastapi.dependencies as deps
+
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+
+    yield
+
+    _executions.clear()
+    registry.clear()
+    _graphql_type_cache.clear()
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+
+
+def _build_app() -> FastAPI:
+    config = FraiseQLConfig(
+        database_url="postgresql://test:test@localhost/test",
+        environment="development",
+        apq_cache_responses=True,
+    )
+    return create_fraiseql_app(
+        config=config,
+        types=[User, Post],
+        queries=[users, posts],
+        mutations=[create_user],
+        lifespan=_noop_lifespan,
+    )
+
+
+def _set_default_authorizer(authorizer: Any) -> None:
+    SchemaRegistry.get_instance().set_default_authorizer(authorizer)
+
+
+def _is_forbidden(body: dict[str, Any]) -> bool:
+    errors = body.get("errors") or []
+    return any((e.get("extensions") or {}).get("code") == "FORBIDDEN" for e in errors)
+
+
+# --- per-path runners: each returns (forbidden, executed) ---------------------------
+
+
+def _run_single_query() -> tuple[bool, bool]:
+    _executions.clear()
+    app = _build_app()
+    _set_default_authorizer(DenyAll())
+    with TestClient(app) as client:
+        body = client.post("/graphql", json={"query": "{ users { id name } }"}).json()
+    return _is_forbidden(body), bool(_executions)
+
+
+def _run_mutation() -> tuple[bool, bool]:
+    _executions.clear()
+    app = _build_app()
+    _set_default_authorizer(DenyAll())
+    with TestClient(app) as client:
+        body = client.post(
+            "/graphql",
+            json={"query": 'mutation { createUser(name: "Bob") { id name } }'},
+        ).json()
+    return _is_forbidden(body), bool(_executions)
+
+
+def _run_multi_field() -> tuple[bool, bool]:
+    _executions.clear()
+    app = _build_app()
+    _set_default_authorizer(DenyAll())
+    with TestClient(app) as client:
+        body = client.post(
+            "/graphql",
+            json={"query": "{ users { id } posts { id } }"},
+        ).json()
+    return _is_forbidden(body), bool(_executions)
+
+
+def _run_get_query() -> tuple[bool, bool]:
+    _executions.clear()
+    app = _build_app()
+    _set_default_authorizer(DenyAll())
+    with TestClient(app) as client:
+        body = client.get("/graphql", params={"query": "{ users { id } }"}).json()
+    return _is_forbidden(body), bool(_executions)
+
+
+class _SpyDB:
+    """Minimal repository stand-in that records transaction execution."""
+
+    def __init__(self) -> None:
+        self.context: dict[str, Any] = {}
+        self.tx_calls = 0
+
+    async def run_in_transaction(self, fn: Any) -> list[dict[str, Any]]:
+        self.tx_calls += 1
+        return [{"result": {}}]
+
+    async def _set_session_variables(self, cursor: Any) -> None:  # pragma: no cover
+        return None
+
+
+def _run_turbo() -> tuple[bool, bool]:
+    from graphql import GraphQLError
+
+    from fraiseql.fastapi.turbo import TurboQuery, TurboRegistry, TurboRouter
+
+    query = "query { users { id } }"
+    registry = TurboRegistry()
+    registry.register(TurboQuery(graphql_query=query, sql_template="SELECT 1", param_mapping={}))
+    spy = _SpyDB()
+    router = TurboRouter(registry, default_authorizer=DenyAll())
+
+    forbidden = False
+    try:
+        result = asyncio.run(router.execute(query, {}, {"db": spy}))
+        if isinstance(result, dict):
+            forbidden = _is_forbidden(result)
+    except GraphQLError as exc:
+        forbidden = (exc.extensions or {}).get("code") == "FORBIDDEN"
+    return forbidden, spy.tx_calls > 0
+
+
+def _run_rust() -> tuple[bool, bool]:
+    app = _build_app()
+    _set_default_authorizer(DenyAll())
+
+    calls: list[Any] = []
+
+    async def _spy(*args: Any, **kwargs: Any) -> bytes:
+        calls.append((args, kwargs))
+        return b'{"data": {"users": []}}'
+
+    with mock.patch("fraiseql._fraiseql_rs.execute_graphql_query", new=_spy):
+        with TestClient(app) as client:
+            response = client.post("/graphql/rust", json={"query": "{ users { id } }"})
+        try:
+            body = response.json()
+        except ValueError:
+            body = {}
+    return _is_forbidden(body), len(calls) > 0
+
+
+def _run_apq() -> tuple[bool, bool]:
+    import hashlib
+
+    from fraiseql.middleware.apq_caching import compute_response_cache_key, get_apq_backend
+
+    config = FraiseQLConfig(
+        database_url="postgresql://test:test@localhost/test",
+        environment="development",
+        apq_cache_responses=True,
+    )
+    app = create_fraiseql_app(
+        config=config,
+        types=[User, Post],
+        queries=[users, posts],
+        mutations=[create_user],
+        lifespan=_noop_lifespan,
+    )
+    _set_default_authorizer(DenyAll())
+
+    query_text = "{ users { id } }"
+    sha = hashlib.sha256(query_text.encode()).hexdigest()
+    cached = {"data": {"users": [{"id": 99}]}}
+
+    backend = get_apq_backend(config)
+    backend.store_persisted_query(sha, query_text)
+    backend.store_cached_response(compute_response_cache_key(sha), cached)
+
+    with TestClient(app) as client:
+        body = client.post(
+            "/graphql",
+            json={"extensions": {"persistedQuery": {"version": 1, "sha256Hash": sha}}},
+        ).json()
+
+    served_cached = body.get("data", {}).get("users") == [{"id": 99}]
+    return _is_forbidden(body), served_cached
+
+
+_CASES = [
+    pytest.param(
+        _run_mutation,
+        id="mutation",
+        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 2"),
+    ),
+    pytest.param(
+        _run_single_query,
+        id="single-field-query",
+        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 3"),
+    ),
+    pytest.param(
+        _run_multi_field,
+        id="multi-field-query",
+        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 3"),
+    ),
+    pytest.param(
+        _run_get_query,
+        id="get-query",
+        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 3"),
+    ),
+    pytest.param(
+        _run_turbo,
+        id="turbo",
+        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 4"),
+    ),
+    pytest.param(
+        _run_rust,
+        id="graphql-rust",
+        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 4"),
+    ),
+    pytest.param(
+        _run_apq,
+        id="apq-cache-hit",
+        marks=pytest.mark.xfail(strict=True, reason="gated in Phase 4"),
+    ),
+]
+
+
+@pytest.mark.parametrize("runner", _CASES)
+def test_deny_all_blocks_every_path(runner) -> None:
+    """A deny-all authorizer forbids the operation and never touches the database."""
+    forbidden, executed = runner()
+    assert forbidden, "expected a FORBIDDEN error on this path"
+    assert not executed, "operation reached the database/Rust despite a deny-all authorizer"
+
+
+def test_graphql_post_routes_are_a_known_allow_list() -> None:
+    """Freeze the set of POST routes under /graphql*.
+
+    A newly added POST route (a potential resolver-bypass) breaks this test until it is
+    added to the matrix above *and* gated in the parametrized spec.
+    """
+    app = _build_app()
+    post_routes = {
+        route.path
+        for route in app.routes
+        if getattr(route, "path", "").startswith("/graphql")
+        and "POST" in getattr(route, "methods", set())
+    }
+    assert post_routes == {"/graphql", "/graphql/rust"}

--- a/tests/integration/security/test_decision_cache_paths.py
+++ b/tests/integration/security/test_decision_cache_paths.py
@@ -1,0 +1,205 @@
+"""Decision caching across execution paths (issue #367, phase 2).
+
+Caching must memoize identical authorization *decisions* on the live paths (the resolver
+path and the resolver-bypass gates) without ever weakening the fail-closed contract proven
+by ``test_authorization_paths.py``. Note that only the *decision* is cached — the resolver /
+Rust pipeline still runs on every request.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.fastapi.config import FraiseQLConfig
+from fraiseql.gql.schema_builder import SchemaRegistry
+from fraiseql.security.decision_cache import AuthorizationCacheConfig
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+pytestmark = pytest.mark.integration
+
+_executions: list[str] = []
+
+
+@fraiseql.type
+class Widget:
+    """Widget type for decision-cache path testing."""
+
+    id: int
+    name: str
+
+
+@fraiseql.query
+async def widgets(info) -> list[Widget]:
+    """Return widgets (records execution)."""
+    _executions.append("widgets")
+    return [Widget(id=1, name="w")]
+
+
+class CountingAuthorizer:
+    """Counts invocations; returns a fixed result (bool or AuthorizationDecision)."""
+
+    def __init__(self, *, result: Any = True) -> None:
+        self.calls = 0
+        self._result = result
+
+    async def authorize_operation(self, **_: Any) -> Any:
+        self.calls += 1
+        return self._result
+
+
+class RaisingAuthorizer:
+    """Always raises — a transient PDP error that must never be cached."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def authorize_operation(self, **_: Any) -> bool:
+        self.calls += 1
+        raise RuntimeError("PDP down")
+
+
+@asynccontextmanager
+async def _noop_lifespan(app: FastAPI):
+    """No-op lifespan so the app needs no live database."""
+    yield
+
+
+async def _ctx_with_user(_request: Any) -> dict[str, Any]:
+    """Inject an identified principal so the cache engages."""
+    return {"user": {"id": "u1"}}
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate the singleton registry (and global deps) around each test."""
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+
+    import fraiseql.fastapi.app as app_mod
+    import fraiseql.fastapi.dependencies as deps
+
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+
+    yield
+
+    _executions.clear()
+    registry.clear()
+    _graphql_type_cache.clear()
+    deps._db_pool = None
+    deps._auth_provider = None
+    deps._fraiseql_config = None
+    app_mod._global_turbo_registry = None
+
+
+def _cache_config() -> AuthorizationCacheConfig:
+    return AuthorizationCacheConfig(
+        principal_key=lambda ctx: (ctx.get("user") or {}).get("id"),
+        ttl_seconds=60.0,
+    )
+
+
+def _build_app(*, authorizer: Any, cache: bool = True, rust: bool = False) -> FastAPI:
+    config = FraiseQLConfig(
+        database_url="postgresql://test:test@localhost/test",
+        environment="development",
+        enable_rust_endpoint=rust,
+    )
+    return create_fraiseql_app(
+        config=config,
+        types=[Widget],
+        queries=[widgets],
+        lifespan=_noop_lifespan,
+        context_getter=_ctx_with_user,
+        authorizer=authorizer,
+        authorization_cache=_cache_config() if cache else None,
+    )
+
+
+def _is_forbidden(body: dict[str, Any]) -> bool:
+    return any(
+        (e.get("extensions") or {}).get("code") == "FORBIDDEN" for e in (body.get("errors") or [])
+    )
+
+
+# --- Cycle 1: resolver path memoizes the decision -------------------------------------
+
+
+def test_resolver_path_caches_identical_query_decisions() -> None:
+    auth = CountingAuthorizer()
+    app = _build_app(authorizer=auth)
+    with TestClient(app) as client:
+        for _ in range(2):
+            body = client.post("/graphql", json={"query": "{ widgets { id name } }"}).json()
+            assert not body.get("errors")
+    assert auth.calls == 1, "second identical query should be served from the decision cache"
+    # The resolver runs on every request; only the *decision* is cached.
+    assert _executions == ["widgets", "widgets"]
+
+
+def test_deny_decision_cached_blocks_second_identical_query() -> None:
+    auth = CountingAuthorizer(result=False)
+    app = _build_app(authorizer=auth)
+    with TestClient(app) as client:
+        for _ in range(2):
+            body = client.post("/graphql", json={"query": "{ widgets { id } }"}).json()
+            assert _is_forbidden(body)
+    assert auth.calls == 1, "a clean deny is cached and re-enforced without re-invoking"
+    assert _executions == [], "resolver never runs on deny"
+
+
+def test_no_cache_invokes_authorizer_every_request() -> None:
+    auth = CountingAuthorizer()
+    app = _build_app(authorizer=auth, cache=False)
+    with TestClient(app) as client:
+        for _ in range(2):
+            client.post("/graphql", json={"query": "{ widgets { id } }"})
+    assert auth.calls == 2, "with no cache configured, behavior is exactly today's"
+
+
+# --- Cycle 2: bypass path honors the same cache ---------------------------------------
+
+
+def test_rust_bypass_path_honors_cache() -> None:
+    auth = CountingAuthorizer()
+    app = _build_app(authorizer=auth, rust=True)
+
+    calls: list[Any] = []
+
+    async def _spy(*_a: Any, **_k: Any) -> bytes:
+        calls.append(1)
+        return b'{"data": {"widgets": []}}'
+
+    with mock.patch("fraiseql._fraiseql_rs.execute_graphql_query", new=_spy), TestClient(app) as c:
+        for _ in range(2):
+            c.post("/graphql/rust", json={"query": "{ widgets { id } }"})
+    assert auth.calls == 1, "the /graphql/rust gate honors the same decision cache"
+    assert len(calls) == 2, "Rust still runs each call; only the decision is cached"
+
+
+# --- Cycle 3: caching never weakens fail-closed ---------------------------------------
+
+
+def test_raising_authorizer_never_cached_stays_denied() -> None:
+    auth = RaisingAuthorizer()
+    app = _build_app(authorizer=auth)
+    with TestClient(app) as client:
+        for _ in range(2):
+            body = client.post("/graphql", json={"query": "{ widgets { id } }"}).json()
+            assert _is_forbidden(body)
+    assert auth.calls == 2, "a raising authorizer must not be cached (re-invoked each request)"
+    assert _executions == [], "resolver never runs when the authorizer raises"

--- a/tests/integration/security/test_field_authorization_auto.py
+++ b/tests/integration/security/test_field_authorization_auto.py
@@ -16,7 +16,7 @@ from graphql import graphql
 import fraiseql
 from fraiseql.gql.builders import SchemaRegistry
 from fraiseql.gql.schema_builder import build_fraiseql_schema
-from fraiseql.security import authorize_field
+from fraiseql.security import authorize_field, field_authorizer_adapter
 
 pytestmark = pytest.mark.integration
 
@@ -141,3 +141,31 @@ async def test_auto_gate_and_explicit_authorize_field_are_anded() -> None:
     assert not allowed.errors
     assert allowed.data["account"]["both"] == "guarded"
     assert "both" in _executions
+
+
+# The hand-applied pattern documented in docs/security/authorization.md must keep working.
+
+
+@fraiseql.type
+class Doc:
+    id: int
+
+    @fraiseql.field
+    @authorize_field(field_authorizer_adapter(AllowAll(), field="Doc.email"))
+    async def email(self, info) -> str | None:
+        _executions.append("doc_email")
+        return "secret@example.com"
+
+
+@fraiseql.query
+async def doc(info) -> Doc:
+    return Doc(id=1)
+
+
+async def test_documented_field_authorizer_adapter_pattern() -> None:
+    """The documented hand-applied adapter pattern on an async ``(self, info)`` field method."""
+    schema = build_fraiseql_schema(query_types=[Doc, doc], authorizer=None)
+    result = await graphql(schema, "{ doc { email } }", context_value={})
+    assert not result.errors
+    assert result.data["doc"]["email"] == "secret@example.com"
+    assert "doc_email" in _executions

--- a/tests/integration/security/test_field_authorization_auto.py
+++ b/tests/integration/security/test_field_authorization_auto.py
@@ -162,6 +162,24 @@ async def doc(info) -> Doc:
     return Doc(id=1)
 
 
+# The natural sync self-only form the docs now show: @field outer / @authorize_field inner on
+# a plain ``def email(self)`` gated by the (async) adapter. Kept in lockstep with the docs.
+@fraiseql.type
+class DocSync:
+    id: int
+
+    @fraiseql.field
+    @authorize_field(field_authorizer_adapter(AllowAll(), field="DocSync.email"))
+    def email(self) -> str | None:
+        _executions.append("docsync_email")
+        return "secret@example.com"
+
+
+@fraiseql.query
+async def doc_sync(info) -> DocSync:
+    return DocSync(id=1)
+
+
 async def test_documented_field_authorizer_adapter_pattern() -> None:
     """The documented hand-applied adapter pattern on an async ``(self, info)`` field method."""
     schema = build_fraiseql_schema(query_types=[Doc, doc], authorizer=None)
@@ -169,3 +187,16 @@ async def test_documented_field_authorizer_adapter_pattern() -> None:
     assert not result.errors
     assert result.data["doc"]["email"] == "secret@example.com"
     assert "doc_email" in _executions
+
+
+async def test_documented_field_authorizer_adapter_pattern_sync_self_only() -> None:
+    """The natural ``def email(self)`` form (sync, self-only) the docs example shows.
+
+    A sync resolver gated by the async adapter must resolve without warnings and without
+    needing ``info`` on the method signature.
+    """
+    schema = build_fraiseql_schema(query_types=[DocSync, doc_sync], authorizer=None)
+    result = await graphql(schema, "{ docSync { email } }", context_value={})
+    assert not result.errors
+    assert result.data["docSync"]["email"] == "secret@example.com"
+    assert "docsync_email" in _executions

--- a/tests/integration/security/test_field_authorization_auto.py
+++ b/tests/integration/security/test_field_authorization_auto.py
@@ -1,0 +1,143 @@
+"""Automatic field-level authorization opt-in (issue #366).
+
+A type declares which fields to gate via ``@fraise_type(authorize_fields=[...])``; each
+listed field is checked with ``operation_type="field"`` and
+``operation_name="TypeName.fieldName"`` before its resolver runs, reusing the field-auth
+enforcement path. Undeclared fields and apps with no authorizer are unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from graphql import graphql
+
+import fraiseql
+from fraiseql.gql.builders import SchemaRegistry
+from fraiseql.gql.schema_builder import build_fraiseql_schema
+from fraiseql.security import authorize_field
+
+pytestmark = pytest.mark.integration
+
+_executions: list[str] = []
+
+
+@fraiseql.type(authorize_fields=["secret", "both"])
+class Account:
+    id: int
+    name: str
+
+    @fraiseql.field
+    def secret(self) -> str | None:
+        _executions.append("secret")
+        return "classified"
+
+    @fraiseql.field
+    def public(self) -> str | None:
+        _executions.append("public")
+        return "ok"
+
+    @fraiseql.field
+    @authorize_field(lambda info: info.context.get("explicit_ok", False))
+    def both(self, info) -> str | None:
+        _executions.append("both")
+        return "guarded"
+
+
+@fraiseql.query
+async def account(info) -> Account:
+    return Account(id=1, name="acme")
+
+
+class DenyFields:
+    """Allows operations; denies every field check."""
+
+    async def authorize_operation(self, *, operation_type: str, **_: Any) -> bool:
+        return operation_type != "field"
+
+
+class AllowAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+class Boom:
+    async def authorize_operation(self, *, operation_type: str, **_: Any) -> bool:
+        if operation_type == "field":
+            raise RuntimeError("field PDP down")
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    _executions.clear()
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    _executions.clear()
+
+
+def _build(*, authorizer: Any) -> Any:
+    return build_fraiseql_schema(query_types=[Account, account], authorizer=authorizer)
+
+
+def _codes(result: Any) -> set[str]:
+    return {(e.extensions or {}).get("code") for e in (result.errors or [])}
+
+
+async def test_declared_field_denied_body_not_run() -> None:
+    schema = _build(authorizer=DenyFields())
+    result = await graphql(schema, "{ account { secret } }")
+    assert "FIELD_AUTHORIZATION_ERROR" in _codes(result)
+    assert "secret" not in _executions, "gated field body ran despite a deny"
+
+
+async def test_undeclared_field_unaffected() -> None:
+    schema = _build(authorizer=DenyFields())
+    result = await graphql(schema, "{ account { name public } }")
+    assert not result.errors
+    assert result.data["account"] == {"name": "acme", "public": "ok"}
+    assert _executions == ["public"], "the undeclared field is never gated"
+
+
+async def test_declared_field_allowed_runs() -> None:
+    schema = _build(authorizer=AllowAll())
+    result = await graphql(schema, "{ account { secret } }")
+    assert not result.errors
+    assert result.data["account"]["secret"] == "classified"
+    assert "secret" in _executions
+
+
+async def test_no_authorizer_unchanged() -> None:
+    schema = _build(authorizer=None)
+    result = await graphql(schema, "{ account { secret } }")
+    assert not result.errors
+    assert result.data["account"]["secret"] == "classified"
+    assert "secret" in _executions
+
+
+async def test_raising_field_authorizer_fail_closed() -> None:
+    schema = _build(authorizer=Boom())
+    result = await graphql(schema, "{ account { secret } }")
+    assert "FIELD_AUTHORIZATION_ERROR" in _codes(result)
+    assert "secret" not in _executions
+
+
+async def test_auto_gate_and_explicit_authorize_field_are_anded() -> None:
+    """Both checks run (AND): an allow-all authorizer cannot override an explicit deny."""
+    schema = _build(authorizer=AllowAll())
+    # explicit @authorize_field denies (explicit_ok defaults False) even though auto allows.
+    denied = await graphql(schema, "{ account { both } }", context_value={})
+    assert "FIELD_AUTHORIZATION_ERROR" in _codes(denied)
+    assert "both" not in _executions
+    # both gates pass → the field runs.
+    allowed = await graphql(schema, "{ account { both } }", context_value={"explicit_ok": True})
+    assert not allowed.errors
+    assert allowed.data["account"]["both"] == "guarded"
+    assert "both" in _executions

--- a/tests/integration/security/test_filter_injection_db.py
+++ b/tests/integration/security/test_filter_injection_db.py
@@ -1,0 +1,94 @@
+"""Authorization filter injection against a real PostgreSQL view (issue #362, phase 5)."""
+
+import pytest
+import pytest_asyncio
+
+pytestmark = pytest.mark.database
+
+from tests.fixtures.database.database_conftest import *  # noqa: F403
+from tests.unit.utils.test_response_utils import extract_graphql_data
+
+import fraiseql
+from fraiseql.db import FraiseQLRepository, register_type_for_view
+from fraiseql.sql.where_generator import safe_create_where_type
+
+
+class TestFilterInjectionAgainstView:
+    """Row scoping: authorization filters in repo context reach SQL and scope rows."""
+
+    @pytest.fixture(scope="class")
+    def test_types(self, clear_registry_class):
+        @fraiseql.type
+        class Widget:
+            id: str
+            name: str
+
+        return {"Widget": Widget, "WidgetWhere": safe_create_where_type(Widget)}
+
+    @pytest_asyncio.fixture(scope="class", loop_scope="class")
+    async def setup_view(self, class_db_pool, test_schema, test_types) -> None:
+        Widget = test_types["Widget"]
+        register_type_for_view("test_widget_view", Widget)
+
+        async with class_db_pool.connection() as conn:
+            await conn.execute(f"SET search_path TO {test_schema}, public")
+            await conn.execute(
+                """
+                CREATE TABLE test_widgets (
+                    id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    name TEXT NOT NULL
+                )
+                """
+            )
+            await conn.execute(
+                """
+                CREATE VIEW test_widget_view AS
+                SELECT
+                    id, tenant_id, name,
+                    jsonb_build_object('id', id, 'name', name) AS data
+                FROM test_widgets
+                """
+            )
+            await conn.execute(
+                """
+                INSERT INTO test_widgets (id, tenant_id, name) VALUES
+                    ('w1', 'A', 'Alpha'),
+                    ('w2', 'A', 'Beta'),
+                    ('w3', 'B', 'Gamma')
+                """
+            )
+            await conn.commit()
+        yield
+
+    def _repo(self, pool, *, auth_filters=None):
+        context = {"mode": "development", "graphql_field_name": "widgets"}
+        if auth_filters is not None:
+            context["_fraiseql_auth_filters"] = {"widgets": auth_filters}
+        return FraiseQLRepository(pool, context=context)
+
+    @pytest.mark.asyncio
+    async def test_no_scope_returns_all_rows(self, class_db_pool, setup_view) -> None:
+        repo = self._repo(class_db_pool)
+        result = await repo.find("test_widget_view")
+        rows = extract_graphql_data(result, "test_widget_view")
+        assert {r["name"] for r in rows} == {"Alpha", "Beta", "Gamma"}
+
+    @pytest.mark.asyncio
+    async def test_auth_filter_scopes_rows(self, class_db_pool, setup_view) -> None:
+        repo = self._repo(class_db_pool, auth_filters={"tenant_id": "A"})
+        result = await repo.find("test_widget_view")
+        rows = extract_graphql_data(result, "test_widget_view")
+        assert {r["name"] for r in rows} == {"Alpha", "Beta"}
+
+    @pytest.mark.asyncio
+    async def test_user_where_is_anded_with_auth_scope(
+        self, class_db_pool, setup_view, test_types
+    ) -> None:
+        WidgetWhere = test_types["WidgetWhere"]
+        repo = self._repo(class_db_pool, auth_filters={"tenant_id": "A"})
+        # User asks for name = "Gamma" (tenant B); the AND-ed scope must exclude it.
+        where = WidgetWhere(name={"eq": "Gamma"})
+        result = await repo.find("test_widget_view", where=where)
+        rows = extract_graphql_data(result, "test_widget_view")
+        assert rows == []

--- a/tests/unit/core/test_resolver_invocation.py
+++ b/tests/unit/core/test_resolver_invocation.py
@@ -1,0 +1,171 @@
+"""Unit tests for the shared resolver-invocation convention.
+
+Each target shape must be called with exactly the arguments its real signature declares,
+inspecting the target *itself* — never an inner original function. This is the contract both
+``@field`` and ``@authorize_field`` rely on to compose in either decorator order.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fraiseql.core.resolver_invocation import (
+    invoke_resolver,
+    resolver_call_spec,
+)
+
+_ROOT = object()
+_INFO = object()
+
+
+def test_field_wrapper_is_called_root_info() -> None:
+    """A ``__fraiseql_field__`` target self-adapts: always called ``(root, info, ...)``."""
+    seen: dict[str, Any] = {}
+
+    def wrapper(root: Any, info: Any, *args: Any, **kwargs: Any) -> str:
+        seen["args"] = (root, info, args, kwargs)
+        return "ok"
+
+    wrapper.__fraiseql_field__ = True  # type: ignore[attr-defined]
+
+    assert invoke_resolver(wrapper, _ROOT, _INFO, extra=1) == "ok"
+    assert seen["args"] == (_ROOT, _INFO, (), {"extra": 1})
+    assert resolver_call_spec(wrapper).is_field_wrapper is True
+
+
+def test_field_wrapper_priority_over_signature() -> None:
+    """The field-wrapper rule short-circuits signature inspection entirely.
+
+    A real ``@field`` wrapper always accepts ``(root, info, *args, **kwargs)``, so the
+    passthrough is correct. The point here is that ``__fraiseql_field__`` is honoured *before*
+    the parameter inspection that would otherwise classify the target as ``self``-only.
+    """
+
+    def self_only_looking(self) -> str:  # noqa: N805 - deliberately self-only shape
+        return "ok"
+
+    self_only_looking.__fraiseql_field__ = True  # type: ignore[attr-defined]
+
+    spec = resolver_call_spec(self_only_looking)
+    assert spec.is_field_wrapper is True
+    assert spec.has_self is False  # never inspected — the field-wrapper rule wins first
+
+
+def test_bound_method_with_info() -> None:
+    class Obj:
+        def m(self, info: Any) -> Any:
+            return ("bound+info", info)
+
+    bound = Obj().m
+    assert invoke_resolver(bound, _ROOT, _INFO) == ("bound+info", _INFO)
+    spec = resolver_call_spec(bound)
+    assert spec.is_bound is True
+    assert spec.expects_info is True
+
+
+def test_bound_method_without_info() -> None:
+    class Obj:
+        def m(self) -> str:
+            return "bound-noinfo"
+
+    bound = Obj().m
+    assert invoke_resolver(bound, _ROOT, _INFO) == "bound-noinfo"
+    spec = resolver_call_spec(bound)
+    assert spec.is_bound is True
+    assert spec.expects_info is False
+
+
+def test_unbound_self_and_info() -> None:
+    seen: dict[str, Any] = {}
+
+    def m(self, info: Any) -> str:  # noqa: N805 - unbound method shape
+        seen["args"] = (self, info)
+        return "self+info"
+
+    assert invoke_resolver(m, _ROOT, _INFO) == "self+info"
+    assert seen["args"] == (_ROOT, _INFO)
+    spec = resolver_call_spec(m)
+    assert spec.has_self is True
+    assert spec.expects_info is True
+
+
+def test_unbound_self_only() -> None:
+    seen: dict[str, Any] = {}
+
+    def m(self) -> str:  # noqa: N805 - unbound method shape, no info declared
+        seen["args"] = (self,)
+        return "self-only"
+
+    assert invoke_resolver(m, _ROOT, _INFO) == "self-only"
+    assert seen["args"] == (_ROOT,)  # info is NOT passed to a self-only method
+    spec = resolver_call_spec(m)
+    assert spec.has_self is True
+    assert spec.expects_info is False
+
+
+def test_regular_root_style_function() -> None:
+    seen: dict[str, Any] = {}
+
+    def r(root: Any, info: Any) -> str:
+        seen["args"] = (root, info)
+        return "root-style"
+
+    assert invoke_resolver(r, _ROOT, _INFO) == "root-style"
+    assert seen["args"] == (_ROOT, _INFO)
+    spec = resolver_call_spec(r)
+    assert spec.has_self is False
+    assert spec.expects_info is True
+
+
+def test_kwargs_are_threaded_through() -> None:
+    def m(self, info: Any, *, limit: int = 0) -> int:  # noqa: N805
+        return limit
+
+    assert invoke_resolver(m, _ROOT, _INFO, limit=7) == 7
+
+
+def test_async_target_returns_awaitable() -> None:
+    async def m(self, info: Any) -> str:  # noqa: N805
+        return "async"
+
+    result = invoke_resolver(m, _ROOT, _INFO)
+    import inspect as _inspect
+
+    assert _inspect.isawaitable(result)
+    result.close()  # avoid an un-awaited coroutine warning
+
+
+def test_inspects_target_not_original_func() -> None:
+    """A faithful wrapper carrying ``__fraiseql_original_func__`` is still inspected itself.
+
+    Falling back to the original ``(self)``-only arity would call the wrapper as
+    ``wrapper(root)`` and drop ``info`` — the exact bug. The wrapper has no
+    ``__fraiseql_field__``, so it is inspected by its own ``(root, info, ...)`` signature.
+    """
+    seen: dict[str, Any] = {}
+
+    def original(self) -> str:  # noqa: N805 - the inner, self-only method
+        return "original"
+
+    def faithful_wrapper(root: Any, info: Any, *args: Any, **kwargs: Any) -> str:
+        seen["args"] = (root, info)
+        return "wrapped"
+
+    faithful_wrapper.__fraiseql_original_func__ = original  # type: ignore[attr-defined]
+
+    assert invoke_resolver(faithful_wrapper, _ROOT, _INFO) == "wrapped"
+    assert seen["args"] == (_ROOT, _INFO), "must use the wrapper's own signature, not original's"
+
+
+@pytest.mark.parametrize("missing", [True, False])
+def test_spec_memoization_is_consistent(missing: bool) -> None:
+    """Repeated lookups return an equal spec (memoized, but value-stable)."""
+
+    def r(root: Any, info: Any) -> None:
+        return None
+
+    first = resolver_call_spec(r)
+    second = resolver_call_spec(r)
+    assert first == second

--- a/tests/unit/db/test_mandatory_filters_context.py
+++ b/tests/unit/db/test_mandatory_filters_context.py
@@ -1,0 +1,91 @@
+"""Repository merge of authorization filters from context (issue #362, phase 5)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from graphql import GraphQLError
+
+from fraiseql.db import FraiseQLRepository, _make_mandatory_conditions
+
+
+def _repo(context: dict[str, Any]) -> FraiseQLRepository:
+    # _consume_mandatory_filters never touches the pool, so None is fine here.
+    return FraiseQLRepository(pool=None, context=context)  # type: ignore[arg-type]
+
+
+def test_auth_filter_from_context_without_explicit() -> None:
+    repo = _repo(
+        {
+            "_fraiseql_auth_filters": {"users": {"tenant_id": "t1"}},
+            "graphql_field_name": "users",
+        }
+    )
+    merged = repo._consume_mandatory_filters({})
+    assert merged == {"tenant_id": "t1"}
+
+    parts, params = _make_mandatory_conditions(merged)
+    assert params == ["t1"]
+    assert "tenant_id" in str(parts[0])
+
+
+def test_merge_explicit_and_auth_filters() -> None:
+    repo = _repo(
+        {
+            "_fraiseql_auth_filters": {"users": {"tenant_id": "t1"}},
+            "graphql_field_name": "users",
+        }
+    )
+    merged = repo._consume_mandatory_filters({"mandatory_filters": {"status": "active"}})
+    assert merged == {"status": "active", "tenant_id": "t1"}
+
+
+def test_consume_pops_kwarg() -> None:
+    repo = _repo({})
+    kwargs = {"mandatory_filters": {"a": 1}, "other": 2}
+    repo._consume_mandatory_filters(kwargs)
+    assert "mandatory_filters" not in kwargs
+    assert kwargs == {"other": 2}
+
+
+def test_no_filters_returns_none() -> None:
+    repo = _repo({})
+    assert repo._consume_mandatory_filters({}) is None
+
+
+def test_overlapping_columns_rejected() -> None:
+    repo = _repo(
+        {
+            "_fraiseql_auth_filters": {"users": {"tenant_id": "t1"}},
+            "graphql_field_name": "users",
+        }
+    )
+    with pytest.raises(GraphQLError):
+        repo._consume_mandatory_filters({"mandatory_filters": {"tenant_id": "t2"}})
+
+
+def test_field_name_keying_isolates_scopes() -> None:
+    # Field A is scoped to tenant t1; field B is unscoped. Each reads its own bucket.
+    repo = _repo(
+        {
+            "_fraiseql_auth_filters": {"a": {"tenant_id": "t1"}},
+            "graphql_field_name": "a",
+        }
+    )
+    assert repo._consume_mandatory_filters({}) == {"tenant_id": "t1"}
+
+    repo.context["graphql_field_name"] = "b"
+    assert repo._consume_mandatory_filters({}) is None
+
+
+def test_unsafe_column_rejected_by_validator() -> None:
+    repo = _repo(
+        {
+            "_fraiseql_auth_filters": {"users": {"tenant_id; DROP TABLE": 1}},
+            "graphql_field_name": "users",
+        }
+    )
+    merged = repo._consume_mandatory_filters({})
+    with pytest.raises(ValueError):
+        _make_mandatory_conditions(merged)

--- a/tests/unit/fastapi/test_turbo_authorization.py
+++ b/tests/unit/fastapi/test_turbo_authorization.py
@@ -1,0 +1,126 @@
+"""TurboRouter bypass-path authorization gate (issue #362, phase 4 part A)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from graphql import GraphQLError
+
+from fraiseql.fastapi.turbo import TurboQuery, TurboRegistry, TurboRouter
+from fraiseql.fastapi.turbo_enhanced import EnhancedTurboRegistry, EnhancedTurboRouter
+
+_QUERY = "query { widgets { id } }"
+
+
+class _SpyDB:
+    """Repository stand-in that records transaction execution."""
+
+    def __init__(self) -> None:
+        self.context: dict[str, Any] = {}
+        self.tx_calls = 0
+
+    async def run_in_transaction(self, fn: Any) -> list[dict[str, Any]]:
+        self.tx_calls += 1
+        return [{"result": [{"id": 1}]}]
+
+    async def _set_session_variables(self, cursor: Any) -> None:
+        return None
+
+
+class DenyAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return False
+
+
+class AllowAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+class Boom:
+    async def authorize_operation(self, **_: Any) -> bool:
+        raise RuntimeError("kaboom")
+
+
+def _registry() -> TurboRegistry:
+    registry = TurboRegistry()
+    registry.register(
+        TurboQuery(graphql_query=_QUERY, sql_template="SELECT 1 AS result", param_mapping={})
+    )
+    return registry
+
+
+def _enhanced_registry() -> EnhancedTurboRegistry:
+    registry = EnhancedTurboRegistry()
+    registry.register(
+        TurboQuery(graphql_query=_QUERY, sql_template="SELECT 1 AS result", param_mapping={})
+    )
+    return registry
+
+
+async def test_deny_all_blocks_turbo_no_db_hit() -> None:
+    spy = _SpyDB()
+    router = TurboRouter(_registry(), default_authorizer=DenyAll())
+    with pytest.raises(GraphQLError) as exc:
+        await router.execute(_QUERY, {}, {"db": spy})
+    assert exc.value.extensions["code"] == "FORBIDDEN"
+    assert spy.tx_calls == 0
+
+
+async def test_allow_all_executes_turbo() -> None:
+    spy = _SpyDB()
+    router = TurboRouter(_registry(), default_authorizer=AllowAll())
+    await router.execute(_QUERY, {}, {"db": spy})
+    assert spy.tx_calls == 1
+
+
+async def test_no_authorizer_keeps_today_behavior() -> None:
+    spy = _SpyDB()
+    router = TurboRouter(_registry())
+    await router.execute(_QUERY, {}, {"db": spy})
+    assert spy.tx_calls == 1
+
+
+async def test_authorizer_raising_fails_closed() -> None:
+    spy = _SpyDB()
+    router = TurboRouter(_registry(), default_authorizer=Boom())
+    with pytest.raises(GraphQLError) as exc:
+        await router.execute(_QUERY, {}, {"db": spy})
+    assert exc.value.extensions["code"] == "FORBIDDEN"
+    assert spy.tx_calls == 0
+
+
+async def test_unregistered_query_falls_through() -> None:
+    spy = _SpyDB()
+    router = TurboRouter(_registry(), default_authorizer=DenyAll())
+    # Not a turbo query -> returns None (falls through to the resolver-gated path),
+    # the gate must not fire here.
+    result = await router.execute("{ other { id } }", {}, {"db": spy})
+    assert result is None
+    assert spy.tx_calls == 0
+
+
+async def test_enhanced_turbo_inherits_gate() -> None:
+    spy = _SpyDB()
+    router = EnhancedTurboRouter(_enhanced_registry(), default_authorizer=DenyAll())
+    with pytest.raises(GraphQLError) as exc:
+        await router.execute(_QUERY, {}, {"db": spy})
+    assert exc.value.extensions["code"] == "FORBIDDEN"
+    assert spy.tx_calls == 0
+
+
+async def test_filters_on_turbo_warn_and_do_not_scope(caplog) -> None:
+    class AllowWithFilters:
+        async def authorize_operation(self, **_: Any) -> Any:
+            from fraiseql.security.authorization import AuthorizationDecision
+
+            return AuthorizationDecision.allow(filters={"tenant_id": "t1"})
+
+    spy = _SpyDB()
+    router = TurboRouter(_registry(), default_authorizer=AllowWithFilters())
+    with caplog.at_level(logging.WARNING):
+        await router.execute(_QUERY, {}, {"db": spy})
+    assert spy.tx_calls == 1
+    assert any("filter" in record.message.lower() for record in caplog.records)

--- a/tests/unit/gql/test_filter_injection.py
+++ b/tests/unit/gql/test_filter_injection.py
@@ -1,0 +1,133 @@
+"""Resolver writes authorization filters into the repository context (issue #362, phase 5)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from graphql import graphql
+
+import fraiseql
+from fraiseql.gql.builders import SchemaRegistry
+from fraiseql.gql.schema_builder import build_fraiseql_schema
+from fraiseql.security.authorization import AuthorizationDecision
+
+_received: dict[str, Any] = {}
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.context: dict[str, Any] = {}
+
+
+@fraiseql.type
+class Widget:
+    id: int
+    name: str
+
+
+@fraiseql.query
+async def things(info, **kwargs) -> list[Widget]:
+    _received.clear()
+    _received.update(kwargs)
+    return []
+
+
+@fraiseql.query
+async def alpha(info) -> list[Widget]:
+    return []
+
+
+@fraiseql.query
+async def beta(info) -> list[Widget]:
+    return []
+
+
+class PerFieldAuthorizer:
+    """Scopes ``alpha`` to a tenant; leaves ``beta`` unscoped."""
+
+    async def authorize_operation(self, *, operation_name: str, **_: Any) -> AuthorizationDecision:
+        if operation_name == "alpha":
+            return AuthorizationDecision.allow(filters={"tenant_id": "tA"})
+        return AuthorizationDecision.allow()
+
+
+@fraiseql.mutation
+async def do_thing(info, name: str) -> Widget:
+    _received.clear()
+    return Widget(id=1, name=name)
+
+
+class AllowWithFilters:
+    async def authorize_operation(self, **_: Any) -> AuthorizationDecision:
+        return AuthorizationDecision.allow(filters={"tenant_id": "t1"})
+
+
+class AllowNoFilters:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    _received.clear()
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    _received.clear()
+
+
+async def test_query_filters_written_to_repo_context() -> None:
+    schema = build_fraiseql_schema(query_types=[Widget, things], authorizer=AllowWithFilters())
+    db = _FakeDB()
+    result = await graphql(schema, "{ things { id } }", context_value={"db": db})
+    assert not result.errors
+    assert db.context["_fraiseql_auth_filters"]["things"] == {"tenant_id": "t1"}
+    # The user function never receives a mandatory_filters kwarg — filters ride context.
+    assert "mandatory_filters" not in _received
+
+
+async def test_query_allow_no_filters_writes_nothing() -> None:
+    schema = build_fraiseql_schema(query_types=[Widget, things], authorizer=AllowNoFilters())
+    db = _FakeDB()
+    result = await graphql(schema, "{ things { id } }", context_value={"db": db})
+    assert not result.errors
+    assert "_fraiseql_auth_filters" not in db.context
+
+
+async def test_multi_root_scopes_do_not_leak() -> None:
+    # Two root fields in one request: alpha is scoped, beta is not. Each field's scope
+    # is keyed by its own field name, so beta never inherits alpha's tenant filter.
+    schema = build_fraiseql_schema(
+        query_types=[Widget, alpha, beta], authorizer=PerFieldAuthorizer()
+    )
+    db = _FakeDB()
+    result = await graphql(schema, "{ alpha { id } beta { id } }", context_value={"db": db})
+    assert not result.errors
+    buckets = db.context.get("_fraiseql_auth_filters", {})
+    assert buckets.get("alpha") == {"tenant_id": "tA"}
+    assert "beta" not in buckets
+
+
+async def test_mutation_filters_ignored_and_warned(caplog) -> None:
+    schema = build_fraiseql_schema(
+        query_types=[Widget, things],
+        mutation_resolvers=[do_thing],
+        authorizer=AllowWithFilters(),
+    )
+    db = _FakeDB()
+    with caplog.at_level(logging.WARNING):
+        result = await graphql(
+            schema, 'mutation { doThing(name: "x") { id name } }', context_value={"db": db}
+        )
+    assert not result.errors
+    assert result.data["doThing"] == {"id": 1, "name": "x"}
+    # Mutations have no row-scoping semantics: filters are ignored, not written.
+    assert "_fraiseql_auth_filters" not in db.context
+    assert any("filter" in record.message.lower() for record in caplog.records)

--- a/tests/unit/gql/test_mutation_authorization.py
+++ b/tests/unit/gql/test_mutation_authorization.py
@@ -1,0 +1,113 @@
+"""Mutation-resolver operation enforcement (issue #362, phase 2)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from graphql import graphql
+
+import fraiseql
+from fraiseql.gql.builders import SchemaRegistry
+from fraiseql.gql.schema_builder import build_fraiseql_schema
+
+_ran: list[str] = []
+
+
+@fraiseql.type
+class Widget:
+    id: int
+    name: str
+
+
+async def _widgets(info) -> list[Widget]:
+    return []
+
+
+@fraiseql.mutation
+async def make_widget(info, name: str) -> Widget:
+    _ran.append(name)
+    return Widget(id=1, name=name)
+
+
+def make_widget_sync(info, name: str) -> Widget:
+    _ran.append(name)
+    return Widget(id=1, name=name)
+
+
+class DenyAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return False
+
+
+class AllowAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    _ran.clear()
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    _ran.clear()
+
+
+def _build(*, authorizer, sync: bool = False):
+    mutation = make_widget_sync if sync else make_widget
+    return build_fraiseql_schema(
+        query_types=[Widget, _widgets],
+        mutation_resolvers=[mutation],
+        authorizer=authorizer,
+    )
+
+
+_MUTATION = 'mutation { makeWidget(name: "x") { id name } }'
+_MUTATION_SYNC = 'mutation { makeWidgetSync(name: "x") { id name } }'
+
+
+async def test_deny_all_blocks_async_mutation() -> None:
+    schema = _build(authorizer=DenyAll())
+    result = await graphql(schema, _MUTATION)
+    assert result.errors
+    assert len(result.errors) == 1
+    assert result.errors[0].extensions["code"] == "FORBIDDEN"
+    assert _ran == [], "mutation body ran despite deny"
+
+
+async def test_deny_all_blocks_sync_mutation() -> None:
+    schema = _build(authorizer=DenyAll(), sync=True)
+    result = await graphql(schema, _MUTATION_SYNC)
+    assert result.errors
+    assert result.errors[0].extensions["code"] == "FORBIDDEN"
+    assert _ran == [], "sync mutation body ran despite deny"
+
+
+async def test_allow_all_runs_async_mutation() -> None:
+    schema = _build(authorizer=AllowAll())
+    result = await graphql(schema, _MUTATION)
+    assert not result.errors
+    assert result.data["makeWidget"] == {"id": 1, "name": "x"}
+    assert _ran == ["x"]
+
+
+async def test_allow_all_runs_sync_mutation() -> None:
+    schema = _build(authorizer=AllowAll(), sync=True)
+    result = await graphql(schema, _MUTATION_SYNC)
+    assert not result.errors
+    assert result.data["makeWidgetSync"] == {"id": 1, "name": "x"}
+    assert _ran == ["x"]
+
+
+async def test_no_authorizer_matches_baseline() -> None:
+    schema = _build(authorizer=None)
+    result = await graphql(schema, _MUTATION)
+    assert not result.errors
+    assert result.data["makeWidget"] == {"id": 1, "name": "x"}
+    assert _ran == ["x"]

--- a/tests/unit/gql/test_query_authorization.py
+++ b/tests/unit/gql/test_query_authorization.py
@@ -76,6 +76,24 @@ async def test_deny_all_blocks_sync_query() -> None:
     assert _ran == []
 
 
+async def test_alias_does_not_bypass_enforcement() -> None:
+    # graphql-core resolves the canonical field (info.field_name), so a field alias
+    # cannot slip past the gate.
+    schema = _build(authorizer=DenyAll())
+    result = await graphql(schema, "{ renamed: widgets { id } }")
+    assert result.errors
+    assert result.errors[0].extensions["code"] == "FORBIDDEN"
+    assert _ran == []
+
+
+async def test_named_operation_does_not_bypass_enforcement() -> None:
+    schema = _build(authorizer=DenyAll())
+    result = await graphql(schema, "query Q { widgets { id } }", operation_name="Q")
+    assert result.errors
+    assert result.errors[0].extensions["code"] == "FORBIDDEN"
+    assert _ran == []
+
+
 async def test_allow_all_runs_query() -> None:
     schema = _build(authorizer=AllowAll())
     result = await graphql(schema, "{ widgets { id name } }")

--- a/tests/unit/gql/test_query_authorization.py
+++ b/tests/unit/gql/test_query_authorization.py
@@ -1,0 +1,102 @@
+"""Query-resolver operation enforcement (issue #362, phase 3)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from graphql import graphql
+
+import fraiseql
+from fraiseql.gql.builders import SchemaRegistry
+from fraiseql.gql.schema_builder import build_fraiseql_schema
+
+_ran: list[str] = []
+
+
+@fraiseql.type
+class Widget:
+    id: int
+    name: str
+
+
+async def widgets(info) -> list[Widget]:
+    _ran.append("async")
+    return [Widget(id=1, name="a")]
+
+
+def widgets_sync(info) -> list[Widget]:
+    _ran.append("sync")
+    return [Widget(id=1, name="a")]
+
+
+class DenyAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return False
+
+
+class AllowAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    _ran.clear()
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    _ran.clear()
+
+
+def _build(*, authorizer, sync: bool = False):
+    query = widgets_sync if sync else widgets
+    return build_fraiseql_schema(query_types=[Widget, query], authorizer=authorizer)
+
+
+async def test_deny_all_blocks_async_query() -> None:
+    schema = _build(authorizer=DenyAll())
+    result = await graphql(schema, "{ widgets { id name } }")
+    assert result.errors
+    assert len(result.errors) == 1
+    assert result.errors[0].extensions["code"] == "FORBIDDEN"
+    assert _ran == []
+
+
+async def test_deny_all_blocks_sync_query() -> None:
+    schema = _build(authorizer=DenyAll(), sync=True)
+    result = await graphql(schema, "{ widgetsSync { id name } }")
+    assert result.errors
+    assert result.errors[0].extensions["code"] == "FORBIDDEN"
+    assert _ran == []
+
+
+async def test_allow_all_runs_query() -> None:
+    schema = _build(authorizer=AllowAll())
+    result = await graphql(schema, "{ widgets { id name } }")
+    assert not result.errors
+    assert result.data["widgets"] == [{"id": 1, "name": "a"}]
+    assert _ran == ["async"]
+
+
+async def test_no_authorizer_matches_baseline() -> None:
+    schema = _build(authorizer=None)
+    result = await graphql(schema, "{ widgets { id name } }")
+    assert not result.errors
+    assert result.data["widgets"] == [{"id": 1, "name": "a"}]
+    assert _ran == ["async"]
+
+
+async def test_pagination_validation_still_fires_before_enforcement() -> None:
+    # Validation runs before enforcement: a bad limit errors with the pagination
+    # message (not FORBIDDEN), and the resolver body never runs.
+    schema = _build(authorizer=AllowAll())
+    result = await graphql(schema, "{ widgets(limit: -1) { id } }")
+    assert result.errors
+    assert "limit must be non-negative" in result.errors[0].message
+    assert _ran == []

--- a/tests/unit/gql/test_registry_authorizer.py
+++ b/tests/unit/gql/test_registry_authorizer.py
@@ -1,0 +1,99 @@
+"""Registry authorizer-slot + build-funnel threading tests (issue #362, phase 1)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import fraiseql
+from fraiseql.gql.builders import SchemaRegistry
+
+
+@fraiseql.type
+class _Thing:
+    id: int
+
+
+async def _probe_query(info) -> list[_Thing]:
+    return []
+
+
+def _register_minimal_query() -> None:
+    """Register one type + query so schema builds don't fail on an empty Query."""
+    registry = SchemaRegistry.get_instance()
+    registry.register_type(_Thing)
+    registry.register_query(_probe_query)
+
+
+class _DummyAuthorizer:
+    async def authorize_operation(
+        self,
+        *,
+        context: dict[str, Any],
+        operation_type: str,
+        operation_name: str,
+        arguments: dict[str, Any],
+    ) -> bool:
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    yield
+    registry.clear()
+
+
+def test_default_authorizer_defaults_none() -> None:
+    registry = SchemaRegistry.get_instance()
+    assert registry.default_authorizer is None
+
+
+def test_set_default_authorizer() -> None:
+    registry = SchemaRegistry.get_instance()
+    dummy = _DummyAuthorizer()
+    registry.set_default_authorizer(dummy)
+    assert registry.default_authorizer is dummy
+
+
+def test_clear_resets_default_authorizer() -> None:
+    registry = SchemaRegistry.get_instance()
+    registry.set_default_authorizer(_DummyAuthorizer())
+    registry.clear()
+    assert registry.default_authorizer is None
+
+
+def test_build_fraiseql_schema_threads_authorizer() -> None:
+    from fraiseql.gql.schema_builder import build_fraiseql_schema
+
+    _register_minimal_query()
+    dummy = _DummyAuthorizer()
+    build_fraiseql_schema(authorizer=dummy)
+    assert SchemaRegistry.get_instance().default_authorizer is dummy
+
+
+def test_build_without_authorizer_leaves_none() -> None:
+    from fraiseql.gql.schema_builder import build_fraiseql_schema
+
+    _register_minimal_query()
+    build_fraiseql_schema()
+    assert SchemaRegistry.get_instance().default_authorizer is None
+
+
+def test_legacy_build_threads_authorizer() -> None:
+    from fraiseql.gql.graphql_entrypoint import build_fraiseql_schema as legacy_build
+
+    _register_minimal_query()
+    dummy = _DummyAuthorizer()
+    legacy_build(authorizer=dummy)
+    assert SchemaRegistry.get_instance().default_authorizer is dummy
+
+
+def test_legacy_build_without_authorizer_leaves_none() -> None:
+    from fraiseql.gql.graphql_entrypoint import build_fraiseql_schema as legacy_build
+
+    _register_minimal_query()
+    legacy_build()
+    assert SchemaRegistry.get_instance().default_authorizer is None

--- a/tests/unit/gql/test_subscription_authorization.py
+++ b/tests/unit/gql/test_subscription_authorization.py
@@ -120,3 +120,24 @@ async def test_no_authorizer_streams_unchanged() -> None:
     values = await _drain(stream)
     assert [v.label for v in values] == ["a"]
     assert _yields == ["ticks"]
+
+
+async def test_per_operation_override_beats_global_default() -> None:
+    """`@subscription(authorizer=...)` wins over a global deny-all default (issue #364, phase 2)."""
+
+    @fraiseql.subscription(authorizer=AllowAll())
+    async def overridden(info) -> AsyncGenerator[Tick]:
+        _yields.append("overridden")
+        yield Tick(id=2, label="b")
+
+    schema = build_fraiseql_schema(
+        query_types=[Tick, _ticks],
+        subscription_resolvers=[overridden],
+        authorizer=DenyAll(),
+    )
+    field = next(iter(schema.subscription_type.fields.values()))
+    info = SimpleNamespace(context={}, field_name="overridden")
+    stream = await field.subscribe(None, info)
+    values = await _drain(stream)
+    assert [v.label for v in values] == ["b"]
+    assert _yields == ["overridden"]

--- a/tests/unit/gql/test_subscription_authorization.py
+++ b/tests/unit/gql/test_subscription_authorization.py
@@ -1,0 +1,122 @@
+"""Subscription-resolver operation enforcement (issue #364, phase 1).
+
+Subscriptions are operations, so the PEP gates them once, at subscribe time, before
+the event stream is created. These tests drive the built ``subscribe`` resolver
+directly — the same resolver graphql-core's ``subscribe`` invokes on the websocket
+path (``websocket.py:256``).
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import AsyncGenerator  # noqa: TC003 — runtime hint for get_type_hints
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from graphql import GraphQLError
+
+import fraiseql
+from fraiseql.gql.builders import SchemaRegistry
+from fraiseql.gql.schema_builder import build_fraiseql_schema
+
+_yields: list[str] = []
+
+
+@fraiseql.type
+class Tick:
+    id: int
+    label: str
+
+
+async def _ticks(info) -> list[Tick]:
+    return []
+
+
+@fraiseql.subscription
+async def ticks(info) -> AsyncGenerator[Tick]:
+    _yields.append("ticks")
+    yield Tick(id=1, label="a")
+
+
+class DenyAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return False
+
+
+class AllowAll:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+class Boom:
+    async def authorize_operation(self, **_: Any) -> bool:
+        raise RuntimeError("authorizer exploded")
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    _yields.clear()
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    _yields.clear()
+
+
+def _subscribe_resolver(authorizer: Any):
+    schema = build_fraiseql_schema(
+        query_types=[Tick, _ticks],
+        subscription_resolvers=[ticks],
+        authorizer=authorizer,
+    )
+    field = next(iter(schema.subscription_type.fields.values()))
+    return field.subscribe
+
+
+_INFO = SimpleNamespace(context={}, field_name="ticks")
+
+
+async def _drain(stream: Any) -> list[Any]:
+    return [value async for value in stream]
+
+
+async def test_deny_blocks_subscribe_and_stream() -> None:
+    """A deny decision raises at subscribe time; the generator body never runs."""
+    subscribe = _subscribe_resolver(DenyAll())
+    with pytest.raises(GraphQLError) as exc:
+        await subscribe(None, _INFO)
+    assert exc.value.extensions["code"] == "FORBIDDEN"
+    assert _yields == [], "subscription body ran despite deny"
+
+
+async def test_raising_authorizer_denies_fail_closed() -> None:
+    """A raising authorizer is normalized to a FORBIDDEN deny (shared fail-closed core)."""
+    subscribe = _subscribe_resolver(Boom())
+    with pytest.raises(GraphQLError) as exc:
+        await subscribe(None, _INFO)
+    assert exc.value.extensions["code"] == "FORBIDDEN"
+    assert _yields == []
+
+
+async def test_allow_streams_values() -> None:
+    """An allow decision returns the inner stream and values flow through unchanged."""
+    subscribe = _subscribe_resolver(AllowAll())
+    stream = await subscribe(None, _INFO)
+    assert inspect.isasyncgen(stream)
+    values = await _drain(stream)
+    assert [v.label for v in values] == ["a"]
+    assert _yields == ["ticks"]
+
+
+async def test_no_authorizer_streams_unchanged() -> None:
+    """With no authorizer the stream is byte-for-byte today's behavior (no enforcement)."""
+    subscribe = _subscribe_resolver(None)
+    stream = await subscribe(None, _INFO)
+    values = await _drain(stream)
+    assert [v.label for v in values] == ["a"]
+    assert _yields == ["ticks"]

--- a/tests/unit/security/test_authorization_contract.py
+++ b/tests/unit/security/test_authorization_contract.py
@@ -1,0 +1,78 @@
+"""Contract tests for the operation-authorization primitives (issue #362, phase 1)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fraiseql.security.authorization import (
+    AuthorizationDecision,
+    Authorizer,
+    normalize_decision,
+)
+
+
+def test_decision_allow_deny_constructors() -> None:
+    allow = AuthorizationDecision.allow()
+    assert allow.allowed is True
+    assert allow.code is None
+
+    deny = AuthorizationDecision.deny()
+    assert deny.allowed is False
+    assert deny.code == "FORBIDDEN"
+
+    custom = AuthorizationDecision.deny(code="NOPE", message="go away")
+    assert custom.code == "NOPE"
+    assert custom.message == "go away"
+
+
+def test_allow_carries_filters() -> None:
+    allow = AuthorizationDecision.allow(filters={"tenant_id": "t1"})
+    assert allow.allowed is True
+    assert allow.filters == {"tenant_id": "t1"}
+
+
+def test_decision_is_frozen() -> None:
+    decision = AuthorizationDecision.allow()
+    with pytest.raises((AttributeError, TypeError)):
+        decision.allowed = False  # type: ignore[misc]
+
+
+def test_normalize_bool_true_is_allow() -> None:
+    decision = normalize_decision(True)
+    assert isinstance(decision, AuthorizationDecision)
+    assert decision.allowed is True
+
+
+def test_normalize_bool_false_is_deny() -> None:
+    decision = normalize_decision(False)
+    assert decision.allowed is False
+    assert decision.code == "FORBIDDEN"
+
+
+def test_normalize_passthrough_decision() -> None:
+    original = AuthorizationDecision.deny(code="X", message="m")
+    assert normalize_decision(original) is original
+
+
+def test_plain_object_with_authorize_operation_is_authorizer() -> None:
+    class MyAuth:
+        async def authorize_operation(
+            self,
+            *,
+            context: dict[str, Any],
+            operation_type: str,
+            operation_name: str,
+            arguments: dict[str, Any],
+        ) -> bool:
+            return True
+
+    assert isinstance(MyAuth(), Authorizer)
+
+
+def test_missing_method_is_not_authorizer() -> None:
+    class NotAuth:
+        pass
+
+    assert not isinstance(NotAuth(), Authorizer)

--- a/tests/unit/security/test_decision_cache.py
+++ b/tests/unit/security/test_decision_cache.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from graphql import GraphQLError
 
-from fraiseql.security.authorization import AuthorizationDecision
+from fraiseql.security.authorization import AuthorizationDecision, enforce_operation_value
 from fraiseql.security.decision_cache import AuthorizationCacheConfig, DecisionCache
 
 pytestmark = pytest.mark.unit
@@ -133,3 +134,114 @@ def test_get_refreshes_lru_recency() -> None:
     assert cache.get(k1) is not None
     assert cache.get(k2) is None
     assert cache.get(k3) is not None
+
+
+# --- behavioral spec through enforce_operation_value (headless, no DB) -----------------
+
+
+class _CountingAuthorizer:
+    """Counts invocations; returns a fixed result (bool or AuthorizationDecision)."""
+
+    def __init__(self, result: Any = True) -> None:
+        self.calls = 0
+        self._result = result
+
+    async def authorize_operation(self, **_: Any) -> Any:
+        self.calls += 1
+        return self._result
+
+
+class _FlakyAuthorizer:
+    """Raises on the first call (transient PDP error), allows thereafter."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def authorize_operation(self, **_: Any) -> bool:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("transient PDP error")
+        return True
+
+
+async def _enforce(authorizer: Any, cache: Any, *, context: Any = None, arguments: Any = None):
+    return await enforce_operation_value(
+        authorizer=authorizer,
+        context=_CTX if context is None else context,
+        operation_type="query",
+        operation_name="users",
+        arguments={} if arguments is None else arguments,
+        cache=cache,
+    )
+
+
+async def test_identical_calls_invoke_authorizer_once() -> None:
+    auth = _CountingAuthorizer()
+    cache = _cache()
+    await _enforce(auth, cache, arguments={"x": 1})
+    await _enforce(auth, cache, arguments={"x": 1})
+    assert auth.calls == 1, "second identical call should be served from cache"
+
+
+async def test_different_arguments_invoke_separately() -> None:
+    auth = _CountingAuthorizer()
+    cache = _cache()
+    await _enforce(auth, cache, arguments={"x": 1})
+    await _enforce(auth, cache, arguments={"x": 2})
+    assert auth.calls == 2
+
+
+async def test_different_principal_invoke_separately() -> None:
+    auth = _CountingAuthorizer()
+    cache = _cache()
+    await _enforce(auth, cache, context={"user": {"id": "u1"}})
+    await _enforce(auth, cache, context={"user": {"id": "u2"}})
+    assert auth.calls == 2
+
+
+async def test_ttl_expiry_reinvokes_authorizer() -> None:
+    clock = _Clock()
+    auth = _CountingAuthorizer()
+    cache = _cache(ttl=5.0, clock=clock)
+    await _enforce(auth, cache)
+    clock.now += 6.0
+    await _enforce(auth, cache)
+    assert auth.calls == 2
+
+
+async def test_raising_authorizer_denied_and_not_cached() -> None:
+    """A raising authorizer fails closed and is never cached: the retry can allow."""
+    auth = _FlakyAuthorizer()
+    cache = _cache()
+    with pytest.raises(GraphQLError) as exc:
+        await _enforce(auth, cache)
+    assert exc.value.extensions["code"] == "FORBIDDEN"
+    decision = await _enforce(auth, cache)  # not served from a cached deny
+    assert decision.allowed
+    assert auth.calls == 2
+
+
+async def test_deny_decision_served_from_cache() -> None:
+    auth = _CountingAuthorizer(result=AuthorizationDecision.deny(code="NO_READS"))
+    cache = _cache()
+    for _ in range(2):
+        with pytest.raises(GraphQLError):
+            await _enforce(auth, cache)
+    assert auth.calls == 1, "a clean deny decision is cached and re-enforced"
+
+
+async def test_none_principal_never_cached() -> None:
+    auth = _CountingAuthorizer()
+    cache = _cache()
+    ctx = {"user": None}
+    await _enforce(auth, cache, context=ctx)
+    await _enforce(auth, cache, context=ctx)
+    assert auth.calls == 2
+
+
+async def test_no_cache_invokes_every_time() -> None:
+    """With no cache configured, behavior is exactly today's: evaluate every call."""
+    auth = _CountingAuthorizer()
+    await _enforce(auth, None)
+    await _enforce(auth, None)
+    assert auth.calls == 2

--- a/tests/unit/security/test_decision_cache.py
+++ b/tests/unit/security/test_decision_cache.py
@@ -1,0 +1,135 @@
+"""Decision cache primitive: key construction, TTL expiry, LRU eviction (issue #367).
+
+Headless unit tests for :class:`DecisionCache` / :class:`AuthorizationCacheConfig` with an
+injected monotonic clock. The end-to-end behavioral spec (counting authorizer invocations
+through ``enforce_operation_value``) lives in ``test_decision_cache_paths.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fraiseql.security.authorization import AuthorizationDecision
+from fraiseql.security.decision_cache import AuthorizationCacheConfig, DecisionCache
+
+pytestmark = pytest.mark.unit
+
+
+class _Clock:
+    """Manually advanced monotonic clock for deterministic TTL tests."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _by_user(ctx: dict[str, Any]) -> Any:
+    user = ctx.get("user")
+    return user.get("id") if user else None
+
+
+def _cache(*, ttl: float = 5.0, max_entries: int = 10_000, clock: Any = None) -> DecisionCache:
+    config = AuthorizationCacheConfig(
+        principal_key=_by_user,
+        ttl_seconds=ttl,
+        max_entries=max_entries,
+        clock=clock or _Clock(),
+    )
+    return DecisionCache(config)
+
+
+_CTX = {"user": {"id": "u1"}}
+
+
+# --- make_key -------------------------------------------------------------------------
+
+
+def test_make_key_none_when_principal_is_none() -> None:
+    """An anonymous/unknown principal is never cached (no cross-principal sharing)."""
+    cache = _cache()
+    assert cache.make_key({"user": None}, "query", "users", {}) is None
+
+
+def test_make_key_none_when_arguments_not_json_serializable() -> None:
+    """Non-JSON-serializable arguments disable caching for that call."""
+    cache = _cache()
+    assert cache.make_key(_CTX, "query", "users", {"ids": {1, 2, 3}}) is None  # set → not JSON
+
+
+def test_make_key_stable_across_argument_ordering() -> None:
+    """Canonicalization makes dict ordering irrelevant."""
+    cache = _cache()
+    k1 = cache.make_key(_CTX, "query", "users", {"a": 1, "b": 2})
+    k2 = cache.make_key(_CTX, "query", "users", {"b": 2, "a": 1})
+    assert k1 == k2 is not None
+
+
+def test_make_key_differs_by_principal_op_and_arguments() -> None:
+    """Each axis of the key separates entries."""
+    cache = _cache()
+    base = cache.make_key(_CTX, "query", "users", {"x": 1})
+    assert base != cache.make_key({"user": {"id": "u2"}}, "query", "users", {"x": 1})
+    assert base != cache.make_key(_CTX, "mutation", "users", {"x": 1})
+    assert base != cache.make_key(_CTX, "query", "posts", {"x": 1})
+    assert base != cache.make_key(_CTX, "query", "users", {"x": 2})
+
+
+# --- get / put / TTL / LRU ------------------------------------------------------------
+
+
+def test_get_miss_returns_none() -> None:
+    cache = _cache()
+    assert cache.get(("u1", "query", "users", "deadbeef")) is None
+
+
+def test_put_then_get_round_trips_decision() -> None:
+    cache = _cache()
+    key = cache.make_key(_CTX, "query", "users", {})
+    decision = AuthorizationDecision.allow(filters={"tenant_id": "t1"})
+    cache.put(key, decision)
+    assert cache.get(key) is decision
+
+
+def test_ttl_expiry_drops_entry() -> None:
+    clock = _Clock()
+    cache = _cache(ttl=5.0, clock=clock)
+    key = cache.make_key(_CTX, "query", "users", {})
+    cache.put(key, AuthorizationDecision.allow())
+    clock.now += 4.99
+    assert cache.get(key) is not None, "still fresh inside the TTL window"
+    clock.now += 0.02  # now past the 5s TTL
+    assert cache.get(key) is None, "expired entry must miss"
+    # And the expired entry is dropped, not merely reported as a miss.
+    assert cache.get(key) is None
+
+
+def test_lru_eviction_past_max_entries() -> None:
+    cache = _cache(max_entries=2)
+    k1 = cache.make_key(_CTX, "query", "a", {})
+    k2 = cache.make_key(_CTX, "query", "b", {})
+    k3 = cache.make_key(_CTX, "query", "c", {})
+    cache.put(k1, AuthorizationDecision.allow())
+    cache.put(k2, AuthorizationDecision.allow())
+    cache.put(k3, AuthorizationDecision.allow())  # evicts k1 (least recently used)
+    assert cache.get(k1) is None
+    assert cache.get(k2) is not None
+    assert cache.get(k3) is not None
+
+
+def test_get_refreshes_lru_recency() -> None:
+    """A read marks an entry as recently used, protecting it from the next eviction."""
+    cache = _cache(max_entries=2)
+    k1 = cache.make_key(_CTX, "query", "a", {})
+    k2 = cache.make_key(_CTX, "query", "b", {})
+    k3 = cache.make_key(_CTX, "query", "c", {})
+    cache.put(k1, AuthorizationDecision.allow())
+    cache.put(k2, AuthorizationDecision.allow())
+    assert cache.get(k1) is not None  # touch k1 → k2 is now least recently used
+    cache.put(k3, AuthorizationDecision.allow())  # evicts k2, not k1
+    assert cache.get(k1) is not None
+    assert cache.get(k2) is None
+    assert cache.get(k3) is not None

--- a/tests/unit/security/test_enforce_operation.py
+++ b/tests/unit/security/test_enforce_operation.py
@@ -1,0 +1,182 @@
+"""Tests for the fail-closed operation-enforcement helper (issue #362, phase 2)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from graphql import GraphQLError
+
+from fraiseql.security.authorization import (
+    AuthorizationDecision,
+    enforce_operation,
+    resolve_authorizer,
+)
+
+
+def _info(context: dict[str, Any] | None = None, field_name: str = "op") -> Any:
+    return SimpleNamespace(context=context if context is not None else {}, field_name=field_name)
+
+
+async def test_no_authorizer_returns_allow() -> None:
+    decision = await enforce_operation(
+        info=_info(),
+        operation_type="query",
+        operation_name="q",
+        arguments={},
+        authorizer=None,
+    )
+    assert decision.allowed is True
+
+
+async def test_allow_decision_is_returned_with_filters() -> None:
+    class AllowWithFilters:
+        async def authorize_operation(self, **_: Any) -> AuthorizationDecision:
+            return AuthorizationDecision.allow(filters={"tenant_id": "t1"})
+
+    decision = await enforce_operation(
+        info=_info(),
+        operation_type="query",
+        operation_name="q",
+        arguments={},
+        authorizer=AllowWithFilters(),
+    )
+    assert decision.allowed is True
+    assert decision.filters == {"tenant_id": "t1"}
+
+
+async def test_deny_decision_raises_with_code_and_message() -> None:
+    class Deny:
+        async def authorize_operation(self, **_: Any) -> AuthorizationDecision:
+            return AuthorizationDecision.deny(code="NOPE", message="go away")
+
+    with pytest.raises(GraphQLError) as exc:
+        await enforce_operation(
+            info=_info(),
+            operation_type="mutation",
+            operation_name="m",
+            arguments={},
+            authorizer=Deny(),
+        )
+    assert exc.value.extensions["code"] == "NOPE"
+    assert exc.value.message == "go away"
+
+
+async def test_sync_bool_authorizer_accepted() -> None:
+    class SyncDeny:
+        def authorize_operation(self, **_: Any) -> bool:
+            return False
+
+    with pytest.raises(GraphQLError) as exc:
+        await enforce_operation(
+            info=_info(),
+            operation_type="query",
+            operation_name="q",
+            arguments={},
+            authorizer=SyncDeny(),
+        )
+    assert exc.value.extensions["code"] == "FORBIDDEN"
+
+
+async def test_async_bool_authorizer_allow() -> None:
+    class AsyncAllow:
+        async def authorize_operation(self, **_: Any) -> bool:
+            return True
+
+    decision = await enforce_operation(
+        info=_info(),
+        operation_type="query",
+        operation_name="q",
+        arguments={},
+        authorizer=AsyncAllow(),
+    )
+    assert decision.allowed is True
+
+
+async def test_arguments_and_context_forwarded_verbatim() -> None:
+    captured: dict[str, Any] = {}
+
+    class Spy:
+        async def authorize_operation(
+            self,
+            *,
+            context: dict[str, Any],
+            operation_type: str,
+            operation_name: str,
+            arguments: dict[str, Any],
+        ) -> bool:
+            captured.update(
+                context=context,
+                operation_type=operation_type,
+                operation_name=operation_name,
+                arguments=arguments,
+            )
+            return True
+
+    await enforce_operation(
+        info=_info(context={"user": "alice"}),
+        operation_type="mutation",
+        operation_name="createWidget",
+        arguments={"name": "x"},
+        authorizer=Spy(),
+    )
+    assert captured["context"] == {"user": "alice"}
+    assert captured["operation_type"] == "mutation"
+    assert captured["operation_name"] == "createWidget"
+    assert captured["arguments"] == {"name": "x"}
+
+
+async def test_authorizer_raising_denies_fail_closed() -> None:
+    class Boom:
+        async def authorize_operation(self, **_: Any) -> bool:
+            raise RuntimeError("internal secret detail")
+
+    with pytest.raises(GraphQLError) as exc:
+        await enforce_operation(
+            info=_info(),
+            operation_type="query",
+            operation_name="q",
+            arguments={},
+            authorizer=Boom(),
+        )
+    assert exc.value.extensions["code"] == "FORBIDDEN"
+    # No internal leakage of the raw exception text.
+    assert "internal secret detail" not in (exc.value.message or "")
+    assert "internal secret detail" not in str(exc.value.extensions)
+
+
+async def test_authorizer_raising_graphqlerror_propagates() -> None:
+    class CustomError:
+        async def authorize_operation(self, **_: Any) -> bool:
+            raise GraphQLError("custom", extensions={"code": "CUSTOM"})
+
+    with pytest.raises(GraphQLError) as exc:
+        await enforce_operation(
+            info=_info(),
+            operation_type="query",
+            operation_name="q",
+            arguments={},
+            authorizer=CustomError(),
+        )
+    assert exc.value.extensions["code"] == "CUSTOM"
+    assert exc.value.message == "custom"
+
+
+def test_resolve_authorizer_prefers_per_operation_attribute() -> None:
+    registry = SimpleNamespace(default_authorizer="GLOBAL")
+
+    def fn() -> None: ...
+
+    assert resolve_authorizer(fn, registry) == "GLOBAL"
+
+    fn.__fraiseql_authorizer__ = "PER_OP"
+    assert resolve_authorizer(fn, registry) == "PER_OP"
+
+
+def test_resolve_authorizer_falls_back_to_default() -> None:
+    registry = SimpleNamespace(default_authorizer="GLOBAL")
+
+    def fn() -> None: ...
+
+    assert resolve_authorizer(fn, registry) == "GLOBAL"

--- a/tests/unit/security/test_field_auth_decision.py
+++ b/tests/unit/security/test_field_auth_decision.py
@@ -1,0 +1,90 @@
+"""Field-level authorization accepts the unified decision contract (issue #362, phase 7)."""
+
+from __future__ import annotations
+
+import warnings
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from fraiseql.security.authorization import AuthorizationDecision
+from fraiseql.security.field_auth import (
+    FieldAuthorizationError,
+    authorize_field,
+    field_authorizer_adapter,
+)
+
+
+def _info(context: dict[str, Any] | None = None, field_name: str = "email") -> Any:
+    return SimpleNamespace(context=context if context is not None else {}, field_name=field_name)
+
+
+async def _resolver(root: Any, info: Any) -> str:
+    return "secret"
+
+
+async def test_decision_deny_surfaces_code_and_message() -> None:
+    def check(info: Any) -> AuthorizationDecision:
+        return AuthorizationDecision.deny(code="NOPE", message="no field for you")
+
+    wrapped = authorize_field(check)(_resolver)
+    with pytest.raises(FieldAuthorizationError) as exc:
+        await wrapped(None, _info())
+    assert exc.value.message == "no field for you"
+    assert exc.value.extensions["code"] == "NOPE"
+
+
+async def test_decision_allow_resolves_field() -> None:
+    def check(info: Any) -> AuthorizationDecision:
+        return AuthorizationDecision.allow()
+
+    wrapped = authorize_field(check)(_resolver)
+    assert await wrapped(None, _info()) == "secret"
+
+
+async def test_legacy_bool_true_resolves() -> None:
+    wrapped = authorize_field(lambda info: True)(_resolver)
+    assert await wrapped(None, _info()) == "secret"
+
+
+async def test_legacy_bool_false_keeps_field_authorization_error_code() -> None:
+    wrapped = authorize_field(lambda info: False)(_resolver)
+    with pytest.raises(FieldAuthorizationError) as exc:
+        await wrapped(None, _info())
+    # Back-compat: a plain bool deny keeps the original code, not "FORBIDDEN".
+    assert exc.value.extensions["code"] == "FIELD_AUTHORIZATION_ERROR"
+
+
+async def test_filters_at_field_granularity_are_ignored_and_warned() -> None:
+    def check(info: Any) -> AuthorizationDecision:
+        return AuthorizationDecision.allow(filters={"tenant_id": "t1"})
+
+    wrapped = authorize_field(check)(_resolver)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = await wrapped(None, _info())
+    assert result == "secret"
+    assert any("filter" in str(w.message).lower() for w in caught)
+
+
+async def test_field_authorizer_adapter_delegates_to_operation_authorizer() -> None:
+    class DenyAuthorizer:
+        async def authorize_operation(
+            self,
+            *,
+            context: dict[str, Any],
+            operation_type: str,
+            operation_name: str,
+            arguments: dict[str, Any],
+        ) -> AuthorizationDecision:
+            assert operation_type == "field"
+            assert operation_name == "email"
+            return AuthorizationDecision.deny(code="FIELD_NOPE", message="adapter denied")
+
+    check = field_authorizer_adapter(DenyAuthorizer(), field="email")
+    wrapped = authorize_field(check)(_resolver)
+    with pytest.raises(FieldAuthorizationError) as exc:
+        await wrapped(None, _info())
+    assert exc.value.extensions["code"] == "FIELD_NOPE"
+    assert exc.value.message == "adapter denied"

--- a/tests/unit/security/test_field_auth_decision.py
+++ b/tests/unit/security/test_field_auth_decision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import warnings
 from types import SimpleNamespace
 from typing import Any
@@ -66,6 +67,24 @@ async def test_filters_at_field_granularity_are_ignored_and_warned() -> None:
         result = await wrapped(None, _info())
     assert result == "secret"
     assert any("filter" in str(w.message).lower() for w in caught)
+
+
+def test_auth_wrapper_reports_its_real_signature() -> None:
+    """The wrapper must advertise ``(root, info, *args, **kwargs)`` — no ``__wrapped__`` leak.
+
+    ``functools.wraps`` would set ``__wrapped__`` and make ``inspect.signature`` follow it to
+    the inner method's ``(self)``-only shape; an outer ``@field`` would then call the wrapper
+    with too few arguments. Asserting on the wrapper's own signature pins the fix.
+    """
+
+    def email(self) -> str:  # noqa: N805 - self-only field method
+        return "secret"
+
+    wrapped = authorize_field(lambda info: True)(email)
+
+    assert not hasattr(wrapped, "__wrapped__"), "auth wrapper must not leak inner via __wrapped__"
+    params = list(inspect.signature(wrapped).parameters)
+    assert params == ["root", "info", "args", "kwargs"]
 
 
 async def test_field_authorizer_adapter_delegates_to_operation_authorizer() -> None:

--- a/tests/unit/security/test_field_decorator_composition.py
+++ b/tests/unit/security/test_field_decorator_composition.py
@@ -328,11 +328,6 @@ _CASES = [
             expected="v6",
             expects_warning=False,
         ),
-        marks=pytest.mark.xfail(
-            strict=True,
-            reason="Order B (@field outer / @authorize_field inner) self-only method: "
-            "auth wrapper mis-reports its signature; resolver never runs (fixed Phase 2)",
-        ),
         id="row6-orderB-self-synccheck",
     ),
     pytest.param(
@@ -340,12 +335,10 @@ _CASES = [
             name="row7-orderB-self-asyncadapter",
             build=lambda: _graphql_runner("t7", "data", "T7", T7, t7),
             expected="v7",
-            expects_warning=False,
-        ),
-        marks=pytest.mark.xfail(
-            strict=True,
-            reason="Order B self-only method + async check: same signature bug as row 6 "
-            "(fixed Phase 2; warning-free in Phase 3)",
+            # Phase 2 makes this resolve correctly, but a sync resolver with an async check
+            # still routes through the run_until_complete bridge and warns. Phase 3 removes
+            # the bridge and this flips to expects_warning=False.
+            expects_warning=True,
         ),
         id="row7-orderB-self-asyncadapter",
     ),

--- a/tests/unit/security/test_field_decorator_composition.py
+++ b/tests/unit/security/test_field_decorator_composition.py
@@ -335,10 +335,9 @@ _CASES = [
             name="row7-orderB-self-asyncadapter",
             build=lambda: _graphql_runner("t7", "data", "T7", T7, t7),
             expected="v7",
-            # Phase 2 makes this resolve correctly, but a sync resolver with an async check
-            # still routes through the run_until_complete bridge and warns. Phase 3 removes
-            # the bridge and this flips to expects_warning=False.
-            expects_warning=True,
+            # Phase 3: an async check now produces an async wrapper, so the sync-resolver
+            # bridge is gone and there is no warning.
+            expects_warning=False,
         ),
         id="row7-orderB-self-asyncadapter",
     ),
@@ -347,7 +346,7 @@ _CASES = [
             name="row8-orderB-selfinfo-asyncadapter",
             build=lambda: _graphql_runner("t8", "data", "T8", T8, t8),
             expected="v8",
-            expects_warning=True,
+            expects_warning=False,
         ),
         id="row8-orderB-selfinfo-asyncadapter",
     ),
@@ -390,3 +389,30 @@ def test_field_decorator_composition_matrix(case: _Case) -> None:
     assert deny.code == "FIELD_AUTHORIZATION_ERROR", f"{case.name}: deny surfaces the field code"
     assert not deny.body_ran, f"{case.name}: resolver body must NOT run when denied (fail-closed)"
     assert deny.value is None, f"{case.name}: denied field yields no value"
+
+
+async def test_sync_resolver_async_check_under_running_loop() -> None:
+    """A sync resolver gated by an async check resolves cleanly under a *running* loop.
+
+    This is the scenario the removed run_until_complete/run_coroutine_threadsafe bridge
+    handled badly (a deadlock risk + a RuntimeWarning). Now the async check produces an async
+    wrapper that graphql-core awaits on the already-running loop. ``await graphql(...)`` here
+    runs inside pytest-asyncio's loop, exercising exactly that path.
+    """
+    schema = build_fraiseql_schema(query_types=[T7, t7])
+    query_str = "{ t7 { data } }"
+
+    _executions.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        allowed = await graphql(schema, query_str, context_value=_ALLOW)
+    assert not allowed.errors
+    assert allowed.data["t7"]["data"] == "v7"
+    assert "T7" in _executions
+    assert not _warned(caught), "the sync->async bridge warning must be gone"
+
+    _executions.clear()
+    denied = await graphql(schema, query_str, context_value=_DENY)
+    codes = {(e.extensions or {}).get("code") for e in (denied.errors or [])}
+    assert "FIELD_AUTHORIZATION_ERROR" in codes
+    assert "T7" not in _executions, "fail-closed: denied body must not run"

--- a/tests/unit/security/test_field_decorator_composition.py
+++ b/tests/unit/security/test_field_decorator_composition.py
@@ -148,7 +148,7 @@ def t5(info) -> T5:
     return T5(id=1)
 
 
-# Row 6 -- Order B, ``def m(self)``, sync lambda. BROKEN today (fixed clean in Phase 2).
+# Row 6 -- Order B, ``def m(self)``, sync lambda. The self-only order that used to fail.
 @fraiseql.type
 class T6:
     id: int
@@ -165,8 +165,8 @@ def t6(info) -> T6:
     return T6(id=1)
 
 
-# Row 7 -- Order B, ``def m(self)``, async adapter check. BROKEN today; Phase 2 resolves it
-# (with a RuntimeWarning), Phase 3 makes it clean.
+# Row 7 -- Order B, ``def m(self)``, async adapter check. A sync resolver gated by an async
+# check: must resolve via an async wrapper, with no event-loop bridge and no warning.
 @fraiseql.type
 class T7:
     id: int
@@ -184,7 +184,7 @@ def t7(info) -> T7:
 
 
 # Row 8 -- Order B, ``def m(self, info)`` sync, async adapter check. Same scenario as row 7
-# (sync resolver + async check); passes today but warns. Phase 3 makes it clean.
+# (sync resolver + async check), differing only in the method shape.
 @fraiseql.type
 class T8:
     id: int
@@ -225,9 +225,9 @@ def _warned(caught: list[warnings.WarningMessage]) -> bool:
 def _graphql_runner(query_field: str, type_field: str, marker: str, type_cls: Any, query_fn: Any):
     """Build the schema once and return a ``run(ctx) -> _Exec`` closure.
 
-    Picks ``graphql`` vs ``graphql_sync`` from the *built* field resolver's async-ness, so
-    the runner auto-adapts when a phase changes a wrapper from sync to async (e.g. row 7
-    after Phase 3) without the matrix having to encode the phase.
+    Picks ``graphql`` vs ``graphql_sync`` from the *built* field resolver's async-ness, so the
+    runner adapts to whether the composed wrapper ended up sync or async without the matrix
+    having to hard-code it per row.
     """
     schema = build_fraiseql_schema(query_types=[type_cls, query_fn])
     obj_type = schema.query_type.fields[query_field].type
@@ -335,8 +335,8 @@ _CASES = [
             name="row7-orderB-self-asyncadapter",
             build=lambda: _graphql_runner("t7", "data", "T7", T7, t7),
             expected="v7",
-            # Phase 3: an async check now produces an async wrapper, so the sync-resolver
-            # bridge is gone and there is no warning.
+            # An async check produces an async wrapper end-to-end, so there is no
+            # sync-resolver event-loop bridge and no warning.
             expects_warning=False,
         ),
         id="row7-orderB-self-asyncadapter",

--- a/tests/unit/security/test_field_decorator_composition.py
+++ b/tests/unit/security/test_field_decorator_composition.py
@@ -1,0 +1,399 @@
+"""Characterization matrix for ``@field`` / ``@authorize_field`` composition.
+
+Pins the full contract (rows 1-8) of how the two field-resolver decorators compose
+across {decorator order} x {method shape} x {check kind}, sync and async. The matrix is
+the regression guard for the working orders and the explicit ledger for the broken cells
+the signature-adaptation fix repairs.
+
+Assertions are deliberately on the GraphQL error **code** (``FIELD_AUTHORIZATION_ERROR``)
+and the "resolver body ran / did not run" invariant -- never on a ``TypeError`` message
+string. The broken cells fail with a missing-positional-argument ``TypeError`` whose text
+uses the wrapper's ``co_qualname`` (``functools.wraps`` does not rewrite it), so asserting
+on that text would be brittle and would not describe the contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import warnings
+from types import SimpleNamespace
+from typing import Any, NamedTuple
+
+import pytest
+from graphql import graphql, graphql_sync
+
+import fraiseql
+from fraiseql import field
+from fraiseql.gql.builders import SchemaRegistry
+from fraiseql.gql.schema_builder import build_fraiseql_schema
+from fraiseql.security import authorize_field, field_authorizer_adapter
+from fraiseql.security.authorization import AuthorizationDecision
+from fraiseql.security.field_auth import FieldAuthorizationError
+
+pytestmark = pytest.mark.security
+
+# Proves whether a gated resolver body actually executed. The fail-closed invariant is
+# "body did not run" on every deny cell; the allow cells require "body ran".
+_executions: list[str] = []
+
+_ALLOW = {"allow": True}
+_DENY = {"allow": False}
+_ASYNC_CHECK_WARNING = "async permission check"
+
+
+class _CtxAuthorizer:
+    """An operation-style authorizer that allows iff ``context['allow']`` is truthy.
+
+    Adapted to a field check via :func:`field_authorizer_adapter` (which is async), so it
+    exercises the async-check path in the matrix.
+    """
+
+    async def authorize_operation(
+        self,
+        *,
+        context: dict[str, Any],
+        operation_type: str,
+        operation_name: str,
+        arguments: dict[str, Any],
+    ) -> bool:
+        return bool(context.get("allow"))
+
+
+# --- Row types: one gated field per type, distinct names so the type cache never collides.
+
+
+# Row 1 -- Order A (@authorize_field outer / @field inner), ``def m(self)``, sync lambda.
+@fraiseql.type
+class T1:
+    id: int
+
+    @authorize_field(lambda info: info.context.get("allow", False))
+    @field
+    def data(self) -> str | None:
+        _executions.append("T1")
+        return "v1"
+
+
+@fraiseql.query
+def t1(info) -> T1:
+    return T1(id=1)
+
+
+# Row 2 -- Order A, ``async def m(self)``, sync lambda.
+@fraiseql.type
+class T2:
+    id: int
+
+    @authorize_field(lambda info: info.context.get("allow", False))
+    @field
+    async def data(self) -> str | None:
+        _executions.append("T2")
+        return "v2"
+
+
+@fraiseql.query
+def t2(info) -> T2:
+    return T2(id=1)
+
+
+# Row 3 -- Order A, ``def m(self, info)``, root-expecting sync check (``lambda info, root``).
+@fraiseql.type
+class T3:
+    id: int
+
+    @authorize_field(lambda info, root: info.context.get("allow", False))
+    @field
+    def data(self, info) -> str | None:
+        _executions.append("T3")
+        return "v3"
+
+
+@fraiseql.query
+def t3(info) -> T3:
+    return T3(id=1)
+
+
+# Row 4 -- standalone @authorize_field on a root-style ``async def r(root, info)``, decision
+# check. Exercised by direct invocation (this is the custom-resolver usage, not a @field).
+async def _r4(root: Any, info: Any) -> str | None:
+    _executions.append("T4")
+    return "v4"
+
+
+def _check4(info: Any) -> AuthorizationDecision:
+    if info.context.get("allow"):
+        return AuthorizationDecision.allow()
+    return AuthorizationDecision.deny(code="FIELD_AUTHORIZATION_ERROR")
+
+
+_row4_wrapped = authorize_field(_check4)(_r4)
+
+
+# Row 5 -- Order B (@field outer / @authorize_field inner), ``async def m(self, info)``,
+# async adapter check.
+@fraiseql.type
+class T5:
+    id: int
+
+    @field
+    @authorize_field(field_authorizer_adapter(_CtxAuthorizer(), field="T5.data"))
+    async def data(self, info) -> str | None:
+        _executions.append("T5")
+        return "v5"
+
+
+@fraiseql.query
+def t5(info) -> T5:
+    return T5(id=1)
+
+
+# Row 6 -- Order B, ``def m(self)``, sync lambda. BROKEN today (fixed clean in Phase 2).
+@fraiseql.type
+class T6:
+    id: int
+
+    @field
+    @authorize_field(lambda info: info.context.get("allow", False))
+    def data(self) -> str | None:
+        _executions.append("T6")
+        return "v6"
+
+
+@fraiseql.query
+def t6(info) -> T6:
+    return T6(id=1)
+
+
+# Row 7 -- Order B, ``def m(self)``, async adapter check. BROKEN today; Phase 2 resolves it
+# (with a RuntimeWarning), Phase 3 makes it clean.
+@fraiseql.type
+class T7:
+    id: int
+
+    @field
+    @authorize_field(field_authorizer_adapter(_CtxAuthorizer(), field="T7.data"))
+    def data(self) -> str | None:
+        _executions.append("T7")
+        return "v7"
+
+
+@fraiseql.query
+def t7(info) -> T7:
+    return T7(id=1)
+
+
+# Row 8 -- Order B, ``def m(self, info)`` sync, async adapter check. Same scenario as row 7
+# (sync resolver + async check); passes today but warns. Phase 3 makes it clean.
+@fraiseql.type
+class T8:
+    id: int
+
+    @field
+    @authorize_field(field_authorizer_adapter(_CtxAuthorizer(), field="T8.data"))
+    def data(self, info) -> str | None:
+        _executions.append("T8")
+        return "v8"
+
+
+@fraiseql.query
+def t8(info) -> T8:
+    return T8(id=1)
+
+
+class _Exec(NamedTuple):
+    value: Any
+    body_ran: bool
+    code: str | None
+    warned: bool
+
+
+class _Case(NamedTuple):
+    name: str
+    build: Any  # () -> (ctx -> _Exec)
+    expected: Any
+    expects_warning: bool
+
+
+def _warned(caught: list[warnings.WarningMessage]) -> bool:
+    return any(
+        issubclass(w.category, RuntimeWarning) and _ASYNC_CHECK_WARNING in str(w.message)
+        for w in caught
+    )
+
+
+def _graphql_runner(query_field: str, type_field: str, marker: str, type_cls: Any, query_fn: Any):
+    """Build the schema once and return a ``run(ctx) -> _Exec`` closure.
+
+    Picks ``graphql`` vs ``graphql_sync`` from the *built* field resolver's async-ness, so
+    the runner auto-adapts when a phase changes a wrapper from sync to async (e.g. row 7
+    after Phase 3) without the matrix having to encode the phase.
+    """
+    schema = build_fraiseql_schema(query_types=[type_cls, query_fn])
+    obj_type = schema.query_type.fields[query_field].type
+    while hasattr(obj_type, "of_type"):
+        obj_type = obj_type.of_type
+    is_async = asyncio.iscoroutinefunction(obj_type.fields[type_field].resolve)
+    query_str = f"{{ {query_field} {{ {type_field} }} }}"
+
+    def run(ctx: dict[str, Any]) -> _Exec:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            if is_async:
+                result = asyncio.run(graphql(schema, query_str, context_value=ctx))
+            else:
+                result = graphql_sync(schema, query_str, context_value=ctx)
+        code = None
+        if result.errors:
+            code = (result.errors[0].extensions or {}).get("code")
+        value = None
+        if result.data and result.data.get(query_field):
+            value = result.data[query_field].get(type_field)
+        return _Exec(value=value, body_ran=marker in _executions, code=code, warned=_warned(caught))
+
+    return run
+
+
+def _direct_runner(wrapped: Any, marker: str):
+    """Return a ``run(ctx) -> _Exec`` closure that calls a standalone wrapper directly."""
+
+    def run(ctx: dict[str, Any]) -> _Exec:
+        info = SimpleNamespace(context=ctx, field_name="data")
+        code = None
+        value = None
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                res = wrapped(None, info)
+                if inspect.isawaitable(res):
+                    res = asyncio.run(res)
+                value = res
+            except FieldAuthorizationError as exc:
+                code = (exc.extensions or {}).get("code")
+        return _Exec(value=value, body_ran=marker in _executions, code=code, warned=_warned(caught))
+
+    return run
+
+
+_CASES = [
+    pytest.param(
+        _Case(
+            name="row1-orderA-self-synccheck",
+            build=lambda: _graphql_runner("t1", "data", "T1", T1, t1),
+            expected="v1",
+            expects_warning=False,
+        ),
+        id="row1-orderA-self-synccheck",
+    ),
+    pytest.param(
+        _Case(
+            name="row2-orderA-asyncself-synccheck",
+            build=lambda: _graphql_runner("t2", "data", "T2", T2, t2),
+            expected="v2",
+            expects_warning=False,
+        ),
+        id="row2-orderA-asyncself-synccheck",
+    ),
+    pytest.param(
+        _Case(
+            name="row3-orderA-selfinfo-rootcheck",
+            build=lambda: _graphql_runner("t3", "data", "T3", T3, t3),
+            expected="v3",
+            expects_warning=False,
+        ),
+        id="row3-orderA-selfinfo-rootcheck",
+    ),
+    pytest.param(
+        _Case(
+            name="row4-standalone-rootstyle-decision",
+            build=lambda: _direct_runner(_row4_wrapped, "T4"),
+            expected="v4",
+            expects_warning=False,
+        ),
+        id="row4-standalone-rootstyle-decision",
+    ),
+    pytest.param(
+        _Case(
+            name="row5-orderB-asyncselfinfo-asyncadapter",
+            build=lambda: _graphql_runner("t5", "data", "T5", T5, t5),
+            expected="v5",
+            expects_warning=False,
+        ),
+        id="row5-orderB-asyncselfinfo-asyncadapter",
+    ),
+    pytest.param(
+        _Case(
+            name="row6-orderB-self-synccheck",
+            build=lambda: _graphql_runner("t6", "data", "T6", T6, t6),
+            expected="v6",
+            expects_warning=False,
+        ),
+        marks=pytest.mark.xfail(
+            strict=True,
+            reason="Order B (@field outer / @authorize_field inner) self-only method: "
+            "auth wrapper mis-reports its signature; resolver never runs (fixed Phase 2)",
+        ),
+        id="row6-orderB-self-synccheck",
+    ),
+    pytest.param(
+        _Case(
+            name="row7-orderB-self-asyncadapter",
+            build=lambda: _graphql_runner("t7", "data", "T7", T7, t7),
+            expected="v7",
+            expects_warning=False,
+        ),
+        marks=pytest.mark.xfail(
+            strict=True,
+            reason="Order B self-only method + async check: same signature bug as row 6 "
+            "(fixed Phase 2; warning-free in Phase 3)",
+        ),
+        id="row7-orderB-self-asyncadapter",
+    ),
+    pytest.param(
+        _Case(
+            name="row8-orderB-selfinfo-asyncadapter",
+            build=lambda: _graphql_runner("t8", "data", "T8", T8, t8),
+            expected="v8",
+            expects_warning=True,
+        ),
+        id="row8-orderB-selfinfo-asyncadapter",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    _executions.clear()
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    _executions.clear()
+
+
+@pytest.mark.parametrize("case", _CASES)
+def test_field_decorator_composition_matrix(case: _Case) -> None:
+    """Both decorator orders, every method shape: allow runs the body, deny fails closed."""
+    run = case.build()
+
+    # ALLOW: value present, body ran, no error.
+    _executions.clear()
+    allow = run(_ALLOW)
+    assert allow.value == case.expected, f"{case.name}: allowed field should resolve its value"
+    assert allow.body_ran, f"{case.name}: resolver body should run when allowed"
+    assert allow.code is None, f"{case.name}: no authorization error when allowed"
+    if case.expects_warning:
+        assert allow.warned, f"{case.name}: expected the sync-resolver+async-check RuntimeWarning"
+    else:
+        assert not allow.warned, f"{case.name}: unexpected RuntimeWarning"
+
+    # DENY: fail-closed -- the error code is surfaced and the body never runs.
+    _executions.clear()
+    deny = run(_DENY)
+    assert deny.code == "FIELD_AUTHORIZATION_ERROR", f"{case.name}: deny surfaces the field code"
+    assert not deny.body_ran, f"{case.name}: resolver body must NOT run when denied (fail-closed)"
+    assert deny.value is None, f"{case.name}: denied field yields no value"

--- a/tests/unit/security/test_per_operation_override.py
+++ b/tests/unit/security/test_per_operation_override.py
@@ -1,0 +1,142 @@
+"""Per-operation authorizer override (issue #362, phase 3)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from graphql import graphql
+
+import fraiseql
+from fraiseql.gql.builders import SchemaRegistry
+from fraiseql.gql.schema_builder import build_fraiseql_schema
+
+_ran: list[str] = []
+
+
+class Deny:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return False
+
+
+class Allow:
+    async def authorize_operation(self, **_: Any) -> bool:
+        return True
+
+
+@fraiseql.type
+class Widget:
+    id: int
+    name: str
+
+
+# --- mutations with per-operation overrides ---
+
+
+@fraiseql.mutation(authorizer=Deny())
+async def mut_perop_deny(info, name: str) -> Widget:
+    _ran.append("mut_perop_deny")
+    return Widget(id=1, name=name)
+
+
+@fraiseql.mutation(authorizer=Allow())
+async def mut_perop_allow(info, name: str) -> Widget:
+    _ran.append("mut_perop_allow")
+    return Widget(id=1, name=name)
+
+
+@fraiseql.mutation
+async def mut_no_perop(info, name: str) -> Widget:
+    _ran.append("mut_no_perop")
+    return Widget(id=1, name=name)
+
+
+# --- queries with per-operation overrides ---
+
+
+@fraiseql.query(authorizer=Deny())
+async def q_perop_deny(info) -> list[Widget]:
+    _ran.append("q_perop_deny")
+    return []
+
+
+@fraiseql.query
+async def q_no_perop(info) -> list[Widget]:
+    _ran.append("q_no_perop")
+    return []
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry = SchemaRegistry.get_instance()
+    registry.clear()
+    from fraiseql.core.graphql_type import _graphql_type_cache
+
+    _graphql_type_cache.clear()
+    _ran.clear()
+    yield
+    registry.clear()
+    _graphql_type_cache.clear()
+    _ran.clear()
+
+
+async def test_per_op_deny_beats_global_allow() -> None:
+    schema = build_fraiseql_schema(
+        query_types=[Widget, q_no_perop],
+        mutation_resolvers=[mut_perop_deny, mut_no_perop],
+        authorizer=Allow(),
+    )
+    denied = await graphql(schema, 'mutation { mutPeropDeny(name: "x") { id } }')
+    assert denied.errors and denied.errors[0].extensions["code"] == "FORBIDDEN"
+    assert "mut_perop_deny" not in _ran
+
+    allowed = await graphql(schema, 'mutation { mutNoPerop(name: "x") { id } }')
+    assert not allowed.errors
+    assert "mut_no_perop" in _ran
+
+
+async def test_per_op_allow_beats_global_deny() -> None:
+    schema = build_fraiseql_schema(
+        query_types=[Widget, q_no_perop],
+        mutation_resolvers=[mut_perop_allow, mut_no_perop],
+        authorizer=Deny(),
+    )
+    allowed = await graphql(schema, 'mutation { mutPeropAllow(name: "x") { id } }')
+    assert not allowed.errors
+    assert "mut_perop_allow" in _ran
+
+    denied = await graphql(schema, 'mutation { mutNoPerop(name: "x") { id } }')
+    assert denied.errors and denied.errors[0].extensions["code"] == "FORBIDDEN"
+    assert "mut_no_perop" not in _ran
+
+
+async def test_query_per_op_deny_beats_global_allow() -> None:
+    schema = build_fraiseql_schema(
+        query_types=[Widget, q_perop_deny, q_no_perop],
+        authorizer=Allow(),
+    )
+    denied = await graphql(schema, "{ qPeropDeny { id } }")
+    assert denied.errors and denied.errors[0].extensions["code"] == "FORBIDDEN"
+    assert "q_perop_deny" not in _ran
+
+    allowed = await graphql(schema, "{ qNoPerop { id } }")
+    assert not allowed.errors
+    assert "q_no_perop" in _ran
+
+
+def test_bare_query_decorator_still_works() -> None:
+    @fraiseql.query
+    async def bare(info) -> list[Widget]:
+        return []
+
+    assert hasattr(bare, "__fraiseql_authorizer__")
+    assert bare.__fraiseql_authorizer__ is None
+
+
+def test_query_decorator_call_form_still_works() -> None:
+    @fraiseql.query()
+    async def called(info) -> list[Widget]:
+        return []
+
+    assert hasattr(called, "__fraiseql_authorizer__")
+    assert called.__fraiseql_authorizer__ is None

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.22.0"
+version = "1.23.0"
 
 [package.dev-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.23.2"
+version = "1.23.3"
 
 [package.dev-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.23.0"
+version = "1.23.1"
 
 [package.dev-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.23.1"
+version = "1.23.2"
 
 [package.dev-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.23.4"
+version = "1.23.5"
 
 [package.dev-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.23.3"
+version = "1.23.4"
 
 [package.dev-dependencies]
 dev = [


### PR DESCRIPTION
Closes #362. Also lands the operation-authorization follow-ups #364, #365, #366, #367, and
a standalone fix to the `@field` / `@authorize_field` decorator composition surfaced during
the #366 work. Cumulative version: **1.23.5**.

Gives FraiseQL a supported, first-class **Policy Enforcement Point**: the framework
*enforces*, while the *decision* is delegated to an app-supplied `Authorizer` (principal-agnostic
— reads everything from `context`). All of it is **opt-in** — with no `authorizer=` configured,
behavior is byte-for-byte unchanged.

---

## #362 — Operation authorization extension point (core)

- `fraiseql.security.authorization`: `AuthorizationDecision` (frozen `allow`/`deny` +
  `code`/`message`/`filters`), runtime-checkable `Authorizer` protocol, `normalize_decision`.
  Re-exported from `fraiseql` and `fraiseql.security`.
- `create_fraiseql_app(authorizer=...)` / `build_fraiseql_schema(authorizer=...)` install a
  global default on `SchemaRegistry.default_authorizer`; `@query(authorizer=...)` /
  `@mutation(authorizer=...)` per-operation overrides.
- **One fail-closed helper** (`enforce_operation_value`): authorizer raises → deny (never falls
  through to allow); deny → `GraphQLError` with `extensions.code`; the raw exception is logged,
  never surfaced. Sync + async supported.
- Enforced via a **resolver wrap** around every root query/mutation, plus the **three
  resolver-bypass paths** (TurboRouter / persisted queries, `POST /graphql/rust`, APQ cached
  passthrough). **Row-scoping filter injection**: a query authorizer may return `filters`,
  AND-merged into the repository's validated/parameterized `mandatory_filters`.
- Survives schema **hot-reload**. Spec-first: a parametrized cross-path deny-all test enumerates
  every execution path and started all `xfail(strict=True)`, so a new ungated path turns the
  suite red.
- Also fixed a pre-existing null-user crash on `POST /graphql/rust`.

## #364 — Subscription authorization

- Subscriptions are gated at **subscribe-time** with the same fail-closed helper.
- `@subscription(authorizer=...)` per-operation override.

## #365 — `POST /graphql/rust` is now opt-in

- New `FraiseQLConfig.enable_rust_endpoint` flag (default `False`,
  `FRAISEQL_ENABLE_RUST_ENDPOINT`). The Rust passthrough bypasses Python resolvers entirely, so
  the route is mounted **only** when explicitly enabled; otherwise a request 404s. When mounted
  it remains authorization-gated.
- ⚠️ **Behavior change:** apps calling `/graphql/rust` must now set `enable_rust_endpoint=True`.

## #367 — Optional authorization decision caching

- `AuthorizationCacheConfig` + `DecisionCache`: opt-in TTL+LRU memoization, wired via
  `create_fraiseql_app(authorization_cache=...)` and installed on
  `SchemaRegistry.decision_cache`; consulted on every gated path; survives hot-reload.
- **Off by default.** Fail-closed is never cached around (raising authorizer / `None` principal /
  non-JSON-serializable args fall through to evaluate). Correctness contract: enable only if the
  authorizer is a pure function of principal + operation + arguments.

## #366 — Automatic field-level gating (opt-in)

- `@fraise_type(authorize_fields=[...])` gates the listed fields with the configured operation
  `Authorizer` automatically, checked with `operation_type="field"` and
  `operation_name="TypeName.fieldName"` before each field resolver runs — no per-field
  `@authorize_field` needed. Narrow opt-in by design (no gate-everything switch).
- Fail-closed; an explicit `@authorize_field` AND-combines with the automatic gate. Consults the
  #367 decision cache, which collapses per-object call volume on nested lists.

## Standalone fix — `@field` / `@authorize_field` decorator composition

A pre-existing field-resolver defect (surfaced during #366): a field method gated with
`@authorize_field` only worked in **one** decorator order, and the order the docs showed was the
broken one. Now the two decorators compose **in either order, for every method shape**
(`self`, `self, info`, sync or `async`).

- **Root cause was two bugs that only bit together.** (1) The auth wrappers used
  `functools.wraps`, whose `__wrapped__` made `inspect.signature` (and an outer `@field`) read
  the *inner* method's `(self)` signature and call the wrapper with too few arguments. (2) The
  wrappers called their inner resolver with a fixed `(root, info, ...)` shape.
- **Fix (chosen long-term design):** a single shared `invoke_resolver` convention
  (`fraiseql.core.resolver_invocation`) is now the source of truth for how `@field` **and**
  `@authorize_field` call what they wrap — it inspects the *target itself*, never
  `__fraiseql_original_func__`. Auth wrappers are now signature-faithful (manual metadata copy,
  no `__wrapped__`).
- **Async authorizer + sync resolver no longer warns or risks deadlock:** the wrapper is async
  end-to-end whenever the resolver *or* the check is async, removing the
  `run_until_complete`/`run_coroutine_threadsafe` bridge. Since `field_authorizer_adapter` is
  async, the natural sync `def` field form is now warning-free.
- Pinned by an 8-row characterization matrix (decorator order × method shape × check kind, sync
  and async) plus a running-event-loop regression. Fail-closed holds on every deny cell.

## Verification

- `ruff check src/` + `ruff format --check src/` clean.
- Field-auth composition matrix: **8/8 + running-loop test**, no xfails, no `RuntimeWarning`
  (asserted under `-W error::RuntimeWarning`).
- `tests/unit tests/integration tests/regression`: **6153 passed, 24 skipped** (DB-only;
  PostgreSQL not available in this environment — those skip the same way on baseline), 0 failed,
  0 xfailed.
- Per-issue suites (#362 cross-path spec, #364 subscriptions, #365 rust opt-in, #366 auto-gate,
  #367 cache) all green.
- Docs: `docs/security/authorization.md` + `examples/authorization/`. CHANGELOG entries through
  **1.23.5**.

## Notes

- The decision contract is intentionally identical to the v2 (Rust) counterpart (#422).
- The field-auth fix changes `__wrapped__` on auth wrappers: external tooling that followed it
  now sees the wrapper's real `(root, info, *args, **kwargs)` signature instead of the inner
  method's (noted in the CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
