### PR TITLE
chore(deps): move LangChain/LlamaIndex integrations to optional extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,6 @@ requires = ["maturin>=1.9,<2.0"]
 dev = [
   "build>=1.4.0",
   "docker>=7.1.0",
-  "langchain>=1.3.9",
-  "langchain-community>=0.4.1",
-  "langchain-core>=1.3.3",
-  "langchain-text-splitters>=1.1.2",
-  "langsmith>=0.7.31",
-  "banks>=2.4.2",
-  "llama-index>=0.14.21",
-  "llama-index-core>=0.14.21",
-  "pillow>=12.2.0",
-  "pypdf>=6.12.0",
   "maturin>=1.12.0",
   "pre-commit>=4.5.0",
   "psutil>=7.2.0",
@@ -116,7 +106,9 @@ all = [
   "boto3>=1.38.0",
   "cryptography>=48.0.1",
   "aioboto3>=15.5.0",
-  "google-cloud-kms>=3.11.0"
+  "google-cloud-kms>=3.11.0",
+  "fraiseql[langchain]",
+  "fraiseql[llamaindex]"
 ]
 auth0 = ["pyjwt[crypto]>=2.13.0", "httpx>=0.28.0"]
 aws = ["boto3>=1.38.0"]
@@ -165,6 +157,21 @@ kms-all = [
 kms-aws = ["aioboto3>=15.5.0"]
 kms-gcp = ["google-cloud-kms>=3.11.0"]
 kms-vault = ["httpx>=0.28.0"]
+langchain = [
+  "langchain>=1.3.9",
+  "langchain-community>=0.4.1",
+  "langchain-core>=1.3.3",
+  "langchain-text-splitters>=1.1.2",
+  "langsmith>=0.7.31"
+]
+llamaindex = [
+  "llama-index>=0.14.21",
+  "llama-index-core>=0.14.21",
+  "banks>=2.4.2",
+  "pillow>=12.2.0",
+  "pypdf>=6.12.0"
+]
+llm = ["fraiseql[langchain]", "fraiseql[llamaindex]"]
 sbom = ["cyclonedx-python-lib>=11.10.0,<12.0", "packageurl-python>=0.17.0"]
 tracing = [
   "protobuf>=5.29.0,<8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -742,22 +742,12 @@ version = "1.23.11"
 [package.dev-dependencies]
 dev = [
   {name = "asgi-lifespan"},
-  {name = "banks"},
   {name = "build"},
   {name = "docker"},
-  {name = "langchain"},
-  {name = "langchain-community"},
-  {name = "langchain-core"},
-  {name = "langchain-text-splitters"},
-  {name = "langsmith"},
-  {name = "llama-index"},
-  {name = "llama-index-core"},
   {name = "maturin"},
   {name = "moto"},
-  {name = "pillow"},
   {name = "pre-commit"},
   {name = "psutil"},
-  {name = "pypdf"},
   {name = "pyright"},
   {name = "pytest"},
   {name = "pytest-asyncio"},
@@ -780,21 +770,22 @@ docs = [
 ]
 
 [package.metadata]
-provides-extras = ["all", "auth0", "aws", "dev", "docs", "kms", "kms-all", "kms-aws", "kms-gcp", "kms-vault", "sbom", "tracing"]
+provides-extras = ["all", "auth0", "aws", "dev", "docs", "kms", "kms-all", "kms-aws", "kms-gcp", "kms-vault", "langchain", "llamaindex", "llm", "sbom", "tracing"]
 requires-dist = [
   {name = "aioboto3", marker = "extra == 'all'", specifier = ">=15.5.0"},
   {name = "aioboto3", marker = "extra == 'kms-all'", specifier = ">=15.5.0"},
   {name = "aioboto3", marker = "extra == 'kms-aws'", specifier = ">=15.5.0"},
-  {name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.14.0"},
+  {name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.14.1"},
   {name = "aiosqlite", specifier = ">=0.22.1"},
+  {name = "banks", marker = "extra == 'llamaindex'", specifier = ">=2.4.2"},
   {name = "black", marker = "extra == 'dev'", specifier = ">=26.3.1"},
   {name = "boto3", marker = "extra == 'all'", specifier = ">=1.38.0"},
   {name = "boto3", marker = "extra == 'aws'", specifier = ">=1.38.0"},
   {name = "build", marker = "extra == 'dev'", specifier = ">=1.4.0"},
   {name = "click", specifier = ">=8.3.0"},
-  {name = "cryptography", marker = "extra == 'all'", specifier = ">=47.0.0"},
-  {name = "cryptography", marker = "extra == 'kms'", specifier = ">=47.0.0"},
-  {name = "cryptography", marker = "extra == 'kms-all'", specifier = ">=47.0.0"},
+  {name = "cryptography", marker = "extra == 'all'", specifier = ">=48.0.1"},
+  {name = "cryptography", marker = "extra == 'kms'", specifier = ">=48.0.1"},
+  {name = "cryptography", marker = "extra == 'kms-all'", specifier = ">=48.0.1"},
   {name = "cyclonedx-python-lib", marker = "extra == 'all'", specifier = ">=11.10.0,<12.0"},
   {name = "cyclonedx-python-lib", marker = "extra == 'sbom'", specifier = ">=11.10.0,<12.0"},
   {name = "docker", marker = "extra == 'dev'", specifier = ">=7.1.0"},
@@ -802,6 +793,10 @@ requires-dist = [
   {name = "faker", marker = "extra == 'dev'", specifier = ">=40.0.0"},
   {name = "fastapi", specifier = ">=0.129.0"},
   {name = "filelock", marker = "extra == 'dev'", specifier = ">=3.24.0"},
+  {name = "fraiseql", extras = ["langchain"], marker = "extra == 'all'"},
+  {name = "fraiseql", extras = ["langchain"], marker = "extra == 'llm'"},
+  {name = "fraiseql", extras = ["llamaindex"], marker = "extra == 'all'"},
+  {name = "fraiseql", extras = ["llamaindex"], marker = "extra == 'llm'"},
   {name = "fraiseql-confiture", specifier = ">=0.5.2"},
   {name = "google-cloud-kms", marker = "extra == 'all'", specifier = ">=3.11.0"},
   {name = "google-cloud-kms", marker = "extra == 'kms-all'", specifier = ">=3.11.0"},
@@ -814,6 +809,13 @@ requires-dist = [
   {name = "httpx", marker = "extra == 'kms-vault'", specifier = ">=0.28.0"},
   {name = "hvac", marker = "extra == 'dev'", specifier = ">=2.4.0"},
   {name = "jinja2", specifier = ">=3.1.6"},
+  {name = "langchain", marker = "extra == 'langchain'", specifier = ">=1.3.9"},
+  {name = "langchain-community", marker = "extra == 'langchain'", specifier = ">=0.4.1"},
+  {name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3"},
+  {name = "langchain-text-splitters", marker = "extra == 'langchain'", specifier = ">=1.1.2"},
+  {name = "langsmith", marker = "extra == 'langchain'", specifier = ">=0.7.31"},
+  {name = "llama-index", marker = "extra == 'llamaindex'", specifier = ">=0.14.21"},
+  {name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.14.21"},
   {name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1"},
   {name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7.6"},
   {name = "mkdocs-redirects", marker = "extra == 'docs'", specifier = ">=1.2.2"},
@@ -829,6 +831,7 @@ requires-dist = [
   {name = "packageurl-python", marker = "extra == 'all'", specifier = ">=0.17.0"},
   {name = "packageurl-python", marker = "extra == 'sbom'", specifier = ">=0.17.0"},
   {name = "passlib", extras = ["argon2"], specifier = ">=1.7.4"},
+  {name = "pillow", marker = "extra == 'llamaindex'", specifier = ">=12.2.0"},
   {name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0"},
   {name = "prometheus-client", marker = "extra == 'dev'", specifier = ">=0.24.0"},
   {name = "protobuf", marker = "extra == 'all'", specifier = ">=5.29.0,<8.0"},
@@ -841,6 +844,7 @@ requires-dist = [
   {name = "pyjwt", extras = ["crypto"], marker = "extra == 'all'", specifier = ">=2.13.0"},
   {name = "pyjwt", extras = ["crypto"], marker = "extra == 'auth0'", specifier = ">=2.13.0"},
   {name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.3"},
+  {name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.12.0"},
   {name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3"},
   {name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0"},
   {name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.2.3"},
@@ -856,7 +860,7 @@ requires-dist = [
   {name = "rich", specifier = ">=14.0.0"},
   {name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12"},
   {name = "sqlparse", specifier = ">=0.5.5"},
-  {name = "starlette", specifier = ">=1.0.1"},
+  {name = "starlette", specifier = ">=1.3.1"},
   {name = "structlog", specifier = ">=25.5.0"},
   {name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.14.2"},
   {name = "testcontainers", extras = ["vault"], marker = "extra == 'dev'", specifier = ">=4.14.2"},
@@ -874,22 +878,12 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
   {name = "asgi-lifespan", specifier = ">=2.1.0"},
-  {name = "banks", specifier = ">=2.4.2"},
   {name = "build", specifier = ">=1.4.0"},
   {name = "docker", specifier = ">=7.1.0"},
-  {name = "langchain", specifier = ">=1.3.9"},
-  {name = "langchain-community", specifier = ">=0.4.1"},
-  {name = "langchain-core", specifier = ">=1.3.3"},
-  {name = "langchain-text-splitters", specifier = ">=1.1.2"},
-  {name = "langsmith", specifier = ">=0.7.31"},
-  {name = "llama-index", specifier = ">=0.14.21"},
-  {name = "llama-index-core", specifier = ">=0.14.21"},
   {name = "maturin", specifier = ">=1.12.0"},
   {name = "moto", extras = ["kms"], specifier = ">=5.1.21"},
-  {name = "pillow", specifier = ">=12.2.0"},
   {name = "pre-commit", specifier = ">=4.5.0"},
   {name = "psutil", specifier = ">=7.2.0"},
-  {name = "pypdf", specifier = ">=6.12.0"},
   {name = "pyright", specifier = ">=1.1.408"},
   {name = "pytest", specifier = ">=9.0.3"},
   {name = "pytest-asyncio", specifier = ">=1.3.0"},
@@ -914,18 +908,28 @@ docs = [
 [package.optional-dependencies]
 all = [
   {name = "aioboto3"},
+  {name = "banks"},
   {name = "boto3"},
   {name = "cryptography"},
   {name = "cyclonedx-python-lib"},
   {name = "google-cloud-kms"},
   {name = "httpx"},
+  {name = "langchain"},
+  {name = "langchain-community"},
+  {name = "langchain-core"},
+  {name = "langchain-text-splitters"},
+  {name = "langsmith"},
+  {name = "llama-index"},
+  {name = "llama-index-core"},
   {name = "opentelemetry-api"},
   {name = "opentelemetry-exporter-otlp"},
   {name = "opentelemetry-instrumentation-psycopg"},
   {name = "opentelemetry-sdk"},
   {name = "packageurl-python"},
+  {name = "pillow"},
   {name = "protobuf"},
   {name = "pyjwt", extra = ["crypto"]},
+  {name = "pypdf"},
   {name = "wrapt"}
 ]
 auth0 = [
@@ -986,6 +990,32 @@ kms-gcp = [
 ]
 kms-vault = [
   {name = "httpx"}
+]
+langchain = [
+  {name = "langchain"},
+  {name = "langchain-community"},
+  {name = "langchain-core"},
+  {name = "langchain-text-splitters"},
+  {name = "langsmith"}
+]
+llamaindex = [
+  {name = "banks"},
+  {name = "llama-index"},
+  {name = "llama-index-core"},
+  {name = "pillow"},
+  {name = "pypdf"}
+]
+llm = [
+  {name = "banks"},
+  {name = "langchain"},
+  {name = "langchain-community"},
+  {name = "langchain-core"},
+  {name = "langchain-text-splitters"},
+  {name = "langsmith"},
+  {name = "llama-index"},
+  {name = "llama-index-core"},
+  {name = "pillow"},
+  {name = "pypdf"}
 ]
 sbom = [
   {name = "cyclonedx-python-lib"},


### PR DESCRIPTION
## Summary

Moves the LLM integration libraries out of the default dev install and into proper opt-in extras. They were in `[dependency-groups].dev` (so every local `uv sync` pulled them and Dependabot scanned them via the lockfile), yet they only power two optional, import-guarded integrations: `src/fraiseql/integrations/langchain.py` and `llamaindex.py`.

## New extras (`[project.optional-dependencies]`)
- **`langchain`** — langchain, langchain-community, langchain-core, langchain-text-splitters, langsmith
- **`llamaindex`** — llama-index, llama-index-core, banks, pillow, pypdf
- **`llm`** — aggregate (`fraiseql[langchain]` + `fraiseql[llamaindex]`)
- Added both to the `all` extra.

Install: `pip install fraiseql[llm]` (or `[langchain]` / `[llamaindex]`).

## Lockfile
- Re-scoped the libs from the dev-group to extras — **no version changes** (258 packages, identical resolution).
- Surgically edited only the `fraiseql` root entry (kept compact format, no churn). This also corrects three specifiers in the root metadata that earlier surgical lock edits left stale: aiohttp → 3.14.1, cryptography → 48.0.1, starlette → 1.3.1.

## Behaviour
- Both integration modules guard imports with `try/except ImportError`; core `import fraiseql` is unaffected.
- Integration tests (`test_langchain_*`, `test_llamaindex_*`) skip when the libs are absent. CI installs `.[dev]`, which never contained these libs, so CI behaviour is unchanged.

## Verification
✅ `uv lock` resolves cleanly, no version changes
✅ Lock diff limited to the root package entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)