### PR TITLE
docs: rewrite contributor guides for the Python (v1) project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to FraiseQL
 
-Thank you for your interest in contributing to FraiseQL v2! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to FraiseQL! This document provides guidelines and instructions for contributing.
+
+FraiseQL (this repository, `fraiseql-python`) is a **runtime GraphQL framework for PostgreSQL**, written in Python with an optional Rust acceleration extension (`fraiseql_rs`).
 
 ## Table of Contents
 
@@ -12,6 +14,7 @@ Thank you for your interest in contributing to FraiseQL v2! This document provid
 - [Testing](#testing)
 - [Pull Request Process](#pull-request-process)
 - [Release Process](#release-process)
+- [Architecture Guidelines](#architecture-guidelines)
 
 ---
 
@@ -27,14 +30,14 @@ Be respectful, professional, and collaborative. We're building something great t
 2. **Clone your fork**:
 
    ```bash
-   git clone git@github.com:YOUR_USERNAME/fraiseql.git
-   cd fraiseql
+   git clone git@github.com:YOUR_USERNAME/fraiseql-python.git
+   cd fraiseql-python
    ```
 
-3. **Add upstream remote**:
+3. **Add the upstream remote**:
 
    ```bash
-   git remote add upstream git@github.com:fraiseql/fraiseql.git
+   git remote add upstream git@github.com:fraiseql/fraiseql-python.git
    ```
 
 ---
@@ -120,32 +123,28 @@ uv run pytest \
 
 ### 1. Create a Feature Branch
 
+`dev` is the default integration branch; `main` tracks production. Branch off `dev`:
+
 ```bash
-git checkout v2-development
-git pull upstream v2-development
+git checkout dev
+git pull upstream dev
 git checkout -b feature/my-feature
 ```
 
 ### 2. Make Changes
 
 - Write code following our [Code Style](#code-style)
-- Add tests for new functionality
+- Add tests for new functionality (write the failing test first)
 - Update documentation if needed
 
 ### 3. Run Checks Locally
 
 ```bash
-# Format code
-make fmt
-
-# Run linter
-make clippy
-
-# Run tests
-make test
-
-# Or run all checks
-make check
+make format        # format with ruff  (uv run ruff format src/)
+make lint          # lint with ruff    (uv run ruff check src/)
+uv run ty check    # type-check with ty
+make test          # unit + integration tests
+make check         # format + lint + test in one step
 ```
 
 ### 4. Commit Changes
@@ -160,7 +159,7 @@ git commit -m "feat(scope): description
 
 **Commit Message Format:**
 
-```
+```text
 <type>(<scope>): <subject>
 
 <body>
@@ -182,133 +181,104 @@ git commit -m "feat(scope): description
 ### 5. Push and Create PR
 
 ```bash
-git push origin feature/my-feature
+git push -u origin feature/my-feature
 ```
 
-Then create a Pull Request on GitHub targeting `v2-development`.
+Then open a Pull Request on GitHub targeting `dev`.
 
 ---
 
 ## Code Style
 
-### Rust Style
-
-We follow the official [Rust Style Guide](https://doc.rust-lang.org/nightly/style-guide/).
+FraiseQL uses the [Ruff](https://docs.astral.sh/ruff/) toolchain and modern Python conventions (config in `pyproject.toml`).
 
 **Key points:**
 
-- **Line width**: 100 characters
-- **Indentation**: 4 spaces
-- **Imports**: Organized with `cargo fmt`
-- **Documentation**: Required for public items
-- **Error handling**: Use `Result` and `?` operator
+- **Python 3.13** with modern union syntax: `X | None`, not `Optional[X]`
+- **Built-in generics**: `list` / `dict` / `set`, not `typing.List` / `Dict` / `Set`
+- **Formatting & linting**: `ruff format` / `ruff check`
+- **Type checking**: `ty` (not mypy) — `uv run ty check`
+- **Docstrings**: required for public functions and classes
 
 **Example:**
 
-```rust
-/// Calculate the sum of two numbers.
-///
-/// # Arguments
-///
-/// * `a` - First number
-/// * `b` - Second number
-///
-/// # Returns
-///
-/// Sum of a and b
-///
-/// # Example
-///
-/// ```
-/// let result = add(2, 3);
-/// assert_eq!(result, 5);
-/// ```
-pub fn add(a: i32, b: i32) -> i32 {
-    a + b
-}
+```python
+def get_user(user_id: int) -> User | None:
+    """Get a single user by ID.
+
+    Args:
+        user_id: The unique user identifier.
+
+    Returns:
+        The User, or None if not found.
+
+    Raises:
+        DatabaseError: If the database connection fails.
+    """
+    ...
 ```
 
-### Linting
+### Rust extension
 
-All code must pass Clippy with no warnings:
+Changes to the optional `fraiseql_rs` extension must pass the strict Clippy gate:
 
 ```bash
-cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --manifest-path fraiseql_rs/Cargo.toml --all-features -- -D warnings
+cargo fmt --manifest-path fraiseql_rs/Cargo.toml
 ```
+
+Rebuild the extension into your environment with `uv run maturin develop`.
 
 ---
 
 ## Testing
 
+FraiseQL uses **pytest** with `pytest-asyncio`.
+
 ### Test Levels
 
-1. **Unit Tests**: Test individual functions/modules
+1. **Unit tests** (`tests/unit/`) — fast, no database:
 
-   ```rust
-   #[cfg(test)]
-   mod tests {
-       use super::*;
+   ```python
+   import pytest
 
-       #[test]
-       fn test_addition() {
-           assert_eq!(add(2, 2), 4);
-       }
-   }
+
+   @pytest.mark.asyncio
+   async def test_query_execution():
+       result = await schema.execute("{ users { id name } }")
+       assert result.data["users"][0]["name"] == "Alice"
    ```
 
-2. **Integration Tests**: Test module interactions
+2. **Integration tests** (`tests/integration/`) — require PostgreSQL:
 
-   ```rust
-   // tests/integration/test_schema.rs
-   #[test]
-   fn test_schema_loading() {
-       let schema = CompiledSchema::load("test.json").unwrap();
-       assert!(schema.is_valid());
-   }
+   ```python
+   @pytest.mark.asyncio
+   async def test_user_creation(test_db_connection):
+       result = await schema.execute(
+           'mutation { createUser(name: "Bob") { id } }'
+       )
+       assert result.data["createUser"]["id"]
    ```
 
-3. **End-to-End Tests**: Test complete flows
-
-   ```rust
-   // tests/e2e/test_query_execution.rs
-   #[tokio::test]
-   async fn test_query_execution() {
-       let executor = setup_executor().await;
-       let result = executor.execute("query { users { id } }").await.unwrap();
-       assert!(!result.has_errors());
-   }
-   ```
+Other suites live in `tests/chaos/` (chaos engineering) and `tests/e2e/`
+(end-to-end).
 
 ### Test Database
 
-Integration tests require PostgreSQL:
+Integration tests use a Docker-managed PostgreSQL:
 
 ```bash
-# Create test database (local setup)
-make db-setup-local
-
-# Or use Docker containers
-make db-up
-
-# Run integration tests
-make test-integration
-
-# Clean up (local)
-make db-teardown-local
-
-# Or stop Docker containers
-make db-down
+make db-up              # start the test database(s)
+make test-integration   # run integration tests
+make db-down            # stop the database(s)
+make db-reset           # reset (remove volumes)
 ```
 
 ### Coverage
 
-We aim for **85%+ test coverage**:
-
 ```bash
-# Generate coverage report
-make coverage
-
-# View report at target/llvm-cov/html/index.html
+uv run pytest --cov=fraiseql --cov-report=html
+# open htmlcov/index.html
 ```
 
 ---
@@ -319,25 +289,26 @@ make coverage
 
 Before submitting a PR, ensure:
 
-- [ ] Code compiles without warnings
 - [ ] All tests pass (`make test`)
-- [ ] Code is formatted (`make fmt`)
-- [ ] Clippy passes (`make clippy`)
-- [ ] Documentation is updated (if needed)
+- [ ] Code is formatted and lint-clean (`make format`, `make lint`)
+- [ ] Type checks pass (`uv run ty check`)
 - [ ] Tests are added for new functionality
-- [ ] Commit messages follow conventional format
-- [ ] PR description explains the change
+- [ ] Documentation is updated (if needed)
+- [ ] Commit messages follow the conventional format
+- [ ] PR targets `dev` and explains the change
 
 ### PR Review Process
 
-1. **Automated checks** run via GitHub Actions
+1. **Automated checks** run via GitHub Actions — the `CI Success`,
+   `Security Gate ✅`, and `Compliance Validation` gates must pass
 2. **Code review** by maintainers
 3. **Address feedback** if requested
 4. **Merge** once approved and CI passes
 
 ### After Merge
 
-The PR will be merged into `v2-development`. Your contribution will be included in the next release!
+Your change merges into `dev` and ships to `main` on the next `dev → main`
+sync, included in the next release.
 
 ---
 
@@ -345,38 +316,27 @@ The PR will be merged into `v2-development`. Your contribution will be included 
 
 Releases are managed by maintainers:
 
-1. Version bump in `Cargo.toml`
+1. Version bump in `pyproject.toml` (the runtime `__version__` is read from package metadata)
 2. Update `CHANGELOG.md`
-3. Create git tag (`v2.x.x`)
-4. CI builds and publishes to crates.io and PyPI
+3. `dev` is synced to `main`
+4. `make release` builds and publishes the wheel + sdist to PyPI
 
 ---
 
 ## Architecture Guidelines
 
-FraiseQL v2 is a **compiled GraphQL execution engine**. Key principles:
+FraiseQL v1 is a **runtime GraphQL framework**: Python decorators define types,
+queries, and mutations, and FraiseQL generates the GraphQL schema and executes
+queries against PostgreSQL at runtime.
 
-### 1. Separation of Concerns
+- **Decorator API**: `@fraise_type`, `@query`, `@mutation` define the schema.
+- **SQL generation**: queries compile to parameterized SQL — never string interpolation.
+- **Optional Rust acceleration**: `fraiseql_rs` (PyO3) speeds up hot paths; the framework runs in pure Python without it.
+- **FastAPI integration**: served over ASGI with configurable middleware.
 
-- **Compilation Layer**: Schema definition → SQL compilation (build-time via fraiseql-cli)
-- **Runtime Layer**: Query execution → Result streaming (runtime via fraiseql-server)
-- **Database Layer**: Data storage and retrieval (multi-database support)
-
-See `.claude/ARCHITECTURE_PRINCIPLES.md` for detailed architecture documentation.
-
-### 2. Layered Optionality
-
-- **Core**: Minimal build includes GraphQL execution engine only
-- **Extensions**: Optional features via Cargo features (Arrow, Observers, Wire)
-- **Configuration**: All behavior controlled via fraiseql.toml or environment variables
-
-### 3. World-Class Engineering
-
-- **No `unsafe` code** (forbidden at compile time via Cargo.toml lints)
-- **Comprehensive error handling** with Result types and context
-- **Extensive documentation** for all public APIs
-- **Thorough testing** (2,400+ tests: unit, integration, E2E, chaos)
-- **Performance-conscious** design with zero-copy patterns and compile-time optimization
+See [`.claude/CLAUDE.md`](.claude/CLAUDE.md) and
+[`.claude/ARCHITECTURE_PRINCIPLES.md`](.claude/ARCHITECTURE_PRINCIPLES.md) for
+detailed architecture documentation.
 
 ---
 
@@ -384,14 +344,15 @@ See `.claude/ARCHITECTURE_PRINCIPLES.md` for detailed architecture documentation
 
 - **Questions**: Open a GitHub Discussion
 - **Bugs**: File a GitHub Issue
-- **Security**: Email <security@fraiseql.dev>
+- **Security**: see [SECURITY.md](SECURITY.md) — please do not report vulnerabilities via public issues
 
 ---
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the same license as the project (MIT OR Apache-2.0).
+By contributing, you agree that your contributions will be licensed under the
+project's [MIT License](LICENSE).
 
 ---
 
-**Thank you for contributing to FraiseQL v2!** 🚀
+**Thank you for contributing to FraiseQL!** 🚀

--- a/docs/guides/development/developer-guide.md
+++ b/docs/guides/development/developer-guide.md
@@ -2,14 +2,20 @@
 ---
 
 title: FraiseQL Developer Guide
-description: Welcome to the FraiseQL development guide! This document covers setup, development workflow, testing, and contribution guidelines.
-keywords: ["debugging", "implementation", "best-practices", "deployment", "tutorial"]
+description: Setup, development workflow, testing, and code standards for working on FraiseQL.
+keywords: ["development", "testing", "workflow", "python", "contributing"]
 tags: ["documentation", "reference"]
 ---
 
 # FraiseQL Developer Guide
 
-Welcome to the FraiseQL development guide! This document covers setup, development workflow, testing, and contribution guidelines.
+Welcome! This guide covers setup, the development workflow, testing, and code
+standards for working on FraiseQL — a runtime GraphQL framework for PostgreSQL,
+written in Python with an optional Rust acceleration extension (`fraiseql_rs`).
+
+For contribution mechanics (forking, PR process, commit format), see the
+[Contributing Guide](../../../CONTRIBUTING.md). This document focuses on
+day-to-day development.
 
 ## Table of Contents
 
@@ -19,756 +25,272 @@ Welcome to the FraiseQL development guide! This document covers setup, developme
 4. [Testing Strategy](#testing-strategy)
 5. [Code Standards](#code-standards)
 6. [Debugging & Troubleshooting](#debugging--troubleshooting)
-7. [Contributing](#contributing)
 
 ## Development Setup
 
 ### Prerequisites
 
-- **Rust 1.75+**: Install from [rustup.rs](https://rustup.rs/)
-- **PostgreSQL 14+**: Required for integration tests
-- **Git**: Version control
-- **Optional**: `cargo-watch` for auto-rebuild on file changes
+- **Python 3.13** (the project targets `>=3.13,<3.14`)
+- **uv** — package/environment manager ([install](https://docs.astral.sh/uv/))
+- **Rust toolchain** — to build the optional `fraiseql_rs` extension ([rustup](https://rustup.rs/))
+- **PostgreSQL 14+** — required for integration tests (the Makefile runs it via Docker)
 
 ### Initial Setup
 
 ```bash
-<!-- Code example in BASH -->
 # Clone the repository
-git clone https://github.com/FraiseQL/FraiseQL.git
-cd FraiseQL
+git clone git@github.com:fraiseql/fraiseql-python.git
+cd fraiseql-python
 
-# Install Rust (if needed)
-rustup update
+# Create the virtualenv (runtime + dev dependencies) and build the Rust extension
+uv sync
 
-# Verify installation
-cargo --version  # Should be 1.75+
-rustc --version
+# Install pre-commit hooks
+uv run pre-commit install
+```
 
-# Install optional tools
-cargo install cargo-watch  # Auto-rebuild
-cargo install cargo-edit   # Dependency management
-```text
-<!-- Code example in TEXT -->
+The LangChain/LlamaIndex integrations are opt-in extras and are not installed by
+default. To work on them: `uv sync --extra langchain --extra llamaindex`.
 
 ### Database Setup
 
-For integration tests, you need PostgreSQL:
+Integration tests use a Docker-managed PostgreSQL:
 
 ```bash
-<!-- Code example in BASH -->
-# Start PostgreSQL (if using Docker)
-docker run -d \
-  --name postgres-FraiseQL \
-  -e POSTGRES_PASSWORD=password \
-  -e POSTGRES_DB=fraiseql_test \
-  -p 5432:5432 \
-  postgres:15
-
-# Or connect to existing PostgreSQL
-export DATABASE_URL="postgresql://user:password@localhost/fraiseql_test"
-```text
-<!-- Code example in TEXT -->
-
-### First Build
-
-```bash
-<!-- Code example in BASH -->
-# Full build (release)
-cargo build --release
-
-# Or debug build (faster)
-cargo build
-
-# Run tests
-cargo test --lib
-
-# Run full test suite
-cargo test
-
-# Check formatting
-cargo fmt --check
-
-# Run linter
-cargo clippy --all-targets --all-features
-```text
-<!-- Code example in TEXT -->
+make db-up        # start the test database(s)
+make db-status    # check health
+make db-down      # stop
+make db-reset     # remove volumes and recreate
+```
 
 ## Project Structure
 
 ```text
-<!-- Code example in TEXT -->
-FraiseQL/
-├── crates/
-│   ├── FraiseQL-core/          # Core execution engine
-│   │   ├── src/
-│   │   │   ├── compiler/       # Schema compilation pipeline
-│   │   │   ├── runtime/        # Query execution
-│   │   │   ├── cache/          # Query result caching
-│   │   │   ├── db/             # Database adapters
-│   │   │   └── schema/         # Schema definitions
-│   │   └── tests/              # Integration tests
-│   │
-│   ├── FraiseQL-server/        # HTTP server
-│   │   ├── src/
-│   │   │   ├── routes/         # HTTP endpoints
-│   │   │   ├── middleware/     # Request middleware
-│   │   │   ├── config.rs       # Server configuration
-│   │   │   └── server.rs       # Server implementation
-│   │   └── benches/            # Performance benchmarks
-│   │
-│   ├── FraiseQL-cli/           # CLI tool
-│   │   ├── src/
-│   │   │   ├── commands/       # CLI subcommands
-│   │   │   └── main.rs
-│   │   └── tests/
-│   │
-│   └── FraiseQL-wire/          # Protocol layer
-│       └── src/                # PostgreSQL wire protocol
+fraiseql_v1/
+├── src/fraiseql/             # Main Python package
+│   ├── decorators/           # @fraise_type, @query, @mutation
+│   ├── gql/                  # GraphQL schema building
+│   ├── mutations/            # Mutation execution
+│   ├── sql/                  # SQL generation
+│   ├── types/                # Type system and scalars
+│   ├── fastapi/              # FastAPI integration
+│   ├── integrations/         # Optional LangChain / LlamaIndex integrations
+│   └── db.py                 # Database abstraction
 │
-├── docs/                        # Documentation
-│   ├── linting.md              # Code quality guide
-│   ├── developer-guide.md      # This file
-│   ├── PERFORMANCE.md          # Performance tuning
-│   └── architecture/           # Architecture docs
+├── tests/
+│   ├── unit/                 # Unit tests (no database)
+│   ├── integration/          # Integration tests (require PostgreSQL)
+│   ├── chaos/                # Chaos-engineering scenarios
+│   └── e2e/                  # End-to-end tests
 │
-├── tools/                       # Development tools
-│   └── scripts/                # Build scripts
-│
-├── Cargo.toml                  # Workspace root
-├── Cargo.lock                  # Dependency lock file
-└── .cargo/config.toml          # Cargo configuration
-```text
-<!-- Code example in TEXT -->
+├── fraiseql_rs/              # Optional Rust extension (PyO3)
+├── Makefile                  # Development commands (see `make help`)
+├── pyproject.toml            # Package config, dependencies, tool settings
+└── uv.lock                   # Locked dependencies
+```
+
+Run `make help` for the full list of convenience commands.
 
 ## Development Workflow
 
 ### Setting Up a Feature Branch
 
+`dev` is the default integration branch; `main` tracks production. Branch off `dev`:
+
 ```bash
-<!-- Code example in BASH -->
-# Create feature branch from dev
 git checkout dev
 git pull origin dev
 git checkout -b feature/your-feature-name
 
-# Verify clean state
-git status  # Should show "nothing to commit, working tree clean"
-```text
-<!-- Code example in TEXT -->
+git status   # should be "nothing to commit, working tree clean"
+```
 
 ### Development Cycle
 
 ```bash
-<!-- Code example in BASH -->
 # 1. Make changes
-vim crates/FraiseQL-core/src/some_file.rs
+$EDITOR src/fraiseql/...
 
-# 2. Format code
-cargo fmt
+# 2. Format and lint
+make format          # uv run ruff format src/
+make lint            # uv run ruff check src/
 
-# 3. Run clippy
-cargo clippy --all-targets --all-features
+# 3. Type-check
+uv run ty check
 
 # 4. Run tests
-cargo test --lib
+make test-unit                       # fast, no database
+make test-integration                # requires PostgreSQL (make db-up first)
 
-# 5. Run integration tests (if needed)
-cargo test --test '*'
-
-# 6. Commit
-git add .
-git commit -m "feat(core): Add new feature description"
-
-# 7. Push and create PR
+# 5. Commit, push, open a PR targeting dev
+git commit -am "feat(scope): describe the change"
 git push -u origin feature/your-feature-name
-```text
-<!-- Code example in TEXT -->
+```
 
-### Using cargo-watch for Fast Iteration
+`make check` runs format + lint + test in one step.
+
+### Working on the Rust extension
+
+After changing `fraiseql_rs/`, rebuild it into your environment and run the
+strict Clippy gate:
 
 ```bash
-<!-- Code example in BASH -->
-# Auto-check on file changes
-cargo watch -x check
-
-# Auto-test on changes
-cargo watch -x "test --lib"
-
-# Auto-build in another terminal
-cargo watch -x build
-```text
-<!-- Code example in TEXT -->
+uv run maturin develop                                  # rebuild the extension
+cargo clippy --manifest-path fraiseql_rs/Cargo.toml --all-features -- -D warnings
+cargo fmt --manifest-path fraiseql_rs/Cargo.toml
+```
 
 ### Running Specific Tests
 
 ```bash
-<!-- Code example in BASH -->
-# Test specific module
-cargo test -p FraiseQL-core cache::result::tests
+# A single test, verbose, stop on first failure
+uv run pytest tests/unit/test_file.py::test_name -xvs
 
-# Run single test
-cargo test test_cache_hit -- --exact
+# A directory
+uv run pytest tests/unit/ -q
 
-# Run with output
-cargo test test_feature -- --nocapture
+# By keyword
+uv run pytest -k "schema and not slow"
 
-# Run ignored tests
-cargo test -- --ignored
-
-# Run with logging
-RUST_LOG=debug cargo test test_feature -- --nocapture
-```text
-<!-- Code example in TEXT -->
+# With logging
+uv run pytest tests/ -o log_cli=true -o log_cli_level=DEBUG
+```
 
 ## Testing Strategy
 
-### Test Organization
-
-Tests are organized by scope:
+FraiseQL uses **pytest** with `pytest-asyncio`. Tests are organized by scope:
 
 ```text
-<!-- Code example in TEXT -->
-Unit Tests (same file)          - Fast, isolated
-Integration Tests (tests/)      - Medium speed, database
-Benchmark Tests (benches/)      - Performance regression
-Doc Tests (in comments)         - API examples
-```text
-<!-- Code example in TEXT -->
+tests/unit/          Fast, isolated, no database
+tests/integration/   Medium speed, real PostgreSQL
+tests/chaos/         Failure-injection scenarios
+tests/e2e/           Full end-to-end flows
+```
 
 ### Writing Tests
 
-```rust
-<!-- Code example in RUST -->
-#[cfg(test)]
-mod tests {
-    use super::*;
+```python
+import pytest
 
-    #[test]
-    fn test_feature_happy_path() {
-        let input = setup_fixture();
-        let result = function_under_test(input);
-        assert_eq!(result, expected_output);
-    }
 
-    #[test]
-    fn test_feature_error_case() {
-        let invalid_input = create_invalid_fixture();
-        let result = function_under_test(invalid_input);
-        assert!(result.is_err());
-    }
+@pytest.mark.asyncio
+async def test_feature_happy_path(test_db_connection):
+    result = await schema.execute("{ users { id name } }")
+    assert not result.errors
+    assert result.data["users"][0]["name"] == "Alice"
 
-    #[tokio::test]
-    async fn test_async_function() {
-        let result = async_function().await;
-        assert_eq!(result, expected);
-    }
-}
-```text
-<!-- Code example in TEXT -->
 
-### Test Coverage
+@pytest.mark.asyncio
+async def test_feature_error_case():
+    result = await schema.execute("{ users { nonexistent } }")
+    assert result.errors
+```
 
-Aim for:
-
-- **Critical paths**: 100% coverage (business logic)
-- **Error handling**: 100% coverage (every error branch)
-- **Edge cases**: 90%+ coverage
-- **Overall**: 80%+ coverage
-
-Run coverage locally:
+### Coverage
 
 ```bash
-<!-- Code example in BASH -->
-# Using tarpaulin
-cargo tarpaulin --out Html --output-dir coverage
-
-# View results
-open coverage/index.html
-```text
-<!-- Code example in TEXT -->
-
-### Performance Testing
-
-```bash
-<!-- Code example in BASH -->
-# Run benchmarks
-cargo bench
-
-# Run specific benchmark
-cargo bench -- cache_hit
-
-# Compare against baseline
-cargo bench -- --baseline main
-```text
-<!-- Code example in TEXT -->
+uv run pytest --cov=fraiseql --cov-report=html
+# open htmlcov/index.html
+```
 
 ## Code Standards
 
-### Naming Conventions
+### Style and Typing
 
-```rust
-<!-- Code example in RUST -->
-// Modules: lowercase_snake_case
-mod query_matcher { }
+- **Python 3.13** with modern union syntax: `X | None`, not `Optional[X]`.
+- **Built-in generics**: `list` / `dict` / `set`, not `typing.List` / `Dict` / `Set`.
+- Formatting and linting via **Ruff** (`make format`, `make lint`); config in `pyproject.toml`.
+- Type checking via **ty** (not mypy): `uv run ty check`.
 
-// Types: PascalCase
-struct QueryMatcher { }
-enum QueryType { }
-trait QueryExecutor { }
+```python
+# ✅ Modern style
+def get_user(user_id: int) -> User | None:
+    ...
 
-// Constants: SCREAMING_SNAKE_CASE
-const MAX_QUERY_DEPTH: usize = 50;
 
-// Functions: lowercase_snake_case
-fn execute_query(query: &str) -> Result<String> { }
+# ❌ Old style
+from typing import Optional
 
-// Generic types: PascalCase
-fn generic_function<T: Trait>(value: T) { }
-```text
-<!-- Code example in TEXT -->
+
+def get_user(user_id: int) -> Optional["User"]:
+    ...
+```
 
 ### Documentation
 
-Every public item must have documentation:
+Every public function and class should have a docstring:
 
-```rust
-<!-- Code example in RUST -->
-/// Brief summary.
-///
-/// Longer description with examples and important notes.
-///
-/// # Arguments
-/// * `param` - Description
-///
-/// # Returns
-/// Description of return value
-///
-/// # Errors
-/// Description of error conditions
-///
-/// # Example
-/// ```text
-<!-- Code example in TEXT -->
-/// let result = function()?;
-/// ```text
-<!-- Code example in TEXT -->
-pub fn function(param: Type) -> Result<Value> {
-}
-```text
-<!-- Code example in TEXT -->
+```python
+def get_user(user_id: int) -> User | None:
+    """Get a single user by ID.
+
+    Args:
+        user_id: The unique user identifier.
+
+    Returns:
+        The User, or None if not found.
+
+    Raises:
+        DatabaseError: If the database connection fails.
+    """
+    ...
+```
 
 ### Error Handling
 
-```rust
-<!-- Code example in RUST -->
-// ❌ Avoid panics in library code
-fn parse_schema(json: &str) -> Schema {
-    serde_json::from_str(json).unwrap()  // Bad!
-}
+Use the `FraiseQLError` hierarchy and return structured results rather than
+raising bare exceptions across boundaries:
 
-// ✅ Return Result
-fn parse_schema(json: &str) -> Result<Schema> {
-    serde_json::from_str(json)
-        .map_err(|e| FraiseQLError::Parse { message: e.to_string() })
-}
-```text
-<!-- Code example in TEXT -->
+```python
+from fraiseql.types.errors import Error
+```
 
-### Type Annotations
-
-```rust
-<!-- Code example in RUST -->
-// ❌ Old style
-fn get_user(id: i32) -> Option<User> {
-    None
-}
-
-// ✅ Modern style (Rust 1.65+)
-fn get_user(id: i32) -> User | None {
-    None
-}
-
-// ✅ For collections
-let users: Vec<User> = vec![];
-let mapping: HashMap<String, u64> = HashMap::new();
-```text
-<!-- Code example in TEXT -->
+Always use parameterized SQL — never interpolate user input into query strings.
 
 ## Debugging & Troubleshooting
 
 ### Logging
 
-Use the `log` crate for structured logging:
-
-```rust
-<!-- Code example in RUST -->
-use log::{debug, info, warn, error};
-
-info!("Server starting on {}", addr);
-debug!(field = %value, "Detailed debug info");
-error!("Failed to execute query: {}", err);
-```text
-<!-- Code example in TEXT -->
-
-Enable logging in tests:
+FraiseQL uses [structlog](https://www.structlog.org/). Raise verbosity in tests
+with pytest's logging flags:
 
 ```bash
-<!-- Code example in BASH -->
-RUST_LOG=debug cargo test test_name -- --nocapture
-```text
-<!-- Code example in TEXT -->
+uv run pytest tests/unit/test_file.py -o log_cli=true -o log_cli_level=DEBUG
+```
 
-### Debugging with Print Statements
+For the Rust extension, set `RUST_LOG=debug` in the environment.
 
-```rust
-<!-- Code example in RUST -->
-// Quick debug print (temporary)
-eprintln!("Debug: {:?}", value);
+### Quick Debugging
 
-// Better: use dbg! macro
-dbg!(&value);
+```python
+import pytest
 
-// Best: use proper logging
-debug!("Value: {:?}", value);
-```text
-<!-- Code example in TEXT -->
+# Drop into the debugger on failure
+# uv run pytest tests/unit/test_file.py --pdb
 
-### Common Issues & Solutions
+# Print without capture
+# uv run pytest -s tests/unit/test_file.py
+```
 
-#### Lifetime Errors
+### Common Issues
 
-```rust
-<!-- Code example in RUST -->
-// ❌ Lifetime mismatch
-fn process<'a>(input: &'a str) -> &'static str {
-    input  // Error: different lifetime
-}
+**`ImportError` / stale Rust extension** — rebuild it: `uv run maturin develop`,
+then `uv sync`.
 
-// ✅ Return owned data
-fn process(input: &str) -> String {
-    input.to_string()
-}
-```text
-<!-- Code example in TEXT -->
+**`database connection refused` in integration tests** — the test database isn't
+running. Start it with `make db-up`; it may take 10–20 seconds to become healthy
+(`make db-status`). Confirm `DATABASE_URL` if you point at an external instance.
 
-#### Borrow Checker Issues
+**Integration tests for LangChain/LlamaIndex are skipped** — their extras aren't
+installed. Run `uv sync --extra langchain --extra llamaindex` first.
 
-```rust
-<!-- Code example in RUST -->
-// ❌ Multiple mutable borrows
-let mut x = vec![1, 2, 3];
-let a = &mut x;
-let b = &mut x;  // Error!
-
-// ✅ Use references sequentially
-let mut x = vec![1, 2, 3];
-{
-    let a = &mut x;
-    a.push(4);
-}
-let b = &mut x;  // OK
-```text
-<!-- Code example in TEXT -->
-
-#### Async Issues
-
-```rust
-<!-- Code example in RUST -->
-// ❌ Not awaiting
-async fn fetch_data() -> Data {
-    get_data()  // Error: forgot await
-}
-
-// ✅ Proper await
-async fn fetch_data() -> Data {
-    get_data().await
-}
-```text
-<!-- Code example in TEXT -->
-
-### Profiling
-
-```bash
-<!-- Code example in BASH -->
-# Generate flamegraph
-cargo install flamegraph
-cargo flamegraph
-
-# View results
-open flamegraph.svg
-```text
-<!-- Code example in TEXT -->
-
-## Contributing
-
-### Before You Start
-
-1. **Check existing issues**: Is this already being worked on?
-2. **Create an issue**: Discuss breaking changes, new features
-3. **Understand the code**: Read related documentation first
-4. **Test locally**: Ensure no regressions
-
-### Creating a Pull Request
-
-1. **Ensure clean history**: Squash fixup commits
-
-   ```bash
-<!-- Code example in BASH -->
-   git rebase -i main
-   ```text
-<!-- Code example in TEXT -->
-
-2. **Write clear commit messages**:
-
-   ```text
-<!-- Code example in TEXT -->
-   feat(scope): Add feature description
-
-   Longer explanation of what and why.
-
-   Fixes #123
-   ```text
-<!-- Code example in TEXT -->
-
-3. **Add tests**: For new features and bug fixes
-
-4. **Update documentation**: If public API changes
-
-5. **Run full checks**:
-
-   ```bash
-<!-- Code example in BASH -->
-   cargo fmt
-   cargo clippy --all-targets --all-features
-   cargo test --lib
-   cargo test --test '*'
-   ```text
-<!-- Code example in TEXT -->
-
-### PR Review Process
-
-- **Maintainers** will review within 48 hours
-- **Address feedback**: Commit updates, don't force push
-- **Approval**: Usually 1-2 approvals
-- **Merge**: Rebase and merge to maintain clean history
-
-### Code Review Checklist
-
-When reviewing code:
-
-- [ ] Tests pass locally
-- [ ] Code follows style guide
-- [ ] Documentation is clear
-- [ ] No performance regressions
-- [ ] Error handling is robust
-- [ ] No unnecessary dependencies
-- [ ] No unsafe code without justification
-
-## Getting Help
-
-- **Documentation**: Start with `docs/` directory
-- **Code Comments**: Check existing similar code
-- **GitHub Issues**: Search for similar problems
-- **Slack**: Ask in #development channel
-- **PR Comments**: Ask during code review
-
-## Resources
-
-- [Rust Book](https://doc.rust-lang.org/book/)
-- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
-- [FraiseQL Architecture](../../architecture/)
-- [Linting Guide](./linting.md)
-
-## Quick Reference
-
-### Most Common Commands
-
-```bash
-<!-- Code example in BASH -->
-cargo fmt              # Format code
-cargo clippy --all     # Lint code
-cargo test --lib       # Run unit tests
-cargo build --release  # Build optimized binary
-cargo watch -x test    # Auto-test on changes
-```text
-<!-- Code example in TEXT -->
-
-### Fast Feedback Loop
-
-```bash
-<!-- Code example in BASH -->
-# Terminal 1: Auto-check on changes
-cargo watch -x check
-
-# Terminal 2: Run tests on change
-cargo watch -x "test --lib"
-
-# Terminal 3: Edit code
-vim src/file.rs
-```text
-<!-- Code example in TEXT -->
-
-### Useful Cargo Flags
-
-```bash
-<!-- Code example in BASH -->
--p CRATE        # Run for specific crate
---release       # Optimized build (slower to compile, faster to run)
---lib           # Only lib target (skip binaries)
--j 4            # Use 4 parallel jobs (useful on slow machines)
---verbose       # Detailed output
-```text
-<!-- Code example in TEXT -->
-
-Happy coding! 🚀
-
----
-
-## Troubleshooting
-
-### "Build fails with 'error: linker `cc` not found'"
-
-**Cause:** C++ build tools not installed on system.
-
-**Diagnosis:**
-
-1. Check if `cc` available: `which cc` or `which gcc`
-2. Check Rust setup: `rustup show`
-
-**Solutions:**
-
-- Install build tools: `sudo apt-get install build-essential` (Linux)
-- Install Xcode Command Line Tools: `xcode-select --install` (macOS)
-- Use `rustup`: `rustup install stable`
-
-### "Cargo build fails with 'cannot find package' dependency"
-
-**Cause:** Dependency not downloading or network issue.
-
-**Diagnosis:**
-
-1. Check internet connectivity
-2. Try clearing cache: `cargo clean`
-3. Check dependency in Cargo.toml spelling
-
-**Solutions:**
-
-- Verify Cargo.toml has correct dependency name/version
-- Update index: `cargo update`
-- Check for network issues: Try pinging crates.io
-- Check if crate is yanked/removed: Look on crates.io
-
-### "Compilation is very slow (>10 minutes)"
-
-**Cause:** Large project or unoptimized linker.
-
-**Diagnosis:**
-
-1. Profile build: `cargo build --release --timings`
-2. Check for heavy dependencies in output
-3. Measure link time vs compile time
-
-**Solutions:**
-
-- Use `mold` linker: Uncomment in `.cargo/config.toml` (Linux only, 3-5x faster)
-- Use incremental compilation: `cargo build -j 4`
-- In CI, use `cargo check` first (faster than full build)
-- Split into smaller crates to compile in parallel
-- Use sccache for distributed caching in CI
-
-### "Tests fail with 'database connection refused'"
-
-**Cause:** Test database not running or not accessible.
-
-**Diagnosis:**
-
-1. Check PostgreSQL running: `docker ps | grep postgres`
-2. Verify connection string: `echo $DATABASE_TEST_URL`
-3. Test manually: `psql $DATABASE_TEST_URL -c 'SELECT 1;'`
-
-**Solutions:**
-
-- Start test database: `docker-compose -f tests/docker-compose.yml up -d`
-- Wait for startup: Database may take 10-20 seconds
-- Create test database if missing: `createdb test_db`
-- Check DATABASE_URL environment variable is set
-
-### "IDE doesn't show type hints or autocomplete"
-
-**Cause:** Rust analyzer not working or not installed.
-
-**Diagnosis:**
-
-1. Check if rust-analyzer installed: `rustup component list | grep rust-analyzer`
-2. Restart IDE/editor
-3. Check if project is recognized: `cargo metadata`
-
-**Solutions:**
-
-- Install rust-analyzer: `rustup component add rust-analyzer`
-- Reload IDE window
-- Check .vscode/settings.json has rust-analyzer path
-- Update VSCode to latest version
-- Check project root has Cargo.toml
-
-### "Cargo clippy shows warnings I didn't write"
-
-**Cause:** Clippy found issues in existing code or dependencies.
-
-**Diagnosis:**
-
-1. Identify source of warning: Look at file path in error
-2. Check if in test code or main code
-3. Filter by crate: `cargo clippy -p specific_crate`
-
-**Solutions:**
-
-- Fix warnings if in your code: `cargo clippy --fix --allow-dirty`
-- For dependency warnings: Ignore (not your code)
-- Add `#[allow(clippy::lint_name)]` if intentional
-- Consider upgrading dependency if it has warning
-
-### "Different Rust version required (error: toolchain mismatch)"
-
-**Cause:** Project requires specific Rust version.
-
-**Diagnosis:**
-
-1. Check rust-toolchain.toml for version requirement
-2. Check current version: `rustc --version`
-
-**Solutions:**
-
-- Install correct version: `rustup install 1.XX.X`
-- Update stable: `rustup update stable`
-- Use specific version: `rustup override set 1.XX.X`
-- Let rustup handle it: It reads rust-toolchain.toml automatically
-
-### "Git pre-commit hook fails on your changes"
-
-**Cause:** Code quality check failed before commit.
-
-**Diagnosis:**
-
-1. Rerun hook manually to see error
-2. Run same check: `cargo clippy --all-targets`
-3. Check what hook does: Look at `.git/hooks/pre-commit`
-
-**Solutions:**
-
-- Fix linting issues: `cargo clippy --fix`
-- Run formatter: `cargo fmt`
-- Skip hook temporarily: `git commit --no-verify` (not recommended)
-- Update hook if it's wrong: Edit `.pre-commit-config.yaml`
-
----
+**Pre-commit hook fails** — reproduce the failing check directly (`make lint`,
+`make format`, `uv run ty check`) and fix, rather than bypassing with
+`--no-verify`.
 
 ## See Also
 
-- **[Testing Strategy](../testing-strategy.md)** - Unit, integration, and E2E testing approach
-- **[Linting & Code Quality](./linting.md)** - Code standards and Clippy configuration
-- **[Benchmarking Guide](./benchmarking.md)** - Performance benchmarking with Criterion
-- **[Profiling Guide](./profiling-guide.md)** - Performance profiling and optimization
-- **[E2E Testing Guide](./e2e-testing.md)** - End-to-end testing infrastructure
-- **[Contributing Guide](../../../CONTRIBUTING.md)** - Contribution workflow and standards
+- [Contributing Guide](../../../CONTRIBUTING.md) — fork/PR workflow and standards
+- [Architecture Principles](../../../.claude/ARCHITECTURE_PRINCIPLES.md) — design decisions
+
+Happy coding! 🚀


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` and `docs/guides/development/developer-guide.md` were stale copies from the Rust **v2** repo — cargo/crates/clippy/tarpaulin commands, `crates.io`, a `v2-development` branch, "FraiseQL v2" titles, and an Apache-2.0 license note. This repo (`fraiseql-python`) is the Python runtime framework with an optional Rust extension. Both are now accurate.

## CONTRIBUTING.md
- Development Workflow, Code Style, Testing, PR Process, Release, and Architecture rewritten for the real Python/uv toolchain (`ruff`, `ty`, `pytest`, `maturin`) and Makefile targets.
- Correct repo/remote (`fraiseql-python`), default branch (`dev`), license (MIT).
- Rust guidance scoped to the `fraiseql_rs` extension (the clippy/fmt gate).

## developer-guide.md
- Full Python rewrite (setup, project structure, workflow, testing, standards, debugging).
- Fixed broken markdown artifacts (stray `<!-- Code example -->` comments and malformed `` ```text `` closing fences).
- Restored the repo's frontmatter convention; points to CONTRIBUTING.md for contribution mechanics.

## Out of scope (heads-up)
The rest of `docs/guides/development/` is still v2/Rust-stale: `README.md`, `benchmarking.md`, `profiling-guide.md`, `test-coverage.md`, `linting.md`, `e2e-testing.md`. These need their own pass (some require digging into the actual perf/profiling setup) or removal from the docs nav — flagging rather than guessing.

## Verification
✅ markdownlint passes ✅ vale passes (0 errors/warnings) ✅ links + ToC anchors resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)