### PR TITLE
chore(deps): bump rust crates (thiserror 2, http 1.4, rand 0.10, sha2 0.11, lru 0.18)

### DIFF
--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -42,27 +42,27 @@ deadpool-postgres = "0.14"
 # GraphQL parsing (Phase 6)
 graphql-parser = "0.4"
 hex = "0.4"  # Hex encoding for tokens
-http = "0.2"  # HTTP header types for CORS
+http = "1.4"  # HTTP header types for CORS
 itertools = "0.12"  # String utilities
 # Authentication (Phase 10)
 jsonwebtoken = "10.3"  # JWT validation with built-in JWK support. Updated from 9.2 to fix CVE-2026-25537 (type confusion/auth bypass)
 lazy_static = "1.4"  # Static regex
 linked-hash-map = "0.5"  # For LRU implementation
 # Query caching (Phase 8)
-lru = "0.16"  # LRU cache
+lru = "0.18"  # LRU cache
 once_cell = "1.0"
 pyo3 = {version = "0.29.0", features = ["extension-module", "experimental-async"]}
 pyo3-async-runtimes = {version = "0.29", features = ["tokio-runtime"]}
 # Security features (Phase 12)
-rand = "0.8"  # Random number generation for CSRF
+rand = "0.10"  # Random number generation for CSRF
 # Query building (Phase 7)
 regex = "1.10"  # Field name transformations
 reqwest = {version = "0.11", features = ["json"]}  # JWKS fetching
 # JSON parsing and serialization (zero-copy where possible)
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-sha2 = "0.10"  # Hashing for signatures
-thiserror = "1.0"
+sha2 = "0.11"  # Hashing for signatures
+thiserror = "2.0"
 tokio = {version = "1.35", features = ["full"]}  # Async runtime
 # PostgreSQL client and connection pooling (Phase 1)
 tokio-postgres = {version = "0.7", features = ["with-serde_json-1", "with-uuid-1", "with-chrono-0_4"]}

--- a/fraiseql_rs/src/auth/cache.rs
+++ b/fraiseql_rs/src/auth/cache.rs
@@ -73,7 +73,7 @@ impl UserContextCache {
     fn hash_token(token: &str) -> String {
         let mut hasher = Sha256::new();
         hasher.update(token.as_bytes());
-        format!("{:x}", hasher.finalize())
+        hex::encode(hasher.finalize())
     }
 }
 

--- a/fraiseql_rs/src/cache/signature.rs
+++ b/fraiseql_rs/src/cache/signature.rs
@@ -14,7 +14,7 @@ pub fn generate_signature(parsed_query: &ParsedQuery) -> String {
     hasher.update(&structure);
     let hash = hasher.finalize();
 
-    format!("{:x}", hash)
+    hex::encode(hash)
 }
 
 /// Build structural representation (variables → placeholders).

--- a/fraiseql_rs/src/security/csrf.rs
+++ b/fraiseql_rs/src/security/csrf.rs
@@ -1,6 +1,6 @@
 //! CSRF token validation.
 
-use rand::Rng;
+use rand::RngExt;
 use sha2::{Digest, Sha256};
 
 use super::errors::{Result, SecurityError};
@@ -17,7 +17,7 @@ impl CSRFManager {
 
     /// Generate CSRF token for session
     pub fn generate_token(&self, session_id: &str) -> String {
-        let nonce: [u8; 32] = rand::thread_rng().gen();
+        let nonce: [u8; 32] = rand::rng().random();
         let payload = format!("{}:{}", session_id, hex::encode(nonce));
 
         let mut hasher = Sha256::new();


### PR DESCRIPTION
Adopts the 5 cargo Dependabot bumps (#382–#386) surfaced once the `cargo` ecosystem was added in #380. **No security advisories** — routine maintenance, bundled into one migrated PR (Dependabot's individual PRs would each conflict on `Cargo.toml` and need the same migration).

## API migrations
- **rand 0.8 → 0.10** — `thread_rng().gen()` → `rng().random()`, and `use rand::Rng` → `use rand::RngExt` (`random()` moved traits). `security/csrf.rs`
- **sha2 0.10 → 0.11** (digest 0.11) — the hash output no longer implements `LowerHex`, so `format!("{:x}", h)` → `hex::encode(h)` (matches the existing pattern in `csrf.rs`). `auth/cache.rs`, `cache/signature.rs`
- **thiserror 1 → 2**, **http 0.2 → 1.4**, **lru 0.16 → 0.18** — drop-in, no source changes

## Verification
- ✅ `cargo clippy --all-features -- -D warnings`: clean (the CI gate)
- ✅ extension builds (`maturin develop`)
- ✅ 245 Rust-path tests pass (rust extension, rust auth, security incl. CSRF token gen + hashing)

Supersedes #382, #383, #384, #385, #386.

> `Cargo.lock` is gitignored; versions are pinned via `Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)