### PR TITLE
fix(aggregation): honor lte/lt upper bound in partial-period rewrite + release v1.23.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.11] - 2026-06-14
+
+### Fixed
+
+- **Partial-period aggregation now honors the `lte`/`lt` upper bound.** When a
+  type is registered with `fine_grain_view` partial-period awareness
+  (`time_grain_column` / `time_grain_trunc`), a `where` date range with both
+  `gte` and `lte` previously applied only the lower bound — the upper bound was
+  silently dropped and the query returned every period from `gte` through the
+  current period (including future periods). The UNION rewrite now threads the
+  upper bound through and clamps the upper edge symmetrically to the lower edge:
+  a period that straddles `lte` is recomputed from the fine-grain view over
+  `[period_start … lte]` rather than returned as a full-period aggregate. This
+  fix also removes a latent double-count where a non-aligned `gte` inside the
+  current period emitted overlapping fine-grain branches.
+
 ## [1.23.10] - 2026-06-13
 
 ### Security

--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -153,7 +153,7 @@ name = "fraiseql_rs"
 publish = false
 readme = "README.md"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "1.23.10"
+version = "1.23.11"
 
 # Benchmark profile for accurate measurements
 [profile.bench]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.23.10"
+version = "1.23.11"
 
 [project.optional-dependencies]
 all = [

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -569,19 +569,30 @@ def _build_partial_period_union_query(
     native_dimension_mapping: dict[str, str] | None,
     jsonb_col: str,
     extra_where: Any | None,  # WhereClause | None
+    upper_bound_exclusive: Any | None = None,  # date | None (exclusive)
     today: Any | None = None,  # date | None
 ) -> "DatabaseQuery":
-    """Build a three-branch UNION ALL query for partial-period awareness.
+    """Build a UNION ALL query for partial-period awareness.
 
-    When a date filter on a coarse-grain (pre-aggregated) view falls in the
-    middle of a period, this builder generates up to three branches:
+    A date filter on a coarse-grain (pre-aggregated) view may straddle a period
+    boundary at either edge of the requested window.  This builder partitions
+    the half-open window ``[lower_bound, upper)`` into up to three contiguous,
+    non-overlapping segments and reads each from the appropriate view:
 
-      - Branch 1 (partial first period): fine-grain rows from lower_bound to
-        the end of its period (omitted when lower_bound is period-aligned).
-      - Branch 2 (complete periods): coarse-grain rows for full periods between
-        the partial period and the current period.
-      - Branch 3 (current in-progress period): always fine-grain rows for the
-        current period up to today.
+      - Leading partial period (fine-grain): the portion of the first period
+        below ``lower_bound``'s period boundary, present only when
+        ``lower_bound`` is not period-aligned.
+      - Complete periods (coarse-grain): whole periods that fall entirely inside
+        the window and have already ended (strictly before the current period).
+      - Upper-edge / current period (fine-grain): the trailing partial period
+        that straddles the upper bound, and/or the current in-progress period,
+        recomputed from the fine-grain view.
+
+    The effective exclusive upper bound is ``upper_bound_exclusive`` when
+    supplied, capped at ``today + 1 day`` (no data exists beyond today, and the
+    coarse view's "complete period" guarantee only holds for periods before the
+    current one).  When ``upper_bound_exclusive`` is None the window runs through
+    today, preserving the original behaviour.
 
     All date values are embedded as SQL Literals, so the returned statement
     can be rendered via ``as_string(None)`` in tests without a connection.
@@ -592,7 +603,7 @@ def _build_partial_period_union_query(
         time_grain_column:       SQL column holding the period date (e.g. "date").
         time_grain_trunc:        One of "day", "week", "half_month", "month",
                                  "quarter", "semester", "year".
-        lower_bound:             Effective lower-bound date extracted from the query.
+        lower_bound:             Effective inclusive lower-bound date.
         group_by:                Dimension field paths for GROUP BY.
         aggregations:            Map of measure alias → aggregation expression.
         native_dimensions:       Set of group_by fields that are native SQL columns.
@@ -601,6 +612,8 @@ def _build_partial_period_union_query(
         jsonb_col:               JSONB column name for JSONB extraction.
         extra_where:             Additional WhereClause conditions (no date filter).
                                  Pass None when there are no extra conditions.
+        upper_bound_exclusive:   Effective exclusive upper-bound date, or None to
+                                 run through today.
         today:                   Override today's date (for deterministic testing).
                                  Defaults to ``date.today()``.
 
@@ -620,17 +633,48 @@ def _build_partial_period_union_query(
     if today is None:
         today = datetime.now(tz=UTC).date()
 
-    aligned = _is_period_aligned(lower_bound, time_grain_trunc)
-    next_ps = _next_period_start(lower_bound, time_grain_trunc)
+    # Exclusive "tomorrow" makes "date < today_exclusive" ≡ "date <= today".
+    today_exclusive = today + timedelta(days=1)
     current_ps = _period_start(today, time_grain_trunc)
 
-    # Branch 2 starts at lower_bound when aligned, else at next_ps
-    b2_start = lower_bound if aligned else next_ps
-    # Branch 2 is only useful when there are complete periods before the current period
-    include_b2 = b2_start < current_ps
+    lo = lower_bound
+    # Effective exclusive upper bound of the window, capped at today_exclusive:
+    # no data exists beyond today, and coarse rows are only reliable before the
+    # current period (handled via coarse_end below).
+    if upper_bound_exclusive is None:
+        hi = today_exclusive
+    else:
+        hi = min(upper_bound_exclusive, today_exclusive)
 
-    # Branch 3 upper bound: exclusive tomorrow makes "date < tomorrow" equivalent to "date <= today"
-    today_exclusive = today + timedelta(days=1)
+    # Lower edge: coarse data can start at the lower bound when it is
+    # period-aligned; otherwise the leading partial period is recomputed from
+    # the fine-grain view up to the next period start.
+    if _is_period_aligned(lo, time_grain_trunc):
+        coarse_start = lo
+    else:
+        coarse_start = _next_period_start(lo, time_grain_trunc)
+
+    # Upper edge: when the window ends exactly on a period boundary the final
+    # period is complete (coarse-safe); otherwise it straddles the upper bound
+    # and must be recomputed from the fine-grain view.
+    if _is_period_aligned(hi, time_grain_trunc):
+        upper_coarse_end = hi
+    else:
+        upper_coarse_end = _period_start(hi - timedelta(days=1), time_grain_trunc)
+
+    # Coarse rows are only reliable for periods strictly before the current one.
+    coarse_end = min(upper_coarse_end, current_ps)
+
+    # Partition [lo, hi) into at most three contiguous, non-overlapping segments:
+    #   [p0, p1) fine-grain leading partial period
+    #   [p1, p2) coarse-grain complete periods
+    #   [p2, p3) fine-grain upper-edge / current in-progress period
+    # Clamping keeps the cut points ordered (p0 ≤ p1 ≤ p2 ≤ p3) even for tiny
+    # windows that fall inside a single period.
+    p0 = lo
+    p1 = min(max(coarse_start, p0), hi)
+    p2 = min(max(coarse_end, p1), hi)
+    p3 = hi
 
     # Build extra_where SQL once (used in all branches)
     extra_where_sql = None
@@ -655,50 +699,43 @@ def _build_partial_period_union_query(
     branches: list[Any] = []
     all_params: list[Any] = []
 
-    # Branch 1: partial first period (only when not aligned)
-    if not aligned:
-        b1_sql, b1_params = _build_fine_grain_branch(
+    def _add_fine(date_gte: Any, date_lt: Any) -> None:
+        branch_sql, branch_params = _build_fine_grain_branch(
             fine_grain_view=fine_grain_view,
             time_grain_trunc=time_grain_trunc,
-            date_gte=lower_bound,
-            date_lt=next_ps,
+            date_gte=date_gte,
+            date_lt=date_lt,
             **common,
         )
-        branches.append(b1_sql)
-        all_params.extend(b1_params)
+        branches.append(branch_sql)
+        all_params.extend(branch_params)
         all_params.extend(extra_where_params)
 
-    # Branch 2: complete coarse-grain periods
-    if include_b2:
-        b2_sql, b2_params = _build_coarse_branch(
+    def _add_coarse(date_gte: Any, date_lt: Any) -> None:
+        branch_sql, branch_params = _build_coarse_branch(
             coarse_view=coarse_view,
-            date_gte=b2_start,
-            date_lt=current_ps,
+            date_gte=date_gte,
+            date_lt=date_lt,
             **common,
         )
-        branches.append(b2_sql)
-        all_params.extend(b2_params)
+        branches.append(branch_sql)
+        all_params.extend(branch_params)
         all_params.extend(extra_where_params)
 
-    # Branch 3: current in-progress period (always fine-grain)
-    # Use today_exclusive (= today + 1 day) so "date < today_exclusive" ≡ "date <= today"
-    b3_sql, b3_params = _build_fine_grain_branch(
-        fine_grain_view=fine_grain_view,
-        time_grain_trunc=time_grain_trunc,
-        date_gte=current_ps,
-        date_lt=today_exclusive,
-        time_grain_column=time_grain_column,
-        group_by=group_by,
-        aggregations=aggregations,
-        native_dimensions=native_dimensions,
-        native_measures=native_measures,
-        native_dimension_mapping=native_dimension_mapping,
-        jsonb_col=jsonb_col,
-        extra_where_sql=extra_where_sql,
-    )
-    branches.append(b3_sql)
-    all_params.extend(b3_params)
-    all_params.extend(extra_where_params)
+    # Branch 1: fine-grain leading partial period
+    if p1 > p0:
+        _add_fine(p0, p1)
+    # Branch 2: coarse-grain complete periods
+    if p2 > p1:
+        _add_coarse(p1, p2)
+    # Branch 3: fine-grain upper-edge / current in-progress period
+    if p3 > p2:
+        _add_fine(p2, p3)
+
+    # Degenerate window (hi ≤ lo): emit a single empty fine-grain branch so the
+    # statement stays valid and simply returns no rows.
+    if not branches:
+        _add_fine(lo, lo)
 
     # Join branches with UNION ALL and add ORDER BY 1
     if len(branches) == 1:
@@ -1400,6 +1437,7 @@ class FraiseQLRepository:
         # lower bound, route through _build_partial_period_union_query instead of
         # the standard _build_find_query.
         use_union_all = False
+        upper_bound_exclusive = None
         if kwargs.get("group_by") and view_name in _table_metadata:
             agg_meta = _table_metadata[view_name].get("aggregation") or {}
             fine_grain_view = agg_meta.get("fine_grain_view")
@@ -1417,13 +1455,21 @@ class FraiseQLRepository:
                         where_clause_for_pp = self._normalize_where(
                             where_obj, view_name, table_columns
                         )
-                        from fraiseql.partial_period import _extract_lower_date_bound
+                        from fraiseql.partial_period import (
+                            _extract_lower_date_bound,
+                            _extract_upper_date_bound,
+                        )
 
                         lower_bound = _extract_lower_date_bound(
                             where_clause_for_pp, time_grain_column
                         )
                         if lower_bound is not None:
                             use_union_all = True
+                            # Honour the upper bound (lte/lt) symmetrically so a
+                            # bounded range does not run through to today (#341).
+                            upper_bound_exclusive = _extract_upper_date_bound(
+                                where_clause_for_pp, time_grain_column
+                            )
                     except Exception:
                         pass
 
@@ -1482,6 +1528,7 @@ class FraiseQLRepository:
                 native_dimension_mapping=union_native_dim_mapping,
                 jsonb_col=union_jsonb_col,
                 extra_where=extra_where,
+                upper_bound_exclusive=upper_bound_exclusive,
             )
         else:
             # Inject mandatory conditions for _build_where_clause consumption (#344)

--- a/src/fraiseql/partial_period.py
+++ b/src/fraiseql/partial_period.py
@@ -201,3 +201,51 @@ def _extract_lower_date_bound(
         return value
 
     return None
+
+
+def _extract_upper_date_bound(
+    where_clause: "WhereClause",
+    column: str,
+) -> date | None:
+    """Extract the effective *exclusive* upper-bound date from a WhereClause.
+
+    Scans *where_clause.conditions* for the first ``lte`` or ``lt`` condition
+    whose ``target_column`` matches *column*.  The result is always an
+    **exclusive** upper bound (``date < result``), which keeps the boundary
+    arithmetic in the partial-period union builder uniform with the half-open
+    intervals it generates:
+
+      - For ``lte`` (``date <= '2024-06-30'``): returns ``'2024-07-01'`` (value
+        incremented by one day, because ``<=`` on a DATE column is equivalent to
+        ``<`` the following day).
+      - For ``lt``  (``date <  '2024-07-01'``): returns ``'2024-07-01'`` unchanged.
+      - ``None`` if no matching condition is found.
+
+    Only top-level conditions are scanned (nested_clauses are ignored), mirroring
+    :func:`_extract_lower_date_bound`.
+
+    Args:
+        where_clause: The normalised WHERE clause to scan.
+        column:       The database column name to match (e.g. ``"date"``).
+
+    Returns:
+        The effective exclusive upper-bound date, or None.
+    """
+    for cond in where_clause.conditions:
+        if cond.target_column != column:
+            continue
+        if cond.operator not in ("lte", "lt"):
+            continue
+
+        value = cond.value
+        # Accept both date objects and ISO strings
+        if isinstance(value, str):
+            value = date.fromisoformat(value)
+        if not isinstance(value, date):
+            continue
+
+        if cond.operator == "lte":
+            value = value + timedelta(days=1)
+        return value
+
+    return None

--- a/tests/regression/issue_341/test_partial_period_upper_bound.py
+++ b/tests/regression/issue_341/test_partial_period_upper_bound.py
@@ -1,0 +1,140 @@
+"""Regression tests: partial-period UNION builder honours the upper bound.
+
+Bug: when a coarse view is registered with ``fine_grain_view`` partial-period
+awareness, a ``where`` date range with both ``gte`` and ``lte`` applied only the
+``gte`` lower bound. The ``lte`` upper bound was silently dropped, so the query
+returned every period from ``gte`` through *today* (including future periods).
+
+These tests pin the symmetric upper-edge behaviour:
+  - an aligned upper bound (period end) limits coarse rows to the requested window;
+  - a straddling upper bound recomputes the final period from the fine-grain view;
+  - an upper bound in the future is capped at today (no future periods);
+  - omitting the upper bound preserves the original "up to today" behaviour.
+"""
+
+from datetime import date
+
+from fraiseql.db import _build_partial_period_union_query
+
+# A fixed "today" well after the test windows so the current-period logic does
+# not interfere with the historical-window assertions.
+TODAY = date(2026, 6, 14)
+
+BASE = dict(
+    coarse_view="v_events_month",
+    fine_grain_view="v_events_day",
+    time_grain_column="date",
+    time_grain_trunc="month",
+    group_by=["date"],
+    aggregations={"data.volume": "SUM(data.volume)"},
+    native_dimensions={"date"},
+    native_measures={"data.volume": "volume"},
+    native_dimension_mapping=None,
+    jsonb_col="data",
+    extra_where=None,
+)
+
+
+def _render(**overrides: object) -> str:
+    query = _build_partial_period_union_query(**{**BASE, **overrides})
+    return query.statement.as_string(None)
+
+
+def test_aligned_lte_limits_to_coarse_window() -> None:
+    """Range gte 2024-05-01, lte 2024-06-30 → only May & June from the coarse view."""
+    rendered = _render(
+        lower_bound=date(2024, 5, 1),
+        upper_bound_exclusive=date(2024, 7, 1),  # lte 2024-06-30 → exclusive 07-01
+        today=TODAY,
+    )
+    # Both edges aligned → a single coarse branch, no fine-grain recompute.
+    assert "UNION ALL" not in rendered
+    assert "v_events_month" in rendered
+    assert "v_events_day" not in rendered
+    # Window is [2024-05-01, 2024-07-01); must not run through to today.
+    assert "2024-07-01" in rendered
+    assert "2026" not in rendered
+
+
+def test_straddling_lte_recomputes_upper_period_from_fine_grain() -> None:
+    """Range gte 2024-05-01, lte 2024-06-15 → full May (coarse) + partial June (fine)."""
+    rendered = _render(
+        lower_bound=date(2024, 5, 1),
+        upper_bound_exclusive=date(2024, 6, 16),  # lte 2024-06-15 → exclusive 06-16
+        today=TODAY,
+    )
+    assert rendered.count("UNION ALL") == 1
+    assert "v_events_month" in rendered  # full May
+    assert "v_events_day" in rendered  # clamped June
+    # The fine-grain branch is bounded by the (exclusive) upper bound.
+    assert "2024-06-16" in rendered
+    assert "2026" not in rendered
+
+
+def test_non_aligned_lower_and_upper() -> None:
+    """Range gte 2024-05-15, lte 2024-06-30 → partial May (fine) + full June (coarse)."""
+    rendered = _render(
+        lower_bound=date(2024, 5, 15),
+        upper_bound_exclusive=date(2024, 7, 1),
+        today=TODAY,
+    )
+    assert rendered.count("UNION ALL") == 1
+    assert "v_events_day" in rendered  # partial leading May
+    assert "v_events_month" in rendered  # full June
+    assert "2024-05-15" in rendered
+    assert "2024-07-01" in rendered
+    assert "2026" not in rendered
+
+
+def test_single_period_both_edges_partial() -> None:
+    """A window inside one period is fully recomputed from the fine-grain view."""
+    rendered = _render(
+        lower_bound=date(2024, 6, 10),
+        upper_bound_exclusive=date(2024, 6, 21),  # lte 2024-06-20
+        today=TODAY,
+    )
+    assert "UNION ALL" not in rendered
+    assert "v_events_day" in rendered
+    assert "v_events_month" not in rendered
+    assert "2024-06-10" in rendered
+    assert "2024-06-21" in rendered
+
+
+def test_future_lte_capped_at_today() -> None:
+    """An lte beyond today never produces future periods (capped at today)."""
+    rendered = _render(
+        lower_bound=date(2026, 1, 1),
+        upper_bound_exclusive=date(2027, 1, 1),  # lte 2026-12-31
+        today=TODAY,
+    )
+    # Jan–May complete (coarse) + current June up to today (fine); nothing in 2027.
+    assert "v_events_month" in rendered
+    assert "v_events_day" in rendered
+    assert "2027" not in rendered
+    # Current in-progress period bounded by today_exclusive (2026-06-15).
+    assert "2026-06-15" in rendered
+
+
+def test_no_upper_bound_runs_through_today() -> None:
+    """Omitting the upper bound preserves the original 'up to today' behaviour."""
+    rendered = _render(
+        lower_bound=date(2026, 1, 1),
+        upper_bound_exclusive=None,
+        today=TODAY,
+    )
+    assert "v_events_month" in rendered
+    assert "v_events_day" in rendered
+    # Branch 3 runs to today_exclusive = 2026-06-15.
+    assert "2026-06-15" in rendered
+
+
+def test_degenerate_window_returns_empty_branch() -> None:
+    """An upper bound at/below the lower bound yields a single empty fine branch."""
+    rendered = _render(
+        lower_bound=date(2024, 6, 10),
+        upper_bound_exclusive=date(2024, 6, 10),
+        today=TODAY,
+    )
+    assert "UNION ALL" not in rendered
+    assert "v_events_day" in rendered
+    assert "v_events_month" not in rendered

--- a/tests/unit/test_partial_period_detection.py
+++ b/tests/unit/test_partial_period_detection.py
@@ -12,7 +12,11 @@ from datetime import date
 
 import pytest
 
-from fraiseql.partial_period import _extract_lower_date_bound, _is_period_aligned
+from fraiseql.partial_period import (
+    _extract_lower_date_bound,
+    _extract_upper_date_bound,
+    _is_period_aligned,
+)
 from fraiseql.where_clause import FieldCondition, WhereClause
 
 # ── _is_period_aligned ────────────────────────────────────────────────────────
@@ -154,3 +158,68 @@ def test_first_matching_condition_wins() -> None:
     wc = WhereClause(conditions=[cond1, cond2])
     result = _extract_lower_date_bound(wc, "date")
     assert result == date(2025, 1, 1)
+
+
+# ── _extract_upper_date_bound ────────────────────────────────────────────────
+
+
+def _make_wc_with_op(col: str, operator: str, value: object) -> WhereClause:
+    cond = FieldCondition(
+        field_path=[col],
+        operator=operator,
+        value=value,
+        lookup_strategy="sql_column",
+        target_column=col,
+    )
+    return WhereClause(conditions=[cond])
+
+
+def test_extracts_lte_as_exclusive_next_day() -> None:
+    """Inclusive lte '2024-06-30' becomes exclusive upper '2024-07-01'."""
+    wc = _make_wc_with_op("date", "lte", date(2024, 6, 30))
+    assert _extract_upper_date_bound(wc, "date") == date(2024, 7, 1)
+
+
+def test_extracts_lt_unchanged() -> None:
+    """Exclusive lt '2024-07-01' is returned unchanged."""
+    wc = _make_wc_with_op("date", "lt", date(2024, 7, 1))
+    assert _extract_upper_date_bound(wc, "date") == date(2024, 7, 1)
+
+
+def test_upper_returns_none_for_lower_bound_operators() -> None:
+    for op in ("gte", "gt", "eq"):
+        wc = _make_wc_with_op("date", op, date(2024, 6, 30))
+        assert _extract_upper_date_bound(wc, "date") is None
+
+
+def test_upper_returns_none_when_no_date_filter() -> None:
+    assert _extract_upper_date_bound(_make_wc_no_date(), "date") is None
+
+
+def test_upper_returns_none_when_column_differs() -> None:
+    wc = _make_wc_with_op("event_date", "lte", date(2024, 6, 30))
+    assert _extract_upper_date_bound(wc, "date") is None
+
+
+def test_upper_accepts_iso_string_value() -> None:
+    wc = _make_wc_with_op("date", "lte", "2024-06-30")
+    assert _extract_upper_date_bound(wc, "date") == date(2024, 7, 1)
+
+
+def test_upper_first_matching_condition_wins() -> None:
+    cond1 = FieldCondition(
+        field_path=["date"],
+        operator="lte",
+        value=date(2024, 6, 30),
+        lookup_strategy="sql_column",
+        target_column="date",
+    )
+    cond2 = FieldCondition(
+        field_path=["date"],
+        operator="lte",
+        value=date(2024, 12, 31),
+        lookup_strategy="sql_column",
+        target_column="date",
+    )
+    wc = WhereClause(conditions=[cond1, cond2])
+    assert _extract_upper_date_bound(wc, "date") == date(2024, 7, 1)

--- a/uv.lock
+++ b/uv.lock
@@ -739,7 +739,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.23.10"
+version = "1.23.11"
 
 [package.dev-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

Fixes a bug where the `fine_grain_view` partial-period aggregation rewrite **silently dropped the `lte`/`lt` upper bound**. A bounded date range at a non-day granularity (e.g. `{gte: 2024-05-01, lte: 2024-06-30}` on a monthly view) returned every period from `gte` through the current period — including future periods — drastically over-reporting preset ranges. (printoptim_backend #1818)

The non-fine-grain (DAY) path was unaffected because it honors both bounds via the standard query path.

## Root cause

`_build_partial_period_union_query` (`src/fraiseql/db.py`) hard-coded the window's upper edge to `today + 1 day` and `find()` only extracted the lower bound. The upper bound from the `where` clause was never threaded into the generated SQL.

## Changes

- **`partial_period.py`**: add `_extract_upper_date_bound` — symmetric to the lower extractor; returns an *exclusive* upper date (`lte V → V+1day`, `lt V → V`).
- **`db.py`**: rework `_build_partial_period_union_query` to accept `upper_bound_exclusive` and partition the window `[lo, hi)` into up to three contiguous, non-overlapping segments (fine leading / coarse complete / fine upper-edge + current). The upper edge is clamped symmetrically to the lower edge — a period straddling `lte` is recomputed from the fine-grain view over `[period_start … lte]`. `hi` is capped at `today+1`.
- **`db.py`**: thread the extracted upper bound through `FraiseQLRepository.find()`.
- Incidentally fixes a latent double-count where a non-aligned `gte` inside the current period emitted overlapping fine-grain branches.

### Behavior after fix (monthly view, `today = 2026-06-14`)

| range | result |
|---|---|
| `{gte: 2024-05-01, lte: 2024-06-30}` | May + June (coarse), 2 rows |
| `{gte: 2024-05-15, lte: 2024-06-30}` | partial May (fine) + full June (coarse) |
| `{gte: 2024-05-01, lte: 2024-06-15}` | full May (coarse) + partial June clamped to the 15th (fine) |
| `{gte: 2024-06-01}` (no `lte`) | unchanged — runs through today |

## Release

Bundled with **v1.23.11** (patch): version bumped in `pyproject.toml`, `fraiseql_rs/Cargo.toml`, `uv.lock` self-pin, plus a CHANGELOG entry. A `v1.23.11` tag (which triggers the PyPI/GitHub release workflow) is **not** pushed by this PR.

## Verification

- ✅ 14 new tests (7 builder regression in `tests/regression/issue_341/test_partial_period_upper_bound.py` + 7 extractor unit tests)
- ✅ `make release-check` passes: ruff check + format clean, **3410 unit tests pass**, version consistent at 1.23.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)