### PR TITLE
fix(types): restore @dataclass_transform in __init__.pyi stub (#370)

### DIFF
--- a/src/fraiseql/__init__.pyi
+++ b/src/fraiseql/__init__.pyi
@@ -1,11 +1,28 @@
-from typing import Any, Callable, Type, TypeVar, overload
+from typing import Any, Callable, Type, TypeVar, dataclass_transform, overload
 
 from .mutations.error_config import MutationErrorConfig as MutationErrorConfig
 
 _T = TypeVar("_T")
 _F = TypeVar("_F", bound=Callable[..., Any])
 
+# Helper function for fields — declared up here so the `field_specifiers` of the
+# `@dataclass_transform` decorators below can reference it.
+def fraise_field(
+    *,
+    description: str | None = None,
+    alias: str | None = None,
+    deprecation_reason: str | None = None,
+    default: Any = ...,
+) -> Any: ...
+
 # Core type decorators
+#
+# `@dataclass_transform` mirrors the runtime decorators (fraiseql/types/fraise_type.py
+# etc.): it tells type checkers that the decorated class gains a dataclass-style
+# `__init__` synthesised from its annotated fields. Without it this stub shadows the
+# runtime annotation and every `@fraiseql.type(...)` construction is reported as
+# `unknown-argument` (the constructor resolves to `object.__init__`).
+@dataclass_transform(kw_only_default=True, field_specifiers=(fraise_field,))
 @overload
 def fraise_type_decorator(cls: Type[_T]) -> Type[_T]: ...
 @overload
@@ -26,6 +43,7 @@ def fraise_type_decorator(
     resolve_nested: bool = False,
     authorize_fields: list[str] | None = None,
 ) -> Type[_T] | Callable[[Type[_T]], Type[_T]]: ...
+@dataclass_transform(kw_only_default=True, field_specifiers=(fraise_field,))
 @overload
 def fraise_input_decorator(cls: Type[_T]) -> Type[_T]: ...
 @overload
@@ -38,10 +56,13 @@ def fraise_input_decorator(
     *,
     description: str | None = None,
 ) -> Type[_T] | Callable[[Type[_T]], Type[_T]]: ...
+@dataclass_transform(kw_only_default=True, field_specifiers=(fraise_field,))
 def success(cls: Type[_T]) -> Type[_T]: ...
+@dataclass_transform(kw_only_default=True, field_specifiers=(fraise_field,))
 def error(cls: Type[_T]) -> Type[_T]: ...
 def result(cls: Type[_T]) -> Type[_T]: ...
 def enum(cls: Type[_T]) -> Type[_T]: ...
+@dataclass_transform(kw_only_default=True, field_specifiers=(fraise_field,))
 def interface(cls: Type[_T]) -> Type[_T]: ...
 
 # Query decorator
@@ -83,14 +104,29 @@ def dataloader_field(
     description: str | None = None,
 ) -> _F | Callable[[_F], _F]: ...
 
-# Mutation decorator
+# Mutation decorator — keep in sync with fraiseql/mutations/mutation_decorator.py.
+@overload
+def mutation(_cls: Type[_T]) -> Type[_T]: ...
+@overload
 def mutation(
     *,
     function: str | None = None,
-    schema: str = "graphql",
+    schema: str | None = None,
     context_params: dict[str, str] | None = None,
     error_config: MutationErrorConfig | None = None,
+    enable_cascade: bool = False,
+    authorizer: Any | None = None,
 ) -> Callable[[Type[_T]], Type[_T]]: ...
+def mutation(
+    _cls: Type[_T] | None = None,
+    *,
+    function: str | None = None,
+    schema: str | None = None,
+    context_params: dict[str, str] | None = None,
+    error_config: MutationErrorConfig | None = None,
+    enable_cascade: bool = False,
+    authorizer: Any | None = None,
+) -> Type[_T] | Callable[[Type[_T]], Type[_T]]: ...
 
 # Subscription decorator
 @overload
@@ -98,15 +134,6 @@ def subscription(func: _F) -> _F: ...
 @overload
 def subscription() -> Callable[[_F], _F]: ...
 def subscription(func: _F | None = None) -> _F | Callable[[_F], _F]: ...
-
-# Helper function for fields
-def fraise_field(
-    *,
-    description: str | None = None,
-    alias: str | None = None,
-    deprecation_reason: str | None = None,
-    default: Any = ...,
-) -> Any: ...
 
 # Scalar field types
 class Date:

--- a/tests/regression/test_issue_370_stub_dataclass_transform.py
+++ b/tests/regression/test_issue_370_stub_dataclass_transform.py
@@ -1,0 +1,105 @@
+"""Regression test for issue #370: type stub drops ``@dataclass_transform``.
+
+The hand-written ``src/fraiseql/__init__.pyi`` shadows the runtime decorators for
+every *external* consumer of fraiseql. fraiseql's own type-check (pyright/ty) only
+reads the ``.py`` sources, so a stub that omits ``@dataclass_transform`` type-checks
+clean here while breaking downstream: ``@fraiseql.type`` classes lose their
+synthesised ``__init__`` and every keyword construction is flagged ``unknown-argument``.
+
+This guards against silent re-drift by asserting, structurally, that the stub keeps
+``@dataclass_transform`` on the field-bearing decorators and that ``mutation()`` stays
+in sync with the runtime signature.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import fraiseql
+
+pytestmark = pytest.mark.regression
+
+# Decorators whose runtime counterparts use @dataclass_transform and whose decorated
+# classes are constructed by consumers with keyword arguments.
+TRANSFORM_DECORATORS = {
+    "fraise_type_decorator",
+    "fraise_input_decorator",
+    "success",
+    "error",
+    "interface",
+}
+# enum (not a dataclass) and result (a factory, not a class decorator) must NOT carry it.
+NON_TRANSFORM_DECORATORS = {"enum", "result"}
+
+REQUIRED_MUTATION_KWARGS = {
+    "function",
+    "schema",
+    "context_params",
+    "error_config",
+    "enable_cascade",
+    "authorizer",
+}
+
+
+def _load_stub() -> ast.Module:
+    stub = Path(fraiseql.__file__).with_name("__init__.pyi")
+    assert stub.exists(), f"type stub not found next to package: {stub}"
+    return ast.parse(stub.read_text())
+
+
+def _functions(tree: ast.Module, name: str) -> list[ast.FunctionDef]:
+    return [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == name]
+
+
+def _dataclass_transform_call(node: ast.FunctionDef) -> ast.Call | None:
+    for dec in node.decorator_list:
+        func = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(func, ast.Name) and func.id == "dataclass_transform":
+            return dec if isinstance(dec, ast.Call) else None
+    return None
+
+
+def _has_dataclass_transform(node: ast.FunctionDef) -> bool:
+    for dec in node.decorator_list:
+        func = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(func, ast.Name) and func.id == "dataclass_transform":
+            return True
+    return False
+
+
+class TestStubDataclassTransform:
+    """The stub must model fraiseql's dataclass-style, keyword-only constructors."""
+
+    @pytest.mark.parametrize("name", sorted(TRANSFORM_DECORATORS))
+    def test_field_bearing_decorators_carry_dataclass_transform(self, name: str) -> None:
+        nodes = _functions(_load_stub(), name)
+        assert nodes, f"decorator {name!r} not found in stub"
+        assert any(_has_dataclass_transform(n) for n in nodes), (
+            f"stub decorator {name!r} is missing @dataclass_transform"
+        )
+
+    @pytest.mark.parametrize("name", sorted(TRANSFORM_DECORATORS))
+    def test_kw_only_default_is_true(self, name: str) -> None:
+        # Runtime generates a keyword-only __init__ (constructor.py: kw_only=True).
+        for node in _functions(_load_stub(), name):
+            call = _dataclass_transform_call(node)
+            if call is None:
+                continue
+            kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg}
+            value = kwargs.get("kw_only_default")
+            assert isinstance(value, ast.Constant), f"{name}: kw_only_default must be set"
+            assert value.value is True, f"{name}: kw_only_default must be True"
+
+    @pytest.mark.parametrize("name", sorted(NON_TRANSFORM_DECORATORS))
+    def test_non_field_decorators_are_not_transformed(self, name: str) -> None:
+        for node in _functions(_load_stub(), name):
+            assert not _has_dataclass_transform(node), f"{name} must not carry @dataclass_transform"
+
+    def test_mutation_signature_in_sync_with_runtime(self) -> None:
+        # mutation() must expose every runtime keyword, else @mutation(...) calls error.
+        seen: set[str] = set()
+        for node in _functions(_load_stub(), "mutation"):
+            seen |= {arg.arg for arg in node.args.kwonlyargs}
+        missing = REQUIRED_MUTATION_KWARGS - seen
+        assert not missing, f"stub mutation() missing keyword params: {sorted(missing)}"


