### PR TITLE
ci: bump actions/setup-python v5 → v6 (Node 24)

### DIFF
--- a/.github/workflows/chaos-engineering-tests.yml
+++ b/.github/workflows/chaos-engineering-tests.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -44,7 +44,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -64,7 +64,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -100,7 +100,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -160,7 +160,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 
@@ -244,7 +244,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 


### PR DESCRIPTION
## Why

`actions/setup-python@v5` runs on **Node.js 20**, which GitHub is deprecating on its runners (forced to Node 24 starting **2026-06-16**, removed 2026-09-16). The `v1.23.8` release run surfaced the deprecation annotation:

> Node.js 20 actions are deprecated. … `actions/setup-python@v5` …

## Change

Bump `actions/setup-python@v5 → @v6` (v6 runs on Node 24). All **13 occurrences** across 6 workflows:

| Workflow | Occurrences |
|---|---|
| `ci.yml` | 4 |
| `docs-validation.yml` | 3 |
| `release.yml` | 2 |
| `security-compliance.yml` | 2 |
| `chaos-engineering-tests.yml` | 1 |
| `docs.yml` | 1 |

No input changes affect our usages (we only pass `python-version`). Scoped to this one action — every other action pin (`checkout@v6`, `upload-artifact@v7`, `setup-uv@v7`, `download-artifact@v7`, `cache@v5`, `github-script@v8`, …) already runs on Node 24.

## Verification
- ✅ `grep` confirms zero remaining `actions/setup-python@v5`; all 13 now `@v6`.
- ✅ Diff is workflow-YAML-only (13 insertions / 13 deletions).
- ✅ pre-commit YAML checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)