### PR TITLE
docs: add v1 landing page + wire getting-started nav (Phase 2)

### DIFF
--- a/docs/architecture/database/tv-table-pattern.md
+++ b/docs/architecture/database/tv-table-pattern.md
@@ -537,7 +537,6 @@ See `/home/lionel/code/FraiseQL/examples/sql/postgres/` for complete DDL example
 
 ## See Also
 
-- [ta_* Table Pattern (Arrow Plane)](./ta-table-pattern.md)
 - [View Selection Guide](./view-selection-guide.md)
 - [Schema Conventions](../../specs/schema-conventions.md)
 - [FraiseQL Database Architecture](../../architecture/)

--- a/docs/architecture/database/view-selection-guide.md
+++ b/docs/architecture/database/view-selection-guide.md
@@ -427,6 +427,5 @@ SELECT * FROM ta_orders WHERE created_at >= ? AND created_at < ?;
 ## See Also
 
 - [tv_* Table Pattern (JSON Plane Details)](./tv-table-pattern.md)
-- [ta_* Table Pattern (Arrow Plane Details)](./ta-table-pattern.md)
 - [Schema Conventions](../../specs/schema-conventions.md)
 - [FraiseQL Database Architecture](../../architecture/)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -90,9 +90,9 @@ Once you've completed these guides, continue your learning journey:
 
 **Installation**: `pip install fraiseql`
 
-**Documentation Hub**: [docs/README.md](../README.md)
+**Documentation Hub**: [Documentation Home](../index.md)
 
-**Need help?**: [GitHub Discussions](../discussions)
+**Need help?**: [GitHub Discussions](https://github.com/fraiseql/fraiseql-python/discussions)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,115 @@
+---
+title: FraiseQL
+description: A Python GraphQL framework that turns PostgreSQL views and functions into a typed GraphQL API at runtime.
+tags:
+  - overview
+  - introduction
+  - graphql
+  - postgresql
+  - fastapi
+---
+
+# FraiseQL
+
+**A Python GraphQL framework for PostgreSQL.** Define your types and operations
+with decorators, point them at PostgreSQL views and functions, and FraiseQL serves
+a typed GraphQL API over FastAPI — no build step, no code generation.
+
+PostgreSQL returns JSONB. An integrated Rust pipeline (`fraiseql_rs`) transforms it
+into GraphQL responses with minimal Python overhead. You write Python; the hot path
+runs in Rust.
+
+```python
+# A complete GraphQL API
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
+class User:
+    """A user in the system."""
+    id: int
+    name: str
+    email: str
+
+@fraiseql.query
+async def users(info) -> list[User]:
+    """Get all users."""
+    db = info.context["db"]
+    return await db.find("v_user")
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users],
+)
+```
+
+Run it with any ASGI server (`uvicorn app:app`) and open `/graphql`.
+
+---
+
+## Why FraiseQL
+
+- **Database-first.** Your PostgreSQL views and functions are the source of truth.
+  Types map to views; mutations call functions. No ORM, no N+1 surprises.
+- **Runtime, not a compiler.** The schema is built from your decorated Python at
+  startup with `create_fraiseql_app` / `build_fraiseql_schema`. Change code, restart,
+  iterate — no compile step.
+- **Rust-fast JSON.** The `fraiseql_rs` pipeline turns PostgreSQL JSONB into GraphQL
+  responses, keeping Python out of the per-row hot path.
+- **FastAPI native.** Ships as a FastAPI/ASGI app with a GraphQL playground,
+  middleware, auth integration, and production hardening built in.
+- **PostgreSQL-focused.** v1 targets PostgreSQL 13+ exclusively and leans into its
+  strengths: JSONB, CTEs, `ltree`, custom functions, and rich indexing.
+
+---
+
+## Get Started
+
+| Step | Guide |
+|------|-------|
+| Build your first API in 5 minutes | [Quickstart](getting-started/quickstart.md) |
+| Go deeper with a guided hour | [First Hour](getting-started/first-hour.md) |
+| Install FraiseQL and PostgreSQL | [Installation](getting-started/installation.md) |
+
+```bash
+pip install "fraiseql[all]"
+```
+
+Requirements: **Python 3.13+** and **PostgreSQL 13+**.
+
+---
+
+## Learn the Concepts
+
+- **[Core Concepts](foundation/02-core-concepts.md)** — types, queries, mutations,
+  and how decorators map to the database.
+- **[Database-Centric Architecture](foundation/03-database-centric-architecture.md)** —
+  the JSONB view pattern, CQRS, and the Trinity identifier convention.
+- **[Design Principles](foundation/04-design-principles.md)** — the ideas that shape
+  the framework.
+- **[Type System](foundation/09-type-system.md)** — scalars, inputs, enums, and how
+  Python type hints become GraphQL types.
+
+## Build & Operate
+
+- **[Guides](guides/README.md)** — schema design, authorization, analytics, and
+  client integration.
+- **[Patterns](patterns/README.md)** — multi-tenant SaaS, OLAP, real-time
+  collaboration, e-commerce, and IoT blueprints.
+- **[Reference](reference/README.md)** — decorators, scalar types, and `WHERE`
+  operators.
+- **[Production Deployment](guides/production-deployment.md)** — running FraiseQL at
+  scale on FastAPI.
+
+---
+
+## A Note on Versions
+
+This documentation is for **FraiseQL v1** — the Python framework in the
+[`fraiseql-python`](https://github.com/fraiseql/fraiseql-python) repository. It is
+PostgreSQL-only and runs your schema at runtime over FastAPI, with the optional
+`fraiseql_rs` Rust pipeline for fast JSON transformation.
+
+A separate, compiled multi-database engine (FraiseQL v2) lives in a different
+repository and is not covered here.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,12 @@ markdown_extensions:
   - pymdownx.tilde
 
 nav:
+  - Home: index.md
+  - Getting Started:
+    - Overview: getting-started/README.md
+    - Quickstart: getting-started/quickstart.md
+    - First Hour: getting-started/first-hour.md
+    - Installation: getting-started/installation.md
   - Foundation:
     - Core Concepts: foundation/02-core-concepts.md
     - Database-Centric Architecture: foundation/03-database-centric-architecture.md


### PR DESCRIPTION
Phase 2 of the docs cleanup (follows #417). This PR restores the published **entry points** that Phase 1 left missing and clears dangling links to removed v2 pages.

## Changes

- **New landing page** (`docs/index.md`): describes FraiseQL v1 accurately — a Python *runtime* GraphQL framework for **PostgreSQL**, served over FastAPI, with the optional `fraiseql_rs` Rust pipeline. Uses the real v1 API (`@fraiseql.type` / `@fraiseql.query` / `create_fraiseql_app`). No compiler/multi-DB/Arrow framing.
- **Nav**: wired the already-clean `getting-started/` directory into `mkdocs.yml` (Home + Getting Started → Overview, Quickstart, First Hour, Installation). These pages existed but were unreachable after the old v2 `README.md`/`getting-started.md` were removed.
- **Dangling links**: removed links to the deleted `ta-table-pattern.md` (v2 Arrow plane) from the nav-published `architecture/database/tv-table-pattern.md` and `view-selection-guide.md`; fixed the broken `../README.md` link in `getting-started/README.md`.

## Verification

- `mkdocs build` (non-strict) introduces **no new warnings**; the `ta-table-pattern` warnings are cleared from nav-published pages.
- All new nav targets resolve.

## Scope

Deliberately small and focused on entry points. The `foundation/` rewrites and the remaining area-by-area v2→v1 rewrites follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)