### PR DESCRIPTION
Fixes #370.

## Problem

The hand-written stub `src/fraiseql/__init__.pyi` shadows the runtime decorators for every **external** consumer, but it re-declares the core type decorators **without** `@dataclass_transform`. So ty / mypy / pyright resolve every `@fraiseql.type` (and `@input`/`@success`/`@error`/`@interface`) class `__init__` to `object.__init__()` and flag every keyword construction as `unknown-argument`.

The runtime decorators (`types/fraise_type.py`, `fraise_input.py`, `interface.py`, `mutations/decorators.py`) are annotated correctly — but a `.pyi` shadows the `.py` for importers, and fraiseql's own type-check only ever reads the `.py`, so this drift was invisible internally while breaking downstream.

## Fix

- `@dataclass_transform(kw_only_default=True, field_specifiers=(fraise_field,))` on `type`/`input`/`success`/`error`/`interface`. `kw_only_default=True` matches the runtime's keyword-only `__init__` (`constructor.py`: `make_init(..., kw_only=True)`) and avoids spurious `dataclass-field-order` diagnostics. `result` (a factory) and `enum` are intentionally left untransformed.
- `mutation()` synced with the runtime signature: adds `enable_cascade`, `authorizer`, `schema: str | None`, and a bare-`@mutation` overload.
- A structural regression test (`tests/regression/test_issue_370_stub_dataclass_transform.py`) — since the stub is never read by our own type-check, it can silently re-drift; this guards the invariant.

## Impact (measured)

`ty 0.0.27` over a real 1.23.6 consumer (`ty check src/`):

| | total | `unknown-argument` |
|---|---|---|
| before | 436 | 216 |
| after | 228 | 6 |

**208 false diagnostics removed** — the single biggest blocker to adopting a type-check gate for fraiseql consumers. (The remaining `unknown-argument` are genuine bugs in that consumer's own code.)

## Out of scope (noted in #370)

Dynamically-created where-input types (`X = create_graphql_where_input(Model)` used as `where: X | None`) still trip `invalid-type-form`; that needs an API typing redesign and is tracked separately.