### PR TITLE
docs(architecture): rewrite Database + Analytics pages for v1 (Phase 2)

### DIFF
--- a/docs/architecture/analytics/aggregation-model.md
+++ b/docs/architecture/analytics/aggregation-model.md
@@ -1,412 +1,274 @@
-<!-- Skip to main content -->
 ---
-
 title: Aggregation Model
-description: FraiseQL v2 supports **database-native aggregations** through compile-time schema analysis and runtime SQL generation. All aggregations execute server-side in t
+description: FraiseQL v1 derives GROUP BY and aggregate SQL at runtime from the GraphQL field selection, executing server-side against your PostgreSQL v_/tv_ views.
 keywords: ["design", "scalability", "performance", "patterns", "security"]
 tags: ["documentation", "reference"]
 ---
 
 # Aggregation Model
 
-**Version:** 1.0
-**Status:** Complete
-**Audience:** Compiler developers, runtime engineers, SDK users
-**Date:** January 12, 2026
+**Status:** Stable
+**Audience:** Runtime engineers, SDK users, DBAs
+**Database:** PostgreSQL
 
 ---
 
 ## Overview
 
-FraiseQL v2 supports **database-native aggregations** through compile-time schema analysis and runtime SQL generation. All aggregations execute server-side in the database, leveraging native SQL performance.
+FraiseQL v1 supports **runtime auto-aggregation**. When a GraphQL query selects
+aggregate fields on a view-backed type, FraiseQL inspects the field selection and
+derives the corresponding `GROUP BY` + aggregate SQL **at request time**, then
+executes it server-side against your PostgreSQL `v_`/`tv_` view. The aggregation
+logic lives in `_derive_auto_aggregation` / `_parse_aggregation_expr` in
+`src/fraiseql/db.py`.
 
-**Key Principle**: No joins. All dimensions must be denormalized into the `data` JSONB column at ETL time.
+There is no compiler and no build step: nothing is generated ahead of time. The
+GraphQL field selection drives the SQL, and PostgreSQL does the heavy lifting.
+
+**Key principle**: aggregation happens inside the database. You model the
+measures and dimensions in a `v_`/`tv_` view, and FraiseQL pushes the grouping
+and aggregate functions down to that view.
+
+You define the type with a normal `@fraiseql.type` decorator pointing at the
+view:
+
+```python
+import fraiseql
+from fraiseql.types import ID
+
+@fraiseql.type(sql_source="v_sales", jsonb_column="data")
+class Sales:
+    id: ID
+    category: str
+    region: str
+    revenue: float
+```
+
+When you run a query that selects aggregate fields, FraiseQL builds the
+`GROUP BY` query for you. You can always fall back to writing the aggregation
+directly in the view's SQL if you need full control.
 
 ---
 
 ## Aggregate Functions
 
-### Supported Functions (All Databases)
+FraiseQL derives the following PostgreSQL aggregate functions from the field
+selection:
 
-**Basic Aggregates**:
+- `COUNT(*)` — count all rows
+- `COUNT(field)` — count non-null values in a field
+- `COUNT(DISTINCT field)` — count unique values
+- `SUM(field)` — sum of values
+- `AVG(field)` — average of values
+- `MIN(field)` — minimum value
+- `MAX(field)` — maximum value
+- `STDDEV(field)` — standard deviation
+- `VARIANCE(field)` — variance
 
-- `COUNT(*)` - Count all rows
-- `COUNT(field)` - Count non-null values in field
-- `COUNT(DISTINCT field)` - Count unique values
-- `SUM(field)` - Sum all values
-- `AVG(field)` - Average of values
-- `MIN(field)` - Minimum value
-- `MAX(field)` - Maximum value
+These are standard PostgreSQL aggregates. Any aggregate expression PostgreSQL
+understands can also be written by hand inside a `v_`/`tv_` view if you need
+something beyond the derived set.
 
-**Example**:
+**Example** — an aggregate query expressed directly in SQL:
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
     COUNT(*) AS total_count,
     COUNT(DISTINCT customer_id) AS unique_customers,
     SUM(revenue) AS total_revenue,
     AVG(revenue) AS avg_revenue,
     MIN(revenue) AS min_revenue,
-    MAX(revenue) AS max_revenue
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-### Database-Specific Extensions
-
-**PostgreSQL**:
-
-- `STDDEV(field)` - Standard deviation
-- `VARIANCE(field)` - Variance
-- `PERCENTILE_CONT(fraction)` - Continuous percentile
-- `PERCENTILE_DISC(fraction)` - Discrete percentile
-
-**MySQL**:
-
-- `GROUP_CONCAT(field)` - Concatenate values with delimiter
-- `STDDEV(field)` - Standard deviation (limited support)
-
-**SQLite**:
-
-- Limited to basic functions only (COUNT, SUM, AVG, MIN, MAX)
-
-**SQL Server**:
-
-- `STDEV(field)` / `STDEVP(field)` - Standard deviation (sample/population)
-- `VAR(field)` / `VARP(field)` - Variance (sample/population)
+    MAX(revenue) AS max_revenue,
+    STDDEV(revenue) AS revenue_stddev,
+    VARIANCE(revenue) AS revenue_variance
+FROM v_sales;
+```
 
 ---
 
 ## GROUP BY Semantics
 
-### Compilation Strategy
+### How auto-aggregation works at runtime
 
-When the compiler encounters a fact table (marked with `fact_table=True` in schema):
+When a GraphQL query selects aggregate fields on a view-backed type, FraiseQL:
 
-1. **Introspect Table Structure**:
-   - Identify measure columns (numeric types: INT, BIGINT, DECIMAL, FLOAT)
-   - Detect `data` JSONB column for dimensions
-   - Identify denormalized filter columns (indexed SQL columns)
+1. **Parses the field selection**: it identifies which selected fields are
+   dimensions (grouping keys) and which are aggregate expressions (e.g.
+   `SUM(revenue)`).
 
-2. **Generate GroupByExecutionPlan**:
-   - GROUP BY clause with JSONB extraction for dimensions
-   - Aggregate function calls on measure columns
-   - Optional HAVING filters on aggregated results
-   - Optional temporal bucketing (DATE_TRUNC, DATE_FORMAT, strftime)
+2. **Derives the `GROUP BY`**: dimensions become the `GROUP BY` keys. JSONB
+   dimensions are extracted with `data->>'field'`; native SQL columns declared
+   as native dimensions use direct column references (see
+   [Native Dimensions](#native-dimensions)).
 
-3. **Validate**:
-   - Grouping columns exist in table structure
-   - Measure columns are numeric types
-   - JSONB paths are valid for database target
+3. **Builds the aggregate SELECT**: each aggregate field becomes an aggregate
+   function call on the underlying measure column or JSONB measure path.
 
-### Runtime Execution
+4. **Executes server-side**: the derived SQL runs against your PostgreSQL view
+   and returns aggregated rows.
 
-1. Parse GraphQL GROUP BY request
-2. Generate SELECT statement with:
-   - GROUP BY clause extracting JSONB dimensions
-   - Aggregate functions on SQL measure columns
-   - Optional HAVING filters
-   - Optional temporal bucketing
-3. Lower to database-specific SQL dialect
-4. Execute on database (server-side aggregation)
-5. Return aggregated results
+The function names are validated against an allowlist before SQL is built, so a
+field selection can never inject an arbitrary function.
 
-**Example**:
+**Example**
 
 GraphQL:
 
 ```graphql
-<!-- Code example in GraphQL -->
 query {
-  sales_aggregate(
-    groupBy: { category: true, region: true }
-  ) {
+  sales {
     category
     region
-    revenue_sum
+    revenueSum
     count
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-Generated SQL (PostgreSQL):
+Derived SQL (PostgreSQL):
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
     data->>'category' AS category,
     data->>'region' AS region,
-    SUM(revenue) AS revenue_sum,
+    SUM((data->>'revenue')::numeric) AS revenue_sum,
     COUNT(*) AS count
-FROM tf_sales
+FROM v_sales
 GROUP BY data->>'category', data->>'region';
-```text
-<!-- Code example in TEXT -->
+```
+
+If you prefer, you can encapsulate exactly the same shape inside a `tv_` view
+and have FraiseQL read pre-aggregated rows directly.
 
 ---
 
 ## HAVING Clause
 
-The HAVING clause filters aggregated results after GROUP BY.
-
-### Compilation
-
-1. **Validate**: Ensure HAVING references only aggregated fields or grouping keys
-2. **Generate**: Post-aggregation WHERE clause
-3. **Lower**: Database-specific HAVING syntax
-
-### Example
-
-GraphQL:
-
-```graphql
-<!-- Code example in GraphQL -->
-query {
-  sales_aggregate(
-    groupBy: { category: true },
-    having: { revenue_sum_gte: 10000 }
-  ) {
-    category
-    revenue_sum
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-Generated SQL (PostgreSQL):
+The `HAVING` clause filters aggregated results after `GROUP BY`. Express it
+inside the view's SQL, where it filters on aggregate expressions or grouping
+keys.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
     data->>'category' AS category,
-    SUM(revenue) AS revenue_sum
-FROM tf_sales
+    SUM((data->>'revenue')::numeric) AS revenue_sum
+FROM v_sales
 GROUP BY data->>'category'
-HAVING SUM(revenue) >= $1;
--- Parameters: [10000]
-```text
-<!-- Code example in TEXT -->
+HAVING SUM((data->>'revenue')::numeric) >= 10000;
+```
+
+`HAVING` references only aggregated fields or grouping keys — the same rule
+PostgreSQL enforces.
 
 ---
 
 ## Temporal Bucketing
 
-Temporal bucketing groups timestamps into intervals (day, week, month, etc.).
-
-### Database-Specific Functions
-
-**PostgreSQL**:
+Group timestamps into intervals (day, week, month, quarter, year) using
+PostgreSQL's `DATE_TRUNC`. Bucket inside the view's SQL so the truncated value
+becomes a stable grouping key.
 
 ```sql
-<!-- Code example in SQL -->
-DATE_TRUNC('day', occurred_at)    -- Day bucket
-DATE_TRUNC('week', occurred_at)   -- Week bucket
-DATE_TRUNC('month', occurred_at)  -- Month bucket
+DATE_TRUNC('day', occurred_at)     -- Day bucket
+DATE_TRUNC('week', occurred_at)    -- Week bucket
+DATE_TRUNC('month', occurred_at)   -- Month bucket
 DATE_TRUNC('quarter', occurred_at) -- Quarter bucket
-DATE_TRUNC('year', occurred_at)   -- Year bucket
-```text
-<!-- Code example in TEXT -->
+DATE_TRUNC('year', occurred_at)    -- Year bucket
+```
 
-**MySQL**:
-
-```sql
-<!-- Code example in SQL -->
-DATE_FORMAT(occurred_at, '%Y-%m-%d')      -- Day bucket
-DATE_FORMAT(occurred_at, '%Y-%m')         -- Month bucket
-DATE_FORMAT(occurred_at, '%Y')            -- Year bucket
-```text
-<!-- Code example in TEXT -->
-
-**SQLite**:
+**Example** — a per-day revenue view:
 
 ```sql
-<!-- Code example in SQL -->
-strftime('%Y-%m-%d', occurred_at)  -- Day bucket
-strftime('%Y-%m', occurred_at)     -- Month bucket
-strftime('%Y', occurred_at)        -- Year bucket
-```text
-<!-- Code example in TEXT -->
-
-**SQL Server**:
-
-```sql
-<!-- Code example in SQL -->
-DATEPART(day, occurred_at)     -- Day component
-DATEPART(week, occurred_at)    -- Week component
-DATEPART(month, occurred_at)   -- Month component
-DATEPART(quarter, occurred_at) -- Quarter component
-DATEPART(year, occurred_at)    -- Year component
-```text
-<!-- Code example in TEXT -->
-
-### Supported Buckets
-
-- `second` - PostgreSQL only
-- `minute` - PostgreSQL, SQL Server
-- `hour` - PostgreSQL, SQL Server
-- `day` - All databases
-- `week` - All databases
-- `month` - All databases
-- `quarter` - PostgreSQL, SQL Server
-- `year` - All databases
-
-### Example
-
-GraphQL:
-
-```graphql
-<!-- Code example in GraphQL -->
-query {
-  sales_aggregate(
-    groupBy: { occurred_at_day: true }
-  ) {
-    occurred_at_day
-    revenue_sum
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-Generated SQL (PostgreSQL):
-
-```sql
-<!-- Code example in SQL -->
 SELECT
     DATE_TRUNC('day', occurred_at) AS occurred_at_day,
     SUM(revenue) AS revenue_sum
-FROM tf_sales
+FROM v_sales
 GROUP BY DATE_TRUNC('day', occurred_at)
 ORDER BY occurred_at_day;
-```text
-<!-- Code example in TEXT -->
+```
+
+For richer temporal grouping (week-of-year, fiscal periods, holiday flags),
+materialize the buckets as columns in your view or a calendar table — see
+[Calendar Dimensions](./calendar-dimensions.md).
 
 ---
 
 ## Conditional Aggregates
 
-Conditional aggregates apply filters to individual aggregate functions.
-
-### PostgreSQL (FILTER Clause)
-
-PostgreSQL supports the native `FILTER (WHERE ...)` syntax:
+Conditional aggregates apply a filter to an individual aggregate function.
+PostgreSQL's native `FILTER (WHERE ...)` clause expresses these cleanly inside a
+view:
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
     COUNT(*) AS total_orders,
     SUM(revenue) FILTER (WHERE data->>'status' = 'completed') AS completed_revenue,
     SUM(revenue) FILTER (WHERE data->>'status' = 'cancelled') AS cancelled_revenue
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
+FROM v_sales;
+```
 
-### MySQL/SQLite/SQL Server (CASE WHEN Emulation)
-
-Other databases emulate with CASE WHEN:
-
-```sql
-<!-- Code example in SQL -->
-SELECT
-    COUNT(*) AS total_orders,
-    SUM(CASE WHEN data->>'status' = 'completed' THEN revenue ELSE 0 END) AS completed_revenue,
-    SUM(CASE WHEN data->>'status' = 'cancelled' THEN revenue ELSE 0 END) AS cancelled_revenue
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-### GraphQL API
-
-```graphql
-<!-- Code example in GraphQL -->
-query {
-  sales_aggregate {
-    count
-    revenue_sum
-    completed_revenue: revenue_sum(
-      filter: { status: { _eq: "completed" } }
-    )
-    cancelled_revenue: revenue_sum(
-      filter: { status: { _eq: "cancelled" } }
-    )
-  }
-}
-```text
-<!-- Code example in TEXT -->
+You can expose each filtered aggregate as a separate column in the view, then
+select them as ordinary fields in GraphQL.
 
 ---
 
 ## Performance Characteristics
 
-### SQL Column Aggregation
+### Aggregate typed columns where you can
 
-**10-100x faster than JSONB aggregation**:
-
-- Direct access to typed numeric columns
-- B-tree indexes on measure columns
-- Database native aggregation optimizations
-
-**Example**:
+Aggregating a typed numeric column is far faster than parsing values out of
+JSONB on every row. Where a measure is queried often, keep it as a real column
+in the view (or in the underlying `tv_` projection table) rather than reaching
+into `data`:
 
 ```sql
-<!-- Code example in SQL -->
--- ✅ FAST: SQL column aggregation
-SELECT SUM(revenue) FROM tf_sales;
--- Execution time: 0.2ms (1M rows)
+-- Fast: aggregating a typed column
+SELECT SUM(revenue) FROM v_sales;
+-- ~0.2 ms over 1M rows
 
--- ❌ SLOW: JSONB aggregation (if measures were in JSONB)
-SELECT SUM((data->>'revenue')::numeric) FROM tf_sales;
--- Execution time: 45ms (1M rows)
--- 225x slower!
-```text
-<!-- Code example in TEXT -->
+-- Slower: parsing the measure out of JSONB on every row
+SELECT SUM((data->>'revenue')::numeric) FROM v_sales;
+-- ~45 ms over 1M rows
+```
 
-### Indexed Measures
+### Index measures used in aggregations
 
-For common aggregation queries, create indexes on measure columns:
+For frequent aggregations with selective filters, index the measure columns of
+the backing table:
 
 ```sql
-<!-- Code example in SQL -->
-CREATE INDEX idx_sales_revenue ON tf_sales(revenue);
-CREATE INDEX idx_sales_quantity ON tf_sales(quantity);
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_sales_revenue ON tv_sales(revenue);
+CREATE INDEX idx_sales_quantity ON tv_sales(quantity);
+```
 
-**Result**: Near-instantaneous aggregations for queries with selective filters.
+### JSONB dimensions
 
-### JSONB Dimensions
-
-JSONB extraction for GROUP BY is slower than SQL columns, but provides flexibility:
+Grouping by a JSONB path is slower than grouping by a typed column, but it is
+flexible. A GIN index on the `data` column helps:
 
 ```sql
-<!-- Code example in SQL -->
--- Moderate speed: JSONB extraction for grouping
-SELECT
-    data->>'category' AS category,
-    SUM(revenue) AS revenue_sum
-FROM tf_sales
-GROUP BY data->>'category';
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_sales_data_gin ON tv_sales USING GIN(data);
+```
 
-**Optimization**: Use GIN index on `data` column (PostgreSQL):
-
-```sql
-<!-- Code example in SQL -->
-CREATE INDEX idx_sales_data_gin ON tf_sales USING GIN(data);
-```text
-<!-- Code example in TEXT -->
+When a dimension is hot, prefer promoting it to a native column and declaring it
+as a native dimension (next section).
 
 ---
 
 ## Native Dimensions
 
-When a view mixes native SQL columns (e.g. `period_date DATE`, `category_id UUID`) with a JSONB `data` column, native columns can be declared as **native dimensions** to avoid JSONB extraction overhead.
+When a view mixes native SQL columns (e.g. `period_date DATE`,
+`category_id UUID`) with a JSONB `data` column, native columns can be declared
+as **native dimensions** so auto-aggregation groups on the real column instead
+of extracting it from JSONB.
 
 ### Problem
 
-By default, all dimension columns in auto-aggregation are extracted from JSONB:
+By default, dimension columns are extracted from JSONB. If `period_date` is
+really a column, that is both slower (the btree index on the column can't be
+used) and, for ordering, incorrect — `ORDER BY "data" -> 'period_date'`
+references the raw `data` column, which is not in `GROUP BY`, and PostgreSQL
+rejects the query:
 
 ```sql
 -- Default: extracts from JSONB even though period_date is a real column
@@ -416,14 +278,10 @@ GROUP BY "data"->>'period_date'
 ORDER BY "data" -> 'period_date'
 ```
 
-This has two issues:
-
-1. **Performance**: btree indexes on native columns cannot be used
-2. **Correctness**: `ORDER BY "data" -> 'period_date'` references the raw `data` column, which is not in `GROUP BY` — PostgreSQL rejects the query
-
 ### Solution
 
-Declare native columns in the `native_dimensions` key of the aggregation metadata:
+Declare the native columns in the `native_dimensions` key of the aggregation
+metadata:
 
 ```python
 register_type_for_view(
@@ -437,7 +295,8 @@ register_type_for_view(
 )
 ```
 
-FraiseQL generates correct SQL using column references instead of JSONB extraction:
+FraiseQL then groups and orders on the native columns directly, using column
+references and a table alias instead of JSONB extraction:
 
 ```sql
 -- Native dimensions: uses column refs and table alias
@@ -452,53 +311,55 @@ GROUP BY t."period_date", t."category_id", "data"->'dimensions'->>'subcategory'
 ORDER BY t."period_date"
 ```
 
-### Mixed Grouping
+### Mixed grouping
 
-Native and JSONB dimensions coexist in the same query. Native dimensions use `t."col"`, JSONB dimensions use `"data"->>'field'`. The table automatically receives an `AS t` alias when native dimensions are present.
+Native and JSONB dimensions coexist in the same query. Native dimensions use
+`t."col"`, JSONB dimensions use `"data"->>'field'`. The table automatically
+receives an `AS t` alias when native dimensions are present.
 
-### Backward Compatibility
+### Backward compatibility
 
-Existing metadata without `native_dimensions` behaves identically. The key is optional and defaults to an empty list.
+Existing metadata without `native_dimensions` behaves identically. The key is
+optional and defaults to an empty list.
 
 ---
 
 ## No Joins Principle
 
-**Critical**: FraiseQL does not support joins. All dimensional data must be denormalized into the `data` JSONB column at ETL time.
-
-**Example**:
+FraiseQL reads from a single view per query — it does not join across types at
+read time. All dimensional data should already be present in the view, either as
+native columns or denormalized into the `data` JSONB column. Do the joins once,
+inside the view's SQL (or in the process that refreshes a `tv_` projection),
+not per request.
 
 ```sql
-<!-- Code example in SQL -->
--- ❌ NOT SUPPORTED: Joining dimension tables
+-- The view does the join once, server-side
+CREATE VIEW v_sales AS
 SELECT
+    s.id,
     s.revenue,
-    p.category
-FROM tf_sales s
-JOIN td_products p ON s.product_id = p.id;
+    p.category AS product_category,
+    jsonb_build_object(
+        'revenue', s.revenue,
+        'product_category', p.category
+    ) AS data
+FROM tb_sales s
+JOIN tb_products p ON p.pk_product = s.fk_product;
+```
 
--- ✅ CORRECT: Denormalized dimensions in JSONB
-SELECT
-    revenue,
-    data->>'product_category' AS category
-FROM tf_sales;
--- Category was denormalized at ETL time by DBA/data team
-```text
-<!-- Code example in TEXT -->
+GraphQL queries then aggregate over `v_sales` without any further joins.
 
-**ETL Responsibility**:
-
-- FraiseQL provides GraphQL query interface over existing tables
-- DBA/data team creates ETL pipelines to populate `tf_` tables
-- Dimensional data is denormalized from `td_` tables into `tf_` tables' `data` column
+**Data-modeling responsibility**: the DBA / data team designs the `v_`/`tv_`
+views and any ETL or refresh process that keeps a `tv_` projection up to date.
+FraiseQL provides the runtime GraphQL interface and the auto-aggregation on top.
 
 ---
 
-## Related Specifications
+## Related Documentation
 
-- **Fact-Dimension Pattern** (`fact-dimension-pattern.md`) - Fact table structure and patterns
-- **Aggregation Operators** (`../specs/aggregation-operators.md`) - Complete operator reference by database
-- **Capability Manifest** (`../specs/capability-manifest.md`) - Database-specific operator availability
-- **Window Functions** (`window-functions.md`) - Phase 5 analytical functions
-
----
+- [Fact-Dimension Pattern](./fact-dimension-pattern.md) — fact and dimension table design for analytics views
+- [Calendar Dimensions](./calendar-dimensions.md) — temporal dimensions and calendar tables
+- [Window Functions](./window-functions.md) — ranking and running totals as raw-SQL view patterns
+- [View Selection Guide](../database/view-selection-guide.md) — choosing between `v_` and `tv_` views
+- [Aggregation Operators](../../specs/aggregation-operators.md) — operator reference
+- [Schema Conventions](../../specs/schema-conventions.md) — naming and schema conventions

--- a/docs/architecture/analytics/calendar-dimensions.md
+++ b/docs/architecture/analytics/calendar-dimensions.md
@@ -1,64 +1,64 @@
-<!-- Skip to main content -->
 ---
-
 title: Calendar Dimensions for High-Performance Analytics
-description: Calendar dimensions provide **10-20x performance improvements** for time-based aggregations by using pre-computed temporal fields stored in JSONB columns instea
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+description: Calendar dimensions provide 10-20x performance improvements for time-based aggregations by using pre-computed temporal fields stored in JSONB columns instead of runtime DATE_TRUNC operations.
+keywords: ["design", "scalability", "performance", "patterns", "postgresql"]
 tags: ["documentation", "reference"]
 ---
 
 # Calendar Dimensions for High-Performance Analytics
 
-**Version:** 1.0
-**Status:** Complete
-**Audience:** DBAs, data engineers, SDK users
-**Date:** January 13, 2026
+**Status:** Stable
+**Audience:** DBAs, data engineers, FraiseQL users
 
 ---
 
 ## Overview
 
-Calendar dimensions provide **10-20x performance improvements** for time-based aggregations by using pre-computed temporal fields stored in JSONB columns instead of runtime `DATE_TRUNC()` operations.
+Calendar dimensions provide **10-20x performance improvements** for time-based
+aggregations by storing pre-computed temporal fields in JSONB columns instead of
+re-deriving them with `DATE_TRUNC()` on every read.
 
-**Performance Impact**:
+This is a **PostgreSQL data-modeling pattern**, not a FraiseQL API. You compute the
+calendar fields in your table or view SQL (a DBA / data-modeling responsibility), and
+FraiseQL simply queries the resulting `v_`/`tv_` view at runtime through its CQRS
+repository. There is no build step and no auto-detection — the speedup comes entirely
+from the SQL you write.
 
-- **Without calendar dimensions**: 500ms for 1M rows (runtime DATE_TRUNC)
-- **With calendar dimensions**: 30ms for 1M rows (pre-computed JSONB extraction)
-- **Speedup**: 16x faster temporal aggregations
+**Performance impact:**
+
+- **Without calendar dimensions:** ~500ms for 1M rows (runtime `DATE_TRUNC`)
+- **With calendar dimensions:** ~30ms for 1M rows (pre-computed JSONB extraction)
+- **Speedup:** ~16x faster temporal aggregations
 
 ---
 
 ## Quick Start
 
-### 1. Add Calendar Column to Your Fact Table
+### 1. Add a calendar column to your fact table
 
-**Simplest approach** - single `date_info` column:
+**Simplest approach** — a single `date_info` column:
 
 ```sql
-<!-- Code example in SQL -->
 ALTER TABLE tf_sales ADD COLUMN date_info JSONB;
-```text
-<!-- Code example in TEXT -->
+```
 
-**Advanced approach** - multiple granularity columns:
+**Advanced approach** — multiple granularity columns:
 
 ```sql
-<!-- Code example in SQL -->
 ALTER TABLE tf_sales
   ADD COLUMN date_info JSONB,
   ADD COLUMN week_info JSONB,
   ADD COLUMN month_info JSONB,
   ADD COLUMN quarter_info JSONB,
   ADD COLUMN year_info JSONB;
-```text
-<!-- Code example in TEXT -->
+```
 
-### 2. Populate Calendar Fields
+### 2. Populate calendar fields on write
 
-Create a trigger or ETL function to populate calendar fields on insert/update:
+Create a trigger (or ETL function) that populates the calendar fields on insert/update,
+so the work happens once per row rather than on every read:
 
 ```sql
-<!-- Code example in SQL -->
 CREATE OR REPLACE FUNCTION populate_calendar_fields()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -71,7 +71,7 @@ BEGIN
         'year', EXTRACT(YEAR FROM NEW.occurred_at)
     );
 
-    -- Optional: Populate month_info for optimized month-level queries
+    -- Optional: populate month_info for month-level queries
     NEW.month_info = jsonb_build_object(
         'month', EXTRACT(MONTH FROM NEW.occurred_at),
         'quarter', EXTRACT(QUARTER FROM NEW.occurred_at),
@@ -86,65 +86,84 @@ CREATE TRIGGER trg_calendar_fields
   BEFORE INSERT OR UPDATE ON tf_sales
   FOR EACH ROW
   EXECUTE FUNCTION populate_calendar_fields();
-```text
-<!-- Code example in TEXT -->
+```
 
-### 3. FraiseQL Auto-Detection
+### 3. Expose the pre-computed buckets through a read view
 
-**No code changes needed!** FraiseQL automatically:
-
-- Detects `*_info` JSONB columns during schema compilation
-- Uses pre-computed fields for temporal queries
-- Falls back to `DATE_TRUNC()` if calendar columns are absent
-
-**Example query**:
-
-```graphql
-<!-- Code example in GraphQL -->
-query {
-  sales_aggregate(
-    groupBy: { occurred_at_month: true }
-  ) {
-    occurred_at_month
-    count
-    revenue_sum
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Generated SQL** (automatic optimization):
+Surface the calendar buckets in the `v_`/`tv_` view that FraiseQL reads. The `data`
+JSONB column already carries the bucket values, so temporal aggregations group by a
+plain JSONB extraction instead of `DATE_TRUNC`:
 
 ```sql
-<!-- Code example in SQL -->
--- WITH calendar dimensions (30ms):
+CREATE VIEW v_sales AS
 SELECT
-  date_info->>'month' AS occurred_at_month,
+    s.id,
+    jsonb_build_object(
+        'id', s.id,
+        'revenue', s.revenue,
+        'occurredAt', s.occurred_at,
+        'month', s.date_info->>'month',
+        'quarter', s.date_info->>'quarter',
+        'year', s.date_info->>'year'
+    ) AS data
+FROM tf_sales s;
+```
+
+Map the view to a FraiseQL type and query it at runtime:
+
+```python
+import fraiseql
+from fraiseql.types import ID
+
+@fraiseql.type(sql_source="v_sales", jsonb_column="data")
+class Sale:
+    id: ID
+    revenue: float
+    occurred_at: str
+    month: int
+    quarter: int
+    year: int
+
+@fraiseql.query
+async def sales(info) -> list[Sale]:
+    db = info.context["db"]
+    return await db.find("v_sales")
+```
+
+FraiseQL reads the pre-computed buckets straight from the view — no `DATE_TRUNC`
+runs on the read path.
+
+**Fast path (pre-computed, ~30ms):**
+
+```sql
+SELECT
+  data->>'month' AS month,
   COUNT(*),
   SUM(revenue)
-FROM tf_sales
-GROUP BY date_info->>'month';
+FROM v_sales
+GROUP BY data->>'month';
+```
 
--- WITHOUT calendar dimensions (500ms):
+**Slow path (runtime DATE_TRUNC, ~500ms):**
+
+```sql
 SELECT
-  DATE_TRUNC('month', occurred_at) AS occurred_at_month,
+  DATE_TRUNC('month', occurred_at) AS month,
   COUNT(*),
   SUM(revenue)
 FROM tf_sales
 GROUP BY DATE_TRUNC('month', occurred_at);
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
 ## Calendar Column Structure
 
-### Single Column Approach (Recommended for Most Cases)
+### Single-column approach (recommended for most cases)
 
 A single `date_info` column can serve all temporal queries:
 
 ```json
-<!-- Code example in JSON -->
 {
   "date": "2024-03-15",
   "week": 11,
@@ -152,24 +171,23 @@ A single `date_info` column can serve all temporal queries:
   "quarter": 1,
   "year": 2024
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Supports these queries**:
+**Supports these buckets** via JSONB extraction in your view:
 
-- `occurred_at_day` → extracts `date_info->>'date'`
-- `occurred_at_week` → extracts `date_info->>'week'`
-- `occurred_at_month` → extracts `date_info->>'month'`
-- `occurred_at_quarter` → extracts `date_info->>'quarter'`
-- `occurred_at_year` → extracts `date_info->>'year'`
+- day → `date_info->>'date'`
+- week → `date_info->>'week'`
+- month → `date_info->>'month'`
+- quarter → `date_info->>'quarter'`
+- year → `date_info->>'year'`
 
-**Storage**: ~150 bytes per row (negligible overhead)
+**Storage:** ~150 bytes per row (negligible overhead).
 
-### Multi-Column Approach (Advanced Pattern)
+### Multi-column approach (advanced pattern)
 
-For maximum flexibility and organization, use 7 separate columns:
+For maximum flexibility and organization, use separate columns per granularity:
 
-| Column | Buckets Available | Use Case |
+| Column | Buckets available | Use case |
 |--------|------------------|----------|
 | `date_info` | date, week, month, quarter, year | Day-level queries |
 | `week_info` | week, month, quarter, year | Week-level queries |
@@ -179,64 +197,58 @@ For maximum flexibility and organization, use 7 separate columns:
 | `year_info` | year | Year-level queries |
 | `decade_info` | decade | Decade-level queries (optional) |
 
-**Example `month_info`**:
+**Example `month_info`:**
 
 ```json
-<!-- Code example in JSON -->
 {
   "month": 3,
   "quarter": 1,
   "year": 2024
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Advantages**:
+**Advantages:**
 
 - Clear separation of granularity levels
 - Easier to manage in complex ETL pipelines
 - Proven pattern for high-performance analytics
 
-**Storage**: ~800 bytes per row (7 columns × ~120 bytes average)
+**Storage:** ~800 bytes per row (7 columns × ~120 bytes average).
 
 ---
 
-## Flexible Detection
+## Flexible Coverage
 
-FraiseQL adapts to **any combination** of calendar columns:
+Calendar columns are entirely under your control — add whatever combination of
+granularities your workload needs and reference them from your view SQL.
 
-### ✅ Single Column
+### Single column
 
 ```sql
-<!-- Code example in SQL -->
 -- Only date_info
 ALTER TABLE tf_sales ADD COLUMN date_info JSONB;
-```text
-<!-- Code example in TEXT -->
+```
 
-- Detects: 1 granularity with 5 buckets (day, week, month, quarter, year)
-- All temporal queries use this column
+- One granularity with five buckets (day, week, month, quarter, year)
+- All temporal queries extract from this column
 
-### ✅ Selective Columns
+### Selective columns
 
 ```sql
-<!-- Code example in SQL -->
 -- Only the columns you need
 ALTER TABLE tf_sales
   ADD COLUMN date_info JSONB,
   ADD COLUMN month_info JSONB;
-```text
-<!-- Code example in TEXT -->
+```
 
-- Detects: 2 granularities
+- Two granularities
 - Day/week queries use `date_info`
 - Month/quarter queries use `month_info`
 
-### ✅ Full Multi-Column Structure
+### Full multi-column structure
 
 ```sql
-<!-- Code example in SQL -->
--- All 7 columns
+-- All seven columns
 ALTER TABLE tf_sales
   ADD COLUMN date_info JSONB,
   ADD COLUMN week_info JSONB,
@@ -245,186 +257,103 @@ ALTER TABLE tf_sales
   ADD COLUMN semester_info JSONB,
   ADD COLUMN year_info JSONB,
   ADD COLUMN decade_info JSONB;
-```text
-<!-- Code example in TEXT -->
+```
 
-- Detects: 7 granularities
+- Seven granularities
 - Maximum flexibility and organization
 
-### ✅ Custom Columns
+### Custom columns
 
 ```sql
-<!-- Code example in SQL -->
--- Any *_info JSONB column is detected
+-- Any JSONB column works; reference it from your view
 ALTER TABLE tf_sales ADD COLUMN my_custom_info JSONB;
-```text
-<!-- Code example in TEXT -->
+```
 
-- Must follow naming pattern: `*_info`
-- Must be JSONB (PostgreSQL) or JSON (MySQL/SQLite/SQL Server)
-
----
-
-## Multi-Database Support
-
-Calendar dimensions work across all 4 supported databases:
-
-### PostgreSQL (JSONB)
-
-```sql
-<!-- Code example in SQL -->
-SELECT date_info->>'month' AS month
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-### MySQL (JSON)
-
-```sql
-<!-- Code example in SQL -->
-SELECT JSON_UNQUOTE(JSON_EXTRACT(date_info, '$.month')) AS month
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-### SQLite (JSON)
-
-```sql
-<!-- Code example in SQL -->
-SELECT json_extract(date_info, '$.month') AS month
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-### SQL Server (JSON as NVARCHAR)
-
-```sql
-<!-- Code example in SQL -->
-SELECT JSON_VALUE(date_info, '$.month') AS month
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-**FraiseQL automatically generates the correct SQL for your database.**
+- Use JSONB so PostgreSQL can index and extract it efficiently
+- Surface the buckets you care about in the `v_`/`tv_` view's `data` column
 
 ---
 
 ## Backward Compatibility
 
-Calendar dimensions are **100% backward compatible**:
+Calendar dimensions are an **opt-in** optimization. A view that uses `DATE_TRUNC`
+keeps working exactly as before; adding calendar columns only changes the SQL inside
+your view, never the GraphQL contract.
 
-### Without Calendar Columns
+### Without calendar columns
 
 ```sql
-<!-- Code example in SQL -->
--- Traditional table (no calendar columns)
+-- Traditional fact table (no calendar columns)
 CREATE TABLE tf_sales (
     revenue DECIMAL(10,2),
     occurred_at TIMESTAMPTZ
 );
-```text
-<!-- Code example in TEXT -->
+```
 
-**Query behavior**:
-
-```graphql
-<!-- Code example in GraphQL -->
-query {
-  sales_aggregate(groupBy: { occurred_at_month: true }) {
-    occurred_at_month
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Generated SQL** (automatic fallback):
+The view derives buckets at read time:
 
 ```sql
-<!-- Code example in SQL -->
-SELECT DATE_TRUNC('month', occurred_at) AS occurred_at_month
+SELECT DATE_TRUNC('month', occurred_at) AS month
 FROM tf_sales
 GROUP BY DATE_TRUNC('month', occurred_at);
-```text
-<!-- Code example in TEXT -->
+```
 
-### With Calendar Columns
+### With calendar columns
 
 ```sql
-<!-- Code example in SQL -->
 -- Enhanced table (with calendar optimization)
 CREATE TABLE tf_sales (
     revenue DECIMAL(10,2),
     occurred_at TIMESTAMPTZ,
-    date_info JSONB  -- Added
+    date_info JSONB  -- added
 );
-```text
-<!-- Code example in TEXT -->
+```
 
-**Same query**, but **16x faster SQL**:
+The same view now reads pre-computed buckets — **~16x faster**:
 
 ```sql
-<!-- Code example in SQL -->
-SELECT date_info->>'month' AS occurred_at_month
+SELECT date_info->>'month' AS month
 FROM tf_sales
 GROUP BY date_info->>'month';
-```text
-<!-- Code example in TEXT -->
+```
 
-**No code changes required** - FraiseQL automatically uses the faster path when available.
+The GraphQL type and query stay identical; only the view SQL changes.
 
 ---
 
 ## Best Practices
 
-### 1. Start Simple, Optimize Later
+### 1. Start simple, optimize later
 
-**Phase 1: No Calendar Columns**
+1. **Profile first** — use plain `DATE_TRUNC()` in your view and identify slow temporal queries.
+2. **Add a single column** — introduce `date_info`, populate it via trigger/ETL, and measure the speedup.
+3. **Expand if needed** — add `month_info`, `quarter_info`, etc. only for the granularities you actually query.
 
-- Use FraiseQL's default `DATE_TRUNC()` behavior
-- Profile query performance
-- Identify slow temporal queries
+### 2. Populate on write, not on read
 
-**Phase 2: Add Single Column**
-
-- Add `date_info` JSONB column
-- Populate with trigger/ETL
-- Measure 10-20x speedup
-
-**Phase 3: Expand (Optional)**
-
-- Add `month_info`, `quarter_info` if needed
-- Only add what you use
-
-### 2. Populate on Write, Not on Read
-
-**✅ Good - Populate on INSERT/UPDATE**:
+Good — populate on `INSERT`/`UPDATE`:
 
 ```sql
-<!-- Code example in SQL -->
 CREATE TRIGGER trg_calendar_fields
   BEFORE INSERT OR UPDATE ON tf_sales
   FOR EACH ROW
   EXECUTE FUNCTION populate_calendar_fields();
-```text
-<!-- Code example in TEXT -->
+```
 
-**❌ Bad - Compute on SELECT**:
+Bad — compute on `SELECT` (this defeats the purpose):
 
 ```sql
-<!-- Code example in SQL -->
--- Don't do this - defeats the purpose!
+-- Re-derives the buckets on every read; no benefit over DATE_TRUNC
 SELECT
   jsonb_build_object('month', EXTRACT(MONTH FROM occurred_at)) AS date_info
 FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
+```
 
-### 3. Backfill Existing Data
+### 3. Backfill existing data
 
-After adding calendar columns, backfill historical data:
+After adding calendar columns, backfill historical rows:
 
 ```sql
-<!-- Code example in SQL -->
 -- Backfill date_info for existing rows
 UPDATE tf_sales
 SET date_info = jsonb_build_object(
@@ -435,14 +364,11 @@ SET date_info = jsonb_build_object(
     'year', EXTRACT(YEAR FROM occurred_at)
 )
 WHERE date_info IS NULL;
-```text
-<!-- Code example in TEXT -->
+```
 
-**For large tables**, use batching:
+For large tables, batch the update:
 
 ```sql
-<!-- Code example in SQL -->
--- Batch update in chunks
 DO $$
 DECLARE
     batch_size INT := 10000;
@@ -471,123 +397,107 @@ BEGIN
         COMMIT;
     END LOOP;
 END $$;
-```text
-<!-- Code example in TEXT -->
+```
 
-### 4. Index Calendar Columns
+### 4. Index calendar columns
 
-For optimal performance, add indexes on frequently queried temporal buckets:
+Add indexes for the temporal buckets you query most:
 
 ```sql
-<!-- Code example in SQL -->
--- GIN index for flexible JSONB queries
+-- GIN index for flexible JSONB containment queries
 CREATE INDEX idx_sales_date_info ON tf_sales USING GIN (date_info);
 
--- Expression index for specific bucket
+-- Expression index for a specific bucket
 CREATE INDEX idx_sales_month
 ON tf_sales ((date_info->>'month'));
 
--- Composite index for common query pattern
+-- Composite index for a common query pattern
 CREATE INDEX idx_sales_year_month
 ON tf_sales ((date_info->>'year'), (date_info->>'month'));
-```text
-<!-- Code example in TEXT -->
+```
 
-### 5. Monitor Storage Impact
+### 5. Monitor storage impact
 
 Calendar dimensions add minimal storage overhead:
 
 ```sql
-<!-- Code example in SQL -->
 -- Check table size before/after
 SELECT
     pg_size_pretty(pg_total_relation_size('tf_sales')) AS total_size,
     pg_size_pretty(pg_relation_size('tf_sales')) AS table_size,
     pg_size_pretty(pg_indexes_size('tf_sales')) AS indexes_size;
-```text
-<!-- Code example in TEXT -->
+```
 
-**Typical impact**:
+Typical impact:
 
 - Single `date_info` column: ~150 bytes/row (~3% overhead for typical fact tables)
-- Full 7-column structure: ~800 bytes/row (~15% overhead)
+- Full seven-column structure: ~800 bytes/row (~15% overhead)
 
 ---
 
 ## Performance Characteristics
 
-### Query Performance
+### Query performance
 
-| Rows | Without Calendar | With Calendar | Speedup |
+| Rows | Without calendar | With calendar | Speedup |
 |------|-----------------|---------------|---------|
 | 100K | 50ms | 5ms | 10x |
 | 1M | 500ms | 30ms | 16x |
 | 10M | 5000ms | 300ms | 16x |
 | 100M | 50000ms | 3000ms | 16x |
 
-**Benchmark**: PostgreSQL 16, single-node, temporal GROUP BY query
+**Benchmark:** PostgreSQL 16, single-node, temporal `GROUP BY` query.
 
-### Storage Trade-offs
+### Storage trade-offs
 
-**Single `date_info` column**:
+**Single `date_info` column:**
 
 - Storage: +3% table size
 - Performance: 10-16x faster temporal queries
-- ROI: Excellent for most use cases
+- ROI: excellent for most use cases
 
-**Full 7-column structure**:
+**Full seven-column structure:**
 
 - Storage: +15% table size
 - Performance: 10-16x faster temporal queries
-- ROI: Best for complex analytics workloads
+- ROI: best for complex analytics workloads
 
-### Write Performance Impact
+### Write performance impact
 
-Calendar columns add **minimal write overhead**:
+Calendar columns add **minimal write overhead** — the trigger does a few `EXTRACT`
+calls and a `jsonb_build_object` per row:
 
-```sql
-<!-- Code example in SQL -->
--- Typical write performance
--- Without calendar: 5000 inserts/sec
--- With calendar: 4800 inserts/sec (4% slower)
-```text
-<!-- Code example in TEXT -->
+- Without calendar: ~5000 inserts/sec
+- With calendar: ~4800 inserts/sec (~4% slower)
 
-**JSONB field population is very efficient** - much cheaper than runtime DATE_TRUNC on reads.
+JSONB field population on write is far cheaper than re-running `DATE_TRUNC` on every read.
 
 ---
 
 ## Troubleshooting
 
-### Calendar Columns Not Detected
+### Queries still use DATE_TRUNC
 
-**Problem**: Added `date_info` column but queries still use `DATE_TRUNC()`
+**Problem:** Added a `date_info` column but queries still run `DATE_TRUNC()`.
 
-**Solution**: Ensure column follows detection rules:
-
-1. Name must end with `_info` (e.g., `date_info`, `custom_info`)
-2. Type must be JSONB (PostgreSQL) or JSON (MySQL/SQLite/SQL Server)
-3. Recompile schema: `FraiseQL-cli compile schema.json`
-
-**Verify detection**:
+**Solution:** Reference the pre-computed bucket in your view SQL. The optimization
+lives in the view, not in FraiseQL — update the `v_`/`tv_` view to extract from
+`date_info` instead of calling `DATE_TRUNC`:
 
 ```sql
-<!-- Code example in SQL -->
--- Check if column exists
+-- Check the column exists and is JSONB
 SELECT column_name, data_type
 FROM information_schema.columns
-WHERE table_name = 'tf_sales' AND column_name LIKE '%_info';
-```text
-<!-- Code example in TEXT -->
+WHERE table_name = 'tf_sales' AND column_name LIKE '%\_info';
+```
 
-### Incorrect Temporal Results
+### Incorrect temporal results
 
-**Problem**: Queries return wrong temporal aggregations after adding calendar columns
+**Problem:** Queries return wrong temporal aggregations after adding calendar columns.
 
-**Solution**: Ensure calendar fields are correctly populated:
+**Solution:** Verify the calendar fields are correctly populated:
 
 ```sql
-<!-- Code example in SQL -->
 -- Verify date_info contents
 SELECT
     occurred_at,
@@ -596,70 +506,57 @@ SELECT
     date_info->>'month' AS extracted_month
 FROM tf_sales
 LIMIT 10;
-```text
-<!-- Code example in TEXT -->
+```
 
-**Check for nulls**:
+Check for unpopulated rows:
 
 ```sql
-<!-- Code example in SQL -->
 SELECT COUNT(*)
 FROM tf_sales
 WHERE date_info IS NULL AND occurred_at IS NOT NULL;
-```text
-<!-- Code example in TEXT -->
+```
 
-### Performance Not Improving
+### Performance not improving
 
-**Problem**: Added calendar columns but queries are still slow
+**Problem:** Added calendar columns but queries are still slow.
 
-**Possible causes**:
+Possible causes:
 
-1. **Missing indexes**:
+1. **Missing indexes:**
 
 ```sql
-<!-- Code example in SQL -->
 -- Add GIN index
 CREATE INDEX idx_sales_date_info ON tf_sales USING GIN (date_info);
-```text
-<!-- Code example in TEXT -->
+```
 
-1. **Large result sets** (calendar optimization helps GROUP BY, not large result sets):
+2. **Large result sets** — calendar optimization helps `GROUP BY`, not large output sets:
 
 ```sql
-<!-- Code example in SQL -->
 -- If returning millions of rows, limit the results
 SELECT ... FROM tf_sales ... LIMIT 1000;
-```text
-<!-- Code example in TEXT -->
+```
 
-1. **Complex WHERE clauses** (calendar only optimizes GROUP BY):
+3. **Heavy WHERE clauses** — calendar columns only speed up `GROUP BY`; make sure your filter columns are indexed:
 
 ```sql
-<!-- Code example in SQL -->
--- Ensure denormalized filter columns are indexed
 CREATE INDEX idx_sales_occurred_at ON tf_sales (occurred_at);
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
 ## Migration Guide
 
-### From DATE_TRUNC to Calendar Dimensions
+### From DATE_TRUNC to calendar dimensions
 
-**Step 1: Add Calendar Column**
+**Step 1 — add the calendar column:**
 
 ```sql
-<!-- Code example in SQL -->
 ALTER TABLE tf_sales ADD COLUMN date_info JSONB;
-```text
-<!-- Code example in TEXT -->
+```
 
-**Step 2: Create Trigger**
+**Step 2 — create the populate trigger:**
 
 ```sql
-<!-- Code example in SQL -->
 CREATE OR REPLACE FUNCTION populate_calendar_fields()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -678,13 +575,11 @@ CREATE TRIGGER trg_calendar_fields
   BEFORE INSERT OR UPDATE ON tf_sales
   FOR EACH ROW
   EXECUTE FUNCTION populate_calendar_fields();
-```text
-<!-- Code example in TEXT -->
+```
 
-**Step 3: Backfill (use batching for large tables)**
+**Step 3 — backfill (batch large tables):**
 
 ```sql
-<!-- Code example in SQL -->
 -- Small tables (<1M rows)
 UPDATE tf_sales
 SET date_info = jsonb_build_object(
@@ -696,30 +591,37 @@ SET date_info = jsonb_build_object(
 )
 WHERE date_info IS NULL;
 
--- Large tables (use batching script from Best Practices section)
-```text
-<!-- Code example in TEXT -->
+-- Large tables: use the batching script from Best Practices
+```
 
-**Step 4: Add Index**
+**Step 4 — add the index:**
 
 ```sql
-<!-- Code example in SQL -->
 CREATE INDEX idx_sales_date_info ON tf_sales USING GIN (date_info);
-```text
-<!-- Code example in TEXT -->
+```
 
-**Step 5: Recompile Schema**
-
-```bash
-<!-- Code example in BASH -->
-FraiseQL-cli compile schema.json
-```text
-<!-- Code example in TEXT -->
-
-**Step 6: Verify Performance**
+**Step 5 — update the read view** to extract pre-computed buckets:
 
 ```sql
-<!-- Code example in SQL -->
+CREATE OR REPLACE VIEW v_sales AS
+SELECT
+    s.id,
+    jsonb_build_object(
+        'id', s.id,
+        'revenue', s.revenue,
+        'occurredAt', s.occurred_at,
+        'month', s.date_info->>'month',
+        'quarter', s.date_info->>'quarter',
+        'year', s.date_info->>'year'
+    ) AS data
+FROM tf_sales s;
+```
+
+FraiseQL already queries `v_sales` at runtime, so no application changes are required.
+
+**Step 6 — verify the speedup:**
+
+```sql
 -- Before: ~500ms for 1M rows
 EXPLAIN ANALYZE
 SELECT
@@ -735,119 +637,72 @@ SELECT
     COUNT(*), SUM(revenue)
 FROM tf_sales
 GROUP BY date_info->>'month';
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
-## Architecture
+## How It Fits the FraiseQL Runtime
 
-### Compilation-Time Detection
+Calendar dimensions live entirely in PostgreSQL. The database is the source of truth,
+and FraiseQL reads whatever your views expose at runtime:
 
-Calendar dimensions are detected during **schema compilation**, not at query runtime:
+1. **You design the schema** — calendar columns and their populate triggers live in your
+   migrations. This is a DBA / data-modeling responsibility.
+2. **The view shapes the data** — your `v_`/`tv_` view builds the `data` JSONB and decides
+   whether a bucket comes from a pre-computed `*_info` column or a runtime `DATE_TRUNC`.
+3. **FraiseQL queries at runtime** — `db.find("v_sales")` returns the view's `data` JSONB,
+   and the Rust hot path shapes it to the requested GraphQL fields. No build step, no
+   schema artifact, no auto-detection.
+4. **Zero overhead when absent** — if a table has no calendar columns, the view falls back
+   to `DATE_TRUNC` and everything still works; the optimization is purely additive.
 
-```text
-<!-- Code example in TEXT -->
-┌─────────────────────────────┐
-│ PostgreSQL Database         │
-│                             │
-│ tf_sales:                   │
-│   - revenue (decimal)       │
-│   - occurred_at (timestamp) │
-│   - date_info (jsonb) ←─────┼─── Detected during compilation
-│   - month_info (jsonb) ←────┼─── "These are calendar dimensions"
-└─────────────────────────────┘
-            ↓
-┌─────────────────────────────┐
-│ FraiseQL-cli compile        │
-│                             │
-│ Introspect table:           │
-│  1. Find *_info columns     │
-│  2. Infer available buckets │
-│  3. Store in metadata       │
-└─────────────────────────────┘
-            ↓
-┌─────────────────────────────┐
-│ schema.compiled.json        │
-│                             │
-│ "calendar_dimensions": [    │
-│   {                         │
-│     "source_column": "...", │
-│     "granularities": [...]  │
-│   }                         │
-│ ]                           │
-└─────────────────────────────┘
-            ↓
-┌─────────────────────────────┐
-│ Query Runtime               │
-│                             │
-│ Parser checks:              │
-│  "occurred_at_month"        │
-│   → Calendar available?     │
-│   → Use date_info->>'month' │
-│                             │
-│ Otherwise:                  │
-│   → Use DATE_TRUNC(...)     │
-└─────────────────────────────┘
-```text
-<!-- Code example in TEXT -->
-
-### DB-First Design
-
-**Schema version acts as ABI** between FraiseQL and database:
-
-1. **Database is source of truth**: Calendar columns live in database schema
-2. **FraiseQL reads schema**: No configuration files needed
-3. **Automatic optimization**: Parser chooses fastest path based on schema
-4. **Zero overhead**: No performance penalty when calendar columns absent
+Because the speedup is encoded in SQL, you can adopt it table by table without touching
+application code or the GraphQL contract.
 
 ---
 
 ## Advanced Topics
 
-### Custom Calendar Buckets
+### Custom calendar buckets
 
-You can add custom temporal buckets beyond the standard ones:
+You can add custom temporal buckets beyond the standard ones, then surface them in your view:
 
 ```sql
-<!-- Code example in SQL -->
--- Add fiscal year (starts April 1)
-NEW.date_info = date_info || jsonb_build_object(
+-- Add a fiscal year that starts April 1
+NEW.date_info = NEW.date_info || jsonb_build_object(
     'fiscal_year',
     CASE
-        WHEN EXTRACT(MONTH FROM occurred_at) >= 4 THEN EXTRACT(YEAR FROM occurred_at)
-        ELSE EXTRACT(YEAR FROM occurred_at) - 1
+        WHEN EXTRACT(MONTH FROM NEW.occurred_at) >= 4 THEN EXTRACT(YEAR FROM NEW.occurred_at)
+        ELSE EXTRACT(YEAR FROM NEW.occurred_at) - 1
     END
 );
-```text
-<!-- Code example in TEXT -->
+```
 
-**Note**: FraiseQL's parser currently only detects standard buckets (day, week, month, quarter, year). Custom buckets can be queried via JSONB path extraction but won't have temporal bucketing shortcuts.
+Expose `data->>'fiscalYear'` from the view and add a matching field on the FraiseQL type;
+FraiseQL will return it like any other column.
 
-### Partial Calendar Coverage
+### Partial calendar coverage
 
-Calendar dimensions work with **sparse data**:
+If only some rows have calendar data, fall back per-row inside the view:
 
 ```sql
-<!-- Code example in SQL -->
 -- Some rows have calendar data, others don't
 SELECT
     COALESCE(date_info->>'month', DATE_TRUNC('month', occurred_at)::text) AS month,
     COUNT(*)
 FROM tf_sales
 GROUP BY month;
-```text
-<!-- Code example in TEXT -->
+```
 
-**Recommendation**: Keep calendar fields consistent. Either populate all rows or none.
+**Recommendation:** keep calendar fields consistent — either populate all rows or none —
+so the fast path is predictable.
 
-### Calendar Dimensions + Window Functions
+### Calendar dimensions with window functions
 
-Calendar dimensions optimize GROUP BY. For window functions, use the `occurred_at` column:
+Calendar buckets speed up `GROUP BY`. For ordered window functions, partition by the
+pre-computed bucket and order by the raw timestamp:
 
 ```sql
-<!-- Code example in SQL -->
--- Window functions use timestamp
 SELECT
     date_info->>'month' AS month,
     SUM(revenue) OVER (
@@ -856,14 +711,18 @@ SELECT
         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
     ) AS cumulative_revenue
 FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
+```
+
+See [Window Functions](./window-functions.md) for the full set of view-side patterns.
 
 ---
 
 ## See Also
 
-- [Aggregation Model](aggregation-model.md) - Core aggregation concepts
-- [Fact-Dimension Pattern](fact-dimension-pattern.md) - Fact table design
-- [Window Functions](window-functions.md) - Advanced analytics
-- [Performance Characteristics](../performance/performance-characteristics.md) - Query performance analysis
+- [Aggregation Model](./aggregation-model.md) — core aggregation concepts
+- [Fact-Dimension Pattern](./fact-dimension-pattern.md) — fact table design
+- [Window Functions](./window-functions.md) — view-side analytics SQL
+- [tv_ Table Pattern](../database/tv-table-pattern.md) — table-backed projection views
+- [View Selection Guide](../database/view-selection-guide.md) — choosing `v_` vs `tv_`
+- [Schema Conventions](../../specs/schema-conventions.md) — naming and `data` JSONB rules
+- [Performance Characteristics](../performance/performance-characteristics.md) — query performance analysis

--- a/docs/architecture/analytics/fact-dimension-pattern.md
+++ b/docs/architecture/analytics/fact-dimension-pattern.md
@@ -1,31 +1,30 @@
-<!-- Skip to main content -->
 ---
-
 title: Fact-Dimension Pattern
-description: FraiseQL enforces the **fact table pattern** for analytical workloads:
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+description: A PostgreSQL data-modeling pattern for analytical workloads in FraiseQL v1.
+keywords: ["design", "scalability", "performance", "patterns", "analytics"]
 tags: ["documentation", "reference"]
 ---
 
 # Fact-Dimension Pattern
 
-**Version:** 1.0
-**Status:** Complete
-**Audience:** Database architects, data engineers, SDK users
-**Date:** January 12, 2026
+**Audience:** Database architects, data engineers, FraiseQL users
 
 ---
 
 ## Overview
 
-FraiseQL enforces the **fact table pattern** for analytical workloads:
+The **fact table pattern** is a data-modeling approach for analytical workloads. You
+design the tables and the ETL/refresh process yourself; FraiseQL queries them at runtime
+through PostgreSQL views, deriving `GROUP BY` and aggregate SQL automatically from the
+GraphQL selection (see [Aggregation Model](./aggregation-model.md)).
 
 - One record = one immutable fact (transaction, measurement, event)
-- Measures stored as SQL columns (10-100x faster aggregation)
-- Dimensions stored in JSONB `data` column (flexible grouping)
+- Measures stored as SQL columns (much faster aggregation)
+- Dimensions stored in a JSONB `data` column (flexible grouping)
 - Denormalized filters as indexed SQL columns
 
-**Critical Principle**: No joins. All dimensional data must be denormalized at ETL time.
+**Critical principle:** No joins at query time. All dimensional data must be denormalized
+at ETL time so the read view is a single standalone table.
 
 ---
 
@@ -34,24 +33,24 @@ FraiseQL enforces the **fact table pattern** for analytical workloads:
 ### Required Columns
 
 1. **Primary Key**: `id` (UUID or BIGSERIAL)
-2. **Measure Columns**: Numeric types for aggregation
-   - INT, BIGINT, DECIMAL, FLOAT, NUMERIC
+2. **Measure Columns**: numeric types for aggregation
+   - `INT`, `BIGINT`, `DECIMAL`, `FLOAT`, `NUMERIC`
    - Examples: `revenue`, `quantity`, `duration_ms`
-3. **Dimensions Column**: `data` JSONB (default name, configurable)
+3. **Dimensions Column**: `data` JSONB (the default column name FraiseQL reads, configurable
+   via `jsonb_column`)
    - Contains all grouping dimensions
    - Examples: category, region, customer_segment
 
 ### Optional Columns
 
-1. **Denormalized Filter Columns**: Indexed SQL columns for fast WHERE filtering
-   - UUIDs, VARCHAR, DATE, ENUM
+1. **Denormalized Filter Columns**: indexed SQL columns for fast `WHERE` filtering
+   - UUIDs, `VARCHAR`, `DATE`, enum
    - Examples: `customer_id`, `product_id`, `occurred_at`, `status`
 2. **Timestamps**: `created_at`, `occurred_at`, etc.
 
 ### Example: Sales Fact Table
 
 ```sql
-<!-- Code example in SQL -->
 CREATE TABLE tf_sales (
     -- Primary key
     id BIGSERIAL PRIMARY KEY,
@@ -62,7 +61,7 @@ CREATE TABLE tf_sales (
     cost DECIMAL(10,2) NOT NULL,
 
     -- Dimensions (JSONB for flexible grouping)
-    dimensions JSONB NOT NULL,
+    data JSONB NOT NULL,
     -- Example data content:
     -- {
     --   "category": "Electronics",
@@ -87,14 +86,36 @@ CREATE INDEX idx_sales_product ON tf_sales(product_id);
 CREATE INDEX idx_sales_occurred ON tf_sales(occurred_at);
 CREATE INDEX idx_sales_status ON tf_sales(status);
 
--- GIN index for JSONB dimensions (PostgreSQL)
+-- GIN index for JSONB dimensions
 CREATE INDEX idx_sales_data_gin ON tf_sales USING GIN(data);
 
 -- Composite index for common query pattern
 CREATE INDEX idx_sales_customer_occurred
     ON tf_sales(customer_id, occurred_at DESC);
-```text
-<!-- Code example in TEXT -->
+```
+
+### Exposing the Fact Table to GraphQL
+
+FraiseQL reads the table through a view (or directly through a table that already carries an
+`id` plus a `data` JSONB column). Define a plain type over the read source — there is no
+special "fact table" decorator parameter:
+
+```python
+import fraiseql
+from fraiseql.types import ID
+
+@fraiseql.type(sql_source="v_sales", jsonb_column="data")
+class Sale:
+    id: ID
+    revenue: float
+    quantity: int
+    category: str
+    region: str
+```
+
+When a query selects measure and dimension fields, FraiseQL derives the `GROUP BY` and the
+aggregate SQL at runtime against this view. The aggregate functions available are the
+standard PostgreSQL ones: `COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, `STDDEV`, `VARIANCE`.
 
 ---
 
@@ -102,118 +123,111 @@ CREATE INDEX idx_sales_customer_occurred
 
 ### Measures (SQL Columns)
 
-**Purpose**: Aggregation targets (SUM, AVG, COUNT, etc.)
+**Purpose**: aggregation targets (`SUM`, `AVG`, `COUNT`, etc.)
 
-**Storage**: Dedicated SQL columns with numeric types
+**Storage**: dedicated SQL columns with numeric types.
 
-**Performance**: 10-100x faster than JSONB
+**Performance**: much faster than aggregating over JSONB.
 
 **Examples**:
 
-- `revenue DECIMAL(10,2)` - Total sale amount
-- `quantity INT` - Number of items
-- `duration_ms BIGINT` - Event duration in milliseconds
-- `error_count INT` - Number of errors
+- `revenue DECIMAL(10,2)` — total sale amount
+- `quantity INT` — number of items
+- `duration_ms BIGINT` — event duration in milliseconds
+- `error_count INT` — number of errors
 
-**Why SQL Columns?**:
+**Why SQL columns?**:
 
 ```sql
-<!-- Code example in SQL -->
--- ✅ FAST: Direct aggregation on SQL column
+-- FAST: direct aggregation on a SQL column
 SELECT SUM(revenue) FROM tf_sales WHERE customer_id = $1;
--- Execution: 0.3ms (1M rows with index)
 
--- ❌ SLOW: Aggregation on JSONB field (don't do this!)
-SELECT SUM((dimensions->>'revenue')::numeric) FROM tf_sales WHERE customer_id = $1;
--- Execution: 52ms (1M rows)
--- 173x slower!
-```text
-<!-- Code example in TEXT -->
+-- SLOW: aggregation on a JSONB field (avoid this)
+SELECT SUM((data->>'revenue')::numeric) FROM tf_sales WHERE customer_id = $1;
+```
+
+The JSONB form must cast text to numeric per row and cannot use a plain numeric index, so it
+is dramatically slower on large tables.
 
 ### Dimensions (JSONB Paths)
 
-**Purpose**: GROUP BY grouping keys
+**Purpose**: `GROUP BY` grouping keys.
 
-**Storage**: JSONB `data` column with flexible schema
+**Storage**: the `data` JSONB column, with a flexible schema.
 
-**Performance**: Slower than SQL columns, but flexible (no ALTER TABLE needed)
+**Performance**: slower than SQL columns, but flexible (no `ALTER TABLE` needed to add a
+dimension).
 
 **Examples**:
 
-- `dimensions->>'category'` - Product category
-- `dimensions->>'region'` - Geographic region
-- `dimensions->>'product_type'` - Product classification
-- `data#>>'{customer,segment}'` - Nested path for customer segment
+- `data->>'category'` — product category
+- `data->>'region'` — geographic region
+- `data->>'product_type'` — product classification
+- `data#>>'{customer,segment}'` — nested path for customer segment
 
 **Why JSONB?**:
 
-- Schema flexibility (add dimensions without ALTER TABLE)
+- Schema flexibility (add dimensions without `ALTER TABLE`)
 - Sparse dimensions (not all facts have all dimensions)
 - Nested structures (hierarchical dimensions)
 - No need to create columns for rarely-used dimensions
 
-**Query Pattern**:
+**Query pattern**:
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
-    dimensions->>'category' AS category,
-    dimensions->>'region' AS region,
+    data->>'category' AS category,
+    data->>'region' AS region,
     SUM(revenue) AS total_revenue
 FROM tf_sales
-GROUP BY dimensions->>'category', dimensions->>'region';
-```text
-<!-- Code example in TEXT -->
+GROUP BY data->>'category', data->>'region';
+```
 
 ### Denormalized Filters (Indexed SQL Columns)
 
-**Purpose**: Fast WHERE filtering (avoid JSONB for high-selectivity filters)
+**Purpose**: fast `WHERE` filtering (avoid JSONB for high-selectivity filters).
 
-**Storage**: Dedicated indexed SQL columns
+**Storage**: dedicated indexed SQL columns.
 
-**Performance**: B-tree index access (microseconds)
+**Performance**: B-tree index access.
 
 **Examples**:
 
-- `customer_id UUID` - Filter by customer (high cardinality)
-- `product_id UUID` - Filter by product
-- `occurred_at TIMESTAMPTZ` - Filter by time range
-- `status VARCHAR(50)` - Filter by status (low cardinality but frequently filtered)
+- `customer_id UUID` — filter by customer (high cardinality)
+- `product_id UUID` — filter by product
+- `occurred_at TIMESTAMPTZ` — filter by time range
+- `status VARCHAR(50)` — filter by status (low cardinality but frequently filtered)
 
-**Why Denormalized?**:
+**Why denormalized?**:
 
 ```sql
-<!-- Code example in SQL -->
--- ✅ FAST: Indexed SQL column filter
+-- FAST: indexed SQL column filter, uses the composite index
 SELECT * FROM tf_sales
 WHERE customer_id = 'uuid-123' AND occurred_at >= '2024-01-01';
--- Uses composite index, execution: 0.05ms
 
--- ❌ SLOW: JSONB filter (don't do this for high-selectivity filters!)
+-- SLOWER: JSONB filter for a high-selectivity exact match (avoid this)
 SELECT * FROM tf_sales
-WHERE dimensions->>'customer_id' = 'uuid-123';
--- GIN index is slower for exact matches, execution: 2-5ms
-```text
-<!-- Code example in TEXT -->
+WHERE data->>'customer_id' = 'uuid-123';
+```
 
 ---
 
 ## No Joins Principle
 
-**Critical Architecture Decision**: FraiseQL does not support joins between tables.
+**Architecture decision**: the read view is a single standalone table — FraiseQL queries it
+directly without joining other tables at query time.
 
 ### Implications
 
-1. All dimensional data must be denormalized into `data` JSONB at ETL time
+1. All dimensional data must be denormalized into the `data` JSONB at ETL time
 2. Dimension tables (`td_*`) are used at ETL time only, never at query time
-3. Each table is completely standalone
-4. Aggregate tables follow the same pattern (not joined to anything)
+3. Each fact table is completely standalone
+4. Pre-aggregated tables follow the same pattern (not joined to anything)
 
 ### Example
 
 ```sql
-<!-- Code example in SQL -->
--- ❌ NOT SUPPORTED: Joining dimension tables at query time
+-- NOT the pattern: joining dimension tables at query time
 SELECT
     s.revenue,
     p.category,
@@ -221,23 +235,19 @@ SELECT
 FROM tf_sales s
 JOIN td_products p ON s.product_id = p.id
 JOIN td_customers c ON s.customer_id = c.id;
--- FraiseQL does not support this!
 
--- ✅ CORRECT: Denormalized dimensions in JSONB (done at ETL time)
+-- CORRECT: dimensions denormalized into JSONB at ETL time
 SELECT
     revenue,
-    dimensions->>'product_category' AS category,
-    dimensions->>'customer_segment' AS segment
+    data->>'product_category' AS category,
+    data->>'customer_segment' AS segment
 FROM tf_sales;
--- Category and segment already denormalized by ETL process
-```text
-<!-- Code example in TEXT -->
+```
 
-### ETL Process (Managed by DBA/Data Team)
+### ETL Process (Managed by the DBA / Data Team)
 
 ```sql
-<!-- Code example in SQL -->
--- Step 1: ETL loads raw transaction
+-- Step 1: ETL loads the raw transaction
 INSERT INTO staging_sales (transaction_id, product_id, customer_id, revenue)
 VALUES ('txn-001', 'prod-123', 'cust-456', 99.99);
 
@@ -247,7 +257,7 @@ INSERT INTO tf_sales (
     revenue,
     quantity,
     cost,
-    data,  -- ← Dimensions denormalized from td_products, td_customers
+    data,  -- dimensions denormalized from td_products, td_customers
     customer_id,
     product_id,
     occurred_at
@@ -262,7 +272,7 @@ SELECT
         'product_name', p.name,
         'customer_segment', c.segment,
         'customer_region', c.region
-    ) AS data,  -- ← Denormalization happens here
+    ) AS data,  -- denormalization happens here
     s.customer_id,
     s.product_id,
     s.occurred_at
@@ -270,213 +280,92 @@ FROM staging_sales s
 JOIN td_products p ON s.product_id = p.id
 JOIN td_customers c ON s.customer_id = c.id;
 
--- Step 3: Staging table is truncated
+-- Step 3: truncate the staging table
 TRUNCATE staging_sales;
-```text
-<!-- Code example in TEXT -->
+```
 
-**Important**: This ETL process is managed by the DBA/data team, NOT by FraiseQL.
-
----
-
-## Compilation Strategy
-
-### Phase 4 (Compiler)
-
-When the compiler encounters a schema with `fact_table=True`:
-
-1. **Introspect Fact Table Structure**:
-
-   ```rust
-<!-- Code example in RUST -->
-   let columns = introspect_table("tf_sales");
-   let measures = columns.filter(|col| col.is_numeric());
-   let data_column = columns.find(|col| col.name == "dimensions" && col.type == "jsonb");
-   let filters = columns.filter(|col| col.has_index());
-   ```text
-<!-- Code example in TEXT -->
-
-2. **Identify Components**:
-   - Measure columns: `revenue`, `quantity`, `cost` (numeric types)
-   - JSONB dimensions column: `dimensions`
-   - Denormalized filter columns: `customer_id`, `product_id`, `occurred_at`
-
-3. **Generate GraphQL Types**:
-   - `Sales` type with measure fields + dimension fields (from JSONB paths)
-   - `SalesWhereInput` with filter columns + JSONB path filters
-   - `SalesAggregateInput` with measure columns for aggregation
-   - `SalesGroupByInput` with dimension paths + temporal buckets
-
-### Phase 5 (Runtime)
-
-When executing an aggregation query:
-
-1. **Parse GROUP BY Request**:
-
-   ```graphql
-<!-- Code example in GraphQL -->
-   query {
-     sales_aggregate(
-       groupBy: { category: true, region: true }
-     ) {
-       category
-       region
-       revenue_sum
-       count
-     }
-   }
-   ```text
-<!-- Code example in TEXT -->
-
-2. **Generate SELECT Statement**:
-
-   ```sql
-<!-- Code example in SQL -->
-   SELECT
-       dimensions->>'category' AS category,
-       dimensions->>'region' AS region,
-       SUM(revenue) AS revenue_sum,
-       COUNT(*) AS count
-   FROM tf_sales
-   GROUP BY dimensions->>'category', dimensions->>'region';
-   ```text
-<!-- Code example in TEXT -->
-
-3. **Execute and Return Results**
+This ETL process is owned by the DBA / data team. FraiseQL does not generate or run it; it
+only queries the resulting view at runtime.
 
 ---
 
-## Database-Specific Considerations
+## How FraiseQL Queries the Fact Table
 
-### PostgreSQL
+You design the fact table and its read view; FraiseQL handles the query side at runtime.
 
-**Strengths**:
+1. **Define a read view** that exposes an `id` and a `data` JSONB column (a `v_` logical view
+   over the fact table, or a `tv_` projection table for heavy reads — see
+   [View Selection Guide](../database/view-selection-guide.md) and
+   [tv_ Table Pattern](../database/tv-table-pattern.md)).
+2. **Declare a plain `@fraiseql.type`** over that view with `sql_source` and `jsonb_column`.
+3. **Let auto-aggregation derive the SQL.** When a GraphQL query selects aggregate fields,
+   FraiseQL builds the `SELECT`, the aggregate functions, and the `GROUP BY` from the
+   requested dimensions automatically.
+
+For example, a GraphQL selection grouping by `category` and `region` and summing `revenue`
+produces, at runtime, SQL equivalent to:
+
+```sql
+SELECT
+    data->>'category' AS category,
+    data->>'region' AS region,
+    SUM(revenue) AS revenue_sum,
+    COUNT(*) AS count
+FROM tf_sales
+GROUP BY data->>'category', data->>'region';
+```
+
+See [Aggregation Model](./aggregation-model.md) for the full `GROUP BY` / `HAVING` /
+`FILTER` semantics.
+
+---
+
+## PostgreSQL JSONB Features
+
+FraiseQL v1 targets PostgreSQL, which gives the fact-dimension pattern a rich toolset:
 
 - Full JSONB support: `->`, `->>`, `#>`, `#>>`, `@>`, `?`, `?&`
-- Native DATE_TRUNC for temporal bucketing
-- FILTER (WHERE ...) for conditional aggregates
+- Native `DATE_TRUNC` for temporal bucketing
+- `FILTER (WHERE ...)` for conditional aggregates
 - GIN indexes for efficient JSONB queries
-- Statistical functions (STDDEV, VARIANCE)
+- Statistical functions (`STDDEV`, `VARIANCE`)
 
 **Example**:
 
 ```sql
-<!-- Code example in SQL -->
--- Advanced JSONB queries
+-- Conditional aggregates over JSONB dimensions
 SELECT
-    dimensions->>'category' AS category,
+    data->>'category' AS category,
     SUM(revenue) FILTER (WHERE data @> '{"region": "North America"}') AS na_revenue,
     SUM(revenue) FILTER (WHERE data @> '{"region": "Europe"}') AS eu_revenue
 FROM tf_sales
-WHERE data ? 'category'  -- Has 'category' key
-GROUP BY dimensions->>'category';
-```text
-<!-- Code example in TEXT -->
-
-### MySQL
-
-**Strengths**:
-
-- JSON_EXTRACT, JSON_CONTAINS for JSON handling
-- DATE_FORMAT for temporal bucketing
-- GROUP_CONCAT for string aggregation
-
-**Limitations**:
-
-- No ILIKE (case-insensitive like)
-- No native regex operators
-- CASE WHEN emulation for conditional aggregates
-
-**Example**:
-
-```sql
-<!-- Code example in SQL -->
--- MySQL JSON extraction
-SELECT
-    JSON_EXTRACT(data, '$.category') AS category,
-    SUM(revenue) AS total_revenue
-FROM tf_sales
-GROUP BY JSON_EXTRACT(data, '$.category');
-```text
-<!-- Code example in TEXT -->
-
-### SQLite
-
-**Strengths**:
-
-- Lightweight, embedded
-- json_extract for basic JSON handling
-- strftime for temporal bucketing
-
-**Limitations**:
-
-- Limited JSON support (no JSON operators beyond extraction)
-- No GIN indexes
-- No statistical functions
-
-**Example**:
-
-```sql
-<!-- Code example in SQL -->
--- SQLite JSON extraction
-SELECT
-    json_extract(data, '$.category') AS category,
-    SUM(revenue) AS total_revenue
-FROM tf_sales
-GROUP BY json_extract(data, '$.category');
-```text
-<!-- Code example in TEXT -->
-
-### SQL Server
-
-**Strengths**:
-
-- JSON_VALUE, JSON_QUERY for JSON handling
-- DATEPART for temporal bucketing
-- Statistical functions (STDEV, VAR with population variants)
-- FOR JSON clause for output formatting
-
-**Limitations**:
-
-- OPENJSON required for complex JSON queries
-- CASE WHEN emulation for conditional aggregates
-
-**Example**:
-
-```sql
-<!-- Code example in SQL -->
--- SQL Server JSON extraction
-SELECT
-    JSON_VALUE(data, '$.category') AS category,
-    SUM(revenue) AS total_revenue
-FROM tf_sales
-GROUP BY JSON_VALUE(data, '$.category');
-```text
-<!-- Code example in TEXT -->
+WHERE data ? 'category'  -- has the 'category' key
+GROUP BY data->>'category';
+```
 
 ---
 
-## Pre-Aggregated Fact Tables = Same Structure, Different Granularity
+## Pre-Aggregated Fact Tables = Same Structure, Coarser Granularity
 
-**Key Insight**: Pre-aggregated tables follow the SAME pattern as fact tables, just with coarser granularity. Use `tf_` prefix with descriptive suffix.
+**Key insight**: pre-aggregated tables follow the same pattern as fact tables, just at a
+coarser granularity. Use the `tf_` prefix with a descriptive suffix.
 
 ### Example: Daily Aggregates
 
 ```sql
-<!-- Code example in SQL -->
 -- Pre-aggregated fact table: same structure as tf_sales, daily granularity
 CREATE TABLE tf_sales_daily (
     id BIGSERIAL PRIMARY KEY,
-    day DATE NOT NULL,  -- Granularity dimension
+    day DATE NOT NULL,  -- granularity dimension
 
     -- Pre-aggregated measures
     revenue DECIMAL(10,2) NOT NULL,      -- SUM(revenue) from tf_sales
     quantity INT NOT NULL,               -- SUM(quantity) from tf_sales
     transaction_count INT NOT NULL,      -- COUNT(*) from tf_sales
 
-    -- Dimensions (same JSONB pattern!)
-    dimensions JSONB NOT NULL,
-    -- Can still group by category, region, etc. from data column
+    -- Dimensions (same JSONB pattern)
+    data JSONB NOT NULL,
+    -- Can still group by category, region, etc. from the data column
 
     -- Timestamps
     created_at TIMESTAMPTZ DEFAULT NOW()
@@ -484,93 +373,79 @@ CREATE TABLE tf_sales_daily (
 
 CREATE UNIQUE INDEX idx_sales_daily_day ON tf_sales_daily(day);
 CREATE INDEX idx_sales_daily_data_gin ON tf_sales_daily USING GIN(data);
-```text
-<!-- Code example in TEXT -->
+```
 
-**Populated via ETL** (managed by DBA/data team):
+**Populated via ETL** (managed by the DBA / data team):
 
 ```sql
-<!-- Code example in SQL -->
-INSERT INTO tf_sales_daily (day, revenue, quantity, transaction_count, data)
+INSERT INTO tf_sales_daily (id, day, revenue, quantity, transaction_count, data)
 SELECT
+    gen_random_uuid(),
     DATE_TRUNC('day', occurred_at)::DATE AS day,
     SUM(revenue) AS revenue,
     SUM(quantity) AS quantity,
     COUNT(*) AS transaction_count,
-    jsonb_build_object() AS data  -- Can preserve dimensions if needed
+    jsonb_build_object() AS data  -- can preserve dimensions if needed
 FROM tf_sales
 GROUP BY DATE_TRUNC('day', occurred_at)::DATE
 ON CONFLICT (day) DO UPDATE SET
     revenue = EXCLUDED.revenue,
     quantity = EXCLUDED.quantity,
     transaction_count = EXCLUDED.transaction_count;
-```text
-<!-- Code example in TEXT -->
+```
 
-**Query Pattern** (FraiseQL treats it like any fact table):
-
-```graphql
-<!-- Code example in GraphQL -->
-query {
-  sales_daily_aggregate(
-    where: { day: { _gte: "2024-01-01" } }
-  ) {
-    day
-    revenue_sum
-    transaction_count_sum
-  }
-}
-```text
-<!-- Code example in TEXT -->
+A daily-rollup view is queried exactly like any other fact-table view — FraiseQL does not
+treat it specially. See [Calendar Dimensions](./calendar-dimensions.md) for modeling time
+buckets, and [Window Functions](./window-functions.md) for running totals and ranking inside
+your view SQL.
 
 ---
 
 ## Best Practices
 
-### When to Use Fact Tables (tf_*)
+### When to Use Fact Tables (`tf_*`)
 
-✅ **Use for**:
+Use for:
 
 - High-volume transactional data (sales, events, logs)
 - Any granularity (raw transactions or pre-aggregated rollups)
 - Real-time or near-real-time data ingestion
 - Data requiring full history retention
 
-❌ **Don't use for**:
+Avoid for:
 
 - Low-volume reference data (use regular tables)
 - Frequently updated records (facts are immutable)
-- Data requiring joins (FraiseQL doesn't support joins)
+- Data requiring query-time joins (denormalize at ETL time instead)
 
-### When to Use Pre-Aggregated Fact Tables (tf_**daily, tf**_monthly, etc.)
+### When to Use Pre-Aggregated Fact Tables (`tf_sales_daily`, `tf_sales_monthly`, etc.)
 
-✅ **Use for**:
+Use for:
 
 - Pre-computed aggregates for common queries
 - Coarser granularity (daily, monthly, per-category, etc.)
 - Query performance optimization
 - Materialized rollups refreshed periodically
-- Same structure as fact tables (measures + `data` JSONB)
+- The same structure as fact tables (measures + `data` JSONB)
 
-### When to Use Dimension Tables (td_*)
+### When to Use Dimension Tables (`td_*`)
 
-✅ **Use for**:
+Use for:
 
 - Reference data for ETL denormalization (products, customers, locations)
 - Lookup data used to enrich fact tables during data loading
 - Master data management
 
-❌ **Don't use for**:
+Avoid for:
 
-- Query-time joins (FraiseQL doesn't support joins)
-- Direct GraphQL exposure (use denormalized data in fact tables instead)
+- Query-time joins (denormalize into the fact table's `data` instead)
+- Direct GraphQL exposure (expose the denormalized fact view instead)
 
 ### Index Strategy
 
-**Denormalized Filter Columns**:
+**Denormalized filter columns**:
 
 ```sql
-<!-- Code example in SQL -->
 -- High-cardinality filters
 CREATE INDEX idx_sales_customer ON tf_sales(customer_id);
 CREATE INDEX idx_sales_product ON tf_sales(product_id);
@@ -581,35 +456,31 @@ CREATE INDEX idx_sales_occurred ON tf_sales(occurred_at);
 -- Composite indexes for common patterns
 CREATE INDEX idx_sales_customer_occurred
     ON tf_sales(customer_id, occurred_at DESC);
-```text
-<!-- Code example in TEXT -->
+```
 
-**JSONB Dimensions** (PostgreSQL):
+**JSONB dimensions**:
 
 ```sql
-<!-- Code example in SQL -->
 -- GIN index for JSONB queries
 CREATE INDEX idx_sales_data_gin ON tf_sales USING GIN(data);
 
--- Specific path index for frequently-queried dimension
+-- Expression index for a frequently-queried dimension
 CREATE INDEX idx_sales_category
-    ON tf_sales ((dimensions->>'category'));
-```text
-<!-- Code example in TEXT -->
+    ON tf_sales ((data->>'category'));
+```
 
-**Don't Over-Index**:
+**Don't over-index**:
 
-- Every index slows INSERT/UPDATE operations
+- Every index slows `INSERT`/`UPDATE` operations
 - Index only frequently-filtered columns
 - Monitor query patterns before adding indexes
 
 ---
 
-## Related Specifications
+## Related Pages
 
-- **Aggregation Model** (`aggregation-model.md`) - GROUP BY, aggregates, HAVING
-- **Analytical Schema Conventions** (`../specs/analytical-schema-conventions.md`) - Naming patterns
-- **Schema Conventions** (`../specs/schema-conventions.md`) - General schema patterns
-- **Database Targeting** (`../database/database-targeting.md`) - Multi-database support
-
----
+- [Aggregation Model](./aggregation-model.md) — `GROUP BY`, aggregates, `HAVING`
+- [Calendar Dimensions](./calendar-dimensions.md) — modeling time buckets in JSONB
+- [Window Functions](./window-functions.md) — running totals and ranking in view SQL
+- [View Selection Guide](../database/view-selection-guide.md) — choosing `v_` vs `tv_`
+- [tv_ Table Pattern](../database/tv-table-pattern.md) — projection tables for heavy reads

--- a/docs/architecture/analytics/window-functions.md
+++ b/docs/architecture/analytics/window-functions.md
@@ -1,26 +1,60 @@
-<!-- Skip to main content -->
 ---
-
-title: Window Functions Architecture
-description: Window functions (analytical functions) perform calculations across rows related to the current row, using an OVER clause to define the window. Unlike aggregate
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+title: Window Functions in FraiseQL Views
+description: How to use PostgreSQL window functions (ROW_NUMBER, RANK, LAG, LEAD, running totals, moving averages) inside your v_/tv_ view SQL and expose the computed columns through the view's data JSONB so FraiseQL serves them like any other field.
+keywords: ["window functions", "postgresql", "views", "analytics", "ranking"]
 tags: ["documentation", "reference"]
 ---
 
-# Window Functions Architecture
+# Window Functions in FraiseQL Views
 
-**Version:** 1.0
-**Status:** Implemented
-**Audience:** Compiler developers, runtime engineers, SDK users
-**Date:** January 18, 2026
+Window functions (analytical functions) perform calculations across rows related to
+the current row, using an `OVER` clause to define the window. Unlike aggregate
+functions with `GROUP BY`, window functions return a value for **every** row.
+
+In FraiseQL v1, window functions are **not** a GraphQL feature — they are plain
+PostgreSQL. You write them inside the `SELECT` of your `v_`/`tv_` read view, fold the
+computed columns into the view's `data` JSONB with `jsonb_build_object(...)`, and
+FraiseQL serves them at runtime like any other field. There is no special syntax, no
+decorator, and nothing to configure: the work happens in your view SQL.
 
 ---
 
-## Overview
+## The Pattern
 
-Window functions (analytical functions) perform calculations across rows related to the current row, using an OVER clause to define the window. Unlike aggregate functions with GROUP BY, window functions return a value for EVERY row.
+A FraiseQL read view always exposes a public `id` (UUID) column plus a `data` JSONB
+column. To surface a window function, compute it in a subquery (or CTE) and reference
+its result when building `data`:
 
-**Status**: Implemented in FraiseQL v2
+```sql
+CREATE VIEW v_sales_ranked AS
+SELECT
+    s.id,
+    jsonb_build_object(
+        'id',          s.id,
+        'category',    s.category,
+        'product',     s.product_name,
+        'revenue',     s.revenue,
+        'rank_in_category',
+            ROW_NUMBER() OVER (
+                PARTITION BY s.category
+                ORDER BY s.revenue DESC
+            ),
+        'running_total',
+            SUM(s.revenue) OVER (
+                PARTITION BY s.category
+                ORDER BY s.occurred_at
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            )
+    ) AS data
+FROM tb_sales s;
+```
+
+A `@fraiseql.type(sql_source="v_sales_ranked")` then exposes `rankInCategory` and
+`runningTotal` as ordinary scalar fields — FraiseQL reads them straight out of `data`.
+
+For heavy or frequently-queried calculations, materialize the same SELECT as a `tv_`
+table-backed view refreshed by a function or trigger (see
+[tv-table pattern](../database/tv-table-pattern.md)).
 
 ---
 
@@ -30,77 +64,81 @@ Window functions (analytical functions) perform calculations across rows related
 
 Assign ranks to rows within partitions.
 
-- `ROW_NUMBER()` - Unique sequential number (1, 2, 3, 4...)
-- `RANK()` - Ranking with gaps for ties (1, 2, 2, 4...)
-- `DENSE_RANK()` - Ranking without gaps (1, 2, 2, 3...)
-- `NTILE(n)` - Divide rows into n buckets (quartiles, deciles, etc.)
-- `PERCENT_RANK()` - Relative rank from 0.0 to 1.0
-- `CUME_DIST()` - Cumulative distribution (0.0 to 1.0)
-
-**Example**:
+- `ROW_NUMBER()` — Unique sequential number (1, 2, 3, 4...)
+- `RANK()` — Ranking with gaps for ties (1, 2, 2, 4...)
+- `DENSE_RANK()` — Ranking without gaps (1, 2, 2, 3...)
+- `NTILE(n)` — Divide rows into n buckets (quartiles, deciles, etc.)
+- `PERCENT_RANK()` — Relative rank from 0.0 to 1.0
+- `CUME_DIST()` — Cumulative distribution (0.0 to 1.0)
 
 ```sql
-<!-- Code example in SQL -->
+CREATE VIEW v_sales_rankings AS
 SELECT
-    data->>'category' AS category,
-    revenue,
-    ROW_NUMBER() OVER (PARTITION BY data->>'category' ORDER BY revenue DESC) AS row_num,
-    RANK() OVER (PARTITION BY data->>'category' ORDER BY revenue DESC) AS rank,
-    DENSE_RANK() OVER (PARTITION BY data->>'category' ORDER BY revenue DESC) AS dense_rank
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
+    s.id,
+    jsonb_build_object(
+        'id',         s.id,
+        'category',   s.category,
+        'revenue',    s.revenue,
+        'row_num',    ROW_NUMBER() OVER (PARTITION BY s.category ORDER BY s.revenue DESC),
+        'rank',       RANK()       OVER (PARTITION BY s.category ORDER BY s.revenue DESC),
+        'dense_rank', DENSE_RANK() OVER (PARTITION BY s.category ORDER BY s.revenue DESC)
+    ) AS data
+FROM tb_sales s;
+```
 
 ### 2. Value Functions
 
 Access values from other rows in the window.
 
-- `LAG(field, offset, default)` - Access previous row value
-- `LEAD(field, offset, default)` - Access next row value
-- `FIRST_VALUE(field)` - First value in window
-- `LAST_VALUE(field)` - Last value in window
-- `NTH_VALUE(field, n)` - Nth value in window
-
-**Example**:
+- `LAG(field, offset, default)` — Access previous row value
+- `LEAD(field, offset, default)` — Access next row value
+- `FIRST_VALUE(field)` — First value in window
+- `LAST_VALUE(field)` — Last value in window
+- `NTH_VALUE(field, n)` — Nth value in window
 
 ```sql
-<!-- Code example in SQL -->
+CREATE VIEW v_sales_deltas AS
 SELECT
-    data->>'category' AS category,
-    occurred_at,
-    revenue,
-    LAG(revenue, 1) OVER (PARTITION BY data->>'category' ORDER BY occurred_at) AS prev_day_revenue,
-    LEAD(revenue, 1) OVER (PARTITION BY data->>'category' ORDER BY occurred_at) AS next_day_revenue
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
+    s.id,
+    jsonb_build_object(
+        'id',                s.id,
+        'category',          s.category,
+        'occurred_at',       s.occurred_at,
+        'revenue',           s.revenue,
+        'prev_day_revenue',  LAG(s.revenue, 1)  OVER (PARTITION BY s.category ORDER BY s.occurred_at),
+        'next_day_revenue',  LEAD(s.revenue, 1) OVER (PARTITION BY s.category ORDER BY s.occurred_at)
+    ) AS data
+FROM tb_sales s;
+```
 
 ### 3. Aggregate Functions as Windows
 
 Apply aggregate functions with window semantics (running totals, moving averages).
 
-- `SUM(field) OVER (...)` - Running total
-- `AVG(field) OVER (...)` - Moving average
-- `COUNT(*) OVER (...)` - Running count
-- `MIN(field) OVER (...)` - Running minimum
-- `MAX(field) OVER (...)` - Running maximum
-
-**Example**:
+- `SUM(field) OVER (...)` — Running total
+- `AVG(field) OVER (...)` — Moving average
+- `COUNT(*) OVER (...)` — Running count
+- `MIN(field) OVER (...)` — Running minimum
+- `MAX(field) OVER (...)` — Running maximum
 
 ```sql
-<!-- Code example in SQL -->
+CREATE VIEW v_sales_running AS
 SELECT
-    data->>'category' AS category,
-    occurred_at,
-    revenue,
-    SUM(revenue) OVER (
-        PARTITION BY data->>'category'
-        ORDER BY occurred_at
-        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-    ) AS running_total
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
+    s.id,
+    jsonb_build_object(
+        'id',          s.id,
+        'category',    s.category,
+        'occurred_at', s.occurred_at,
+        'revenue',     s.revenue,
+        'running_total',
+            SUM(s.revenue) OVER (
+                PARTITION BY s.category
+                ORDER BY s.occurred_at
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            )
+    ) AS data
+FROM tb_sales s;
+```
 
 ---
 
@@ -108,375 +146,257 @@ FROM tf_sales;
 
 ### PARTITION BY
 
-Divides rows into partitions (groups). Window function applies separately to each partition.
-
-**Syntax**:
+Divides rows into partitions (groups). The window function applies separately to each
+partition.
 
 ```sql
-<!-- Code example in SQL -->
 OVER (PARTITION BY column1, column2, ...)
-```text
-<!-- Code example in TEXT -->
-
-**Example**:
+```
 
 ```sql
-<!-- Code example in SQL -->
 -- Row number within each category
-ROW_NUMBER() OVER (PARTITION BY data->>'category' ORDER BY revenue DESC)
+ROW_NUMBER() OVER (PARTITION BY s.category ORDER BY s.revenue DESC)
 
 -- No partition = single global window
-ROW_NUMBER() OVER (ORDER BY revenue DESC)
-```text
-<!-- Code example in TEXT -->
+ROW_NUMBER() OVER (ORDER BY s.revenue DESC)
+```
 
 ### ORDER BY
 
-Defines row ordering within each partition. Required for ranking functions and frame clauses.
-
-**Syntax**:
+Defines row ordering within each partition. Required for ranking functions and frame
+clauses.
 
 ```sql
-<!-- Code example in SQL -->
 OVER (PARTITION BY ... ORDER BY column1 [ASC|DESC], column2 [ASC|DESC], ...)
-```text
-<!-- Code example in TEXT -->
-
-**Example**:
+```
 
 ```sql
-<!-- Code example in SQL -->
 -- Rank by revenue descending within category
-RANK() OVER (PARTITION BY data->>'category' ORDER BY revenue DESC)
+RANK() OVER (PARTITION BY s.category ORDER BY s.revenue DESC)
 
 -- Running total ordered by date
-SUM(revenue) OVER (PARTITION BY data->>'category' ORDER BY occurred_at ASC)
-```text
-<!-- Code example in TEXT -->
+SUM(s.revenue) OVER (PARTITION BY s.category ORDER BY s.occurred_at ASC)
+```
 
 ### Frame Clauses
 
-Define which rows are included in the window frame relative to current row. Used with aggregate window functions.
+Define which rows are included in the window frame relative to the current row. Used
+with aggregate window functions.
 
 **Frame Types**:
 
-- `ROWS` - Physical row-based window (count rows)
-- `RANGE` - Logical value-based window (based on ORDER BY value)
-- `GROUPS` - Group-based window (PostgreSQL only)
+- `ROWS` — Physical row-based window (count rows)
+- `RANGE` — Logical value-based window (based on the `ORDER BY` value)
+- `GROUPS` — Group-based window
 
 **Frame Boundaries**:
 
-- `UNBOUNDED PRECEDING` - Start of partition
-- `n PRECEDING` - n rows/range units before current
-- `CURRENT ROW` - Current row
-- `n FOLLOWING` - n rows/range units after current
-- `UNBOUNDED FOLLOWING` - End of partition
+- `UNBOUNDED PRECEDING` — Start of partition
+- `n PRECEDING` — n rows/range units before current
+- `CURRENT ROW` — Current row
+- `n FOLLOWING` — n rows/range units after current
+- `UNBOUNDED FOLLOWING` — End of partition
 
 **Default Frame** (if not specified):
 
-- With ORDER BY: `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`
-- Without ORDER BY: `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`
-
-**Examples**:
+- With `ORDER BY`: `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`
+- Without `ORDER BY`: `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`
 
 ```sql
-<!-- Code example in SQL -->
 -- Cumulative sum (all rows up to current)
-SUM(revenue) OVER (
-    PARTITION BY data->>'category'
-    ORDER BY occurred_at
+SUM(s.revenue) OVER (
+    PARTITION BY s.category
+    ORDER BY s.occurred_at
     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
 )
 
 -- 7-day moving average (last 7 rows including current)
-AVG(revenue) OVER (
-    PARTITION BY data->>'category'
-    ORDER BY occurred_at
+AVG(s.revenue) OVER (
+    PARTITION BY s.category
+    ORDER BY s.occurred_at
     ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
 )
 
 -- Centered 3-row moving average (current ± 1 row)
-AVG(revenue) OVER (
-    PARTITION BY data->>'category'
-    ORDER BY occurred_at
+AVG(s.revenue) OVER (
+    PARTITION BY s.category
+    ORDER BY s.occurred_at
     ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
 )
 
 -- All rows in partition (default without ORDER BY)
-SUM(revenue) OVER (
-    PARTITION BY data->>'category'
+SUM(s.revenue) OVER (
+    PARTITION BY s.category
     ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
-## Compilation Strategy
+## Evaluation Order
 
-### Compiler Tasks
-
-1. **Parse Window Function Specifications** from schema decorators
-2. **Validate Columns**:
-   - PARTITION BY columns exist in table
-   - ORDER BY columns exist in table
-   - Field references are valid
-3. **Generate Window Clause SQL**:
-   - Build OVER clause with PARTITION BY, ORDER BY, frame
-4. **Database-Specific Lowering**:
-   - Adjust syntax for target database
-   - Validate frame clause support
-
-### Runtime Execution
-
-1. Apply WHERE filters first (before window functions)
-2. Compute window functions (database-side)
-3. Apply HAVING if present (after aggregates)
-4. Apply final ORDER BY and LIMIT
-5. Return results with window columns
-
-**Execution Order**:
+PostgreSQL evaluates window functions at a fixed point in the query pipeline. Knowing
+this order matters when you combine them with filters and aggregates inside a view:
 
 ```text
-<!-- Code example in TEXT -->
 WHERE → GROUP BY → HAVING → Window Functions → ORDER BY → LIMIT
-```text
-<!-- Code example in TEXT -->
+```
+
+- `WHERE` filters rows **before** window functions see them.
+- `GROUP BY` / `HAVING` aggregate **before** window functions run, so a window can
+  operate over already-aggregated rows (e.g. `LAG(SUM(revenue), 12)`).
+- Because window functions run after `WHERE`, you cannot filter on a window result in
+  the same query level — wrap the view (or a subquery) and filter the outer level (see
+  [Top-N Per Category](#4-top-n-per-category)).
 
 ---
 
-## Database-Specific Support
+## PostgreSQL Support
 
-### PostgreSQL
+PostgreSQL has full window-function support, which is everything these patterns need:
 
-**Support Level**: ✅ Full
-
-**Features**:
-
-- All ranking functions (ROW_NUMBER, RANK, DENSE_RANK, NTILE, PERCENT_RANK, CUME_DIST)
-- All value functions (LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE)
-- All frame types (ROWS, RANGE, GROUPS)
-- EXCLUDE clause (EXCLUDE CURRENT ROW, EXCLUDE GROUP, EXCLUDE TIES, EXCLUDE NO OTHERS)
-
-**Example**:
+- All ranking functions (`ROW_NUMBER`, `RANK`, `DENSE_RANK`, `NTILE`, `PERCENT_RANK`, `CUME_DIST`)
+- All value functions (`LAG`, `LEAD`, `FIRST_VALUE`, `LAST_VALUE`, `NTH_VALUE`)
+- All frame types (`ROWS`, `RANGE`, `GROUPS`)
+- The `EXCLUDE` clause (`EXCLUDE CURRENT ROW`, `EXCLUDE GROUP`, `EXCLUDE TIES`, `EXCLUDE NO OTHERS`)
 
 ```sql
-<!-- Code example in SQL -->
+CREATE VIEW v_sales_excluded AS
 SELECT
-    data->>'category' AS category,
-    revenue,
-    SUM(revenue) OVER (
-        PARTITION BY data->>'category'
-        ORDER BY occurred_at
-        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-        EXCLUDE CURRENT ROW
-    ) AS cumulative_revenue_excluding_current
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-### MySQL (8.0+)
-
-**Support Level**: ✅ Near-full (requires MySQL 8.0+)
-
-**Features**:
-
-- All ranking functions
-- All value functions
-- Frame types: ROWS, RANGE
-- ❌ No GROUPS frame type
-- ❌ No EXCLUDE clause
-
-**Example**:
-
-```sql
-<!-- Code example in SQL -->
-SELECT
-    JSON_EXTRACT(data, '$.category') AS category,
-    revenue,
-    ROW_NUMBER() OVER (PARTITION BY JSON_EXTRACT(data, '$.category') ORDER BY revenue DESC) AS rank
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-### SQLite (3.25+)
-
-**Support Level**: ✅ Good (requires SQLite 3.25+, released 2018)
-
-**Features**:
-
-- All ranking functions
-- All value functions
-- Frame types: ROWS, RANGE
-- ❌ No GROUPS frame type
-- ❌ No EXCLUDE clause
-
-**Example**:
-
-```sql
-<!-- Code example in SQL -->
-SELECT
-    json_extract(data, '$.category') AS category,
-    revenue,
-    SUM(revenue) OVER (
-        PARTITION BY json_extract(data, '$.category')
-        ORDER BY occurred_at
-        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
-    ) AS moving_avg_7d
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
-
-### SQL Server
-
-**Support Level**: ✅ Full
-
-**Features**:
-
-- All ranking functions
-- All value functions (LAG, LEAD, FIRST_VALUE, LAST_VALUE)
-- Frame types: ROWS, RANGE
-- ❌ No GROUPS frame type
-- ❌ No EXCLUDE clause
-
-**Example**:
-
-```sql
-<!-- Code example in SQL -->
-SELECT
-    JSON_VALUE(data, '$.category') AS category,
-    revenue,
-    LAG(revenue, 1) OVER (
-        PARTITION BY JSON_VALUE(data, '$.category')
-        ORDER BY occurred_at
-    ) AS prev_day_revenue
-FROM tf_sales;
-```text
-<!-- Code example in TEXT -->
+    s.id,
+    jsonb_build_object(
+        'id',       s.id,
+        'category', s.category,
+        'revenue',  s.revenue,
+        'cumulative_revenue_excluding_current',
+            SUM(s.revenue) OVER (
+                PARTITION BY s.category
+                ORDER BY s.occurred_at
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                EXCLUDE CURRENT ROW
+            )
+    ) AS data
+FROM tb_sales s;
+```
 
 ---
 
 ## Use Cases
 
+Each example below is the body of a view's `SELECT`. Wrap it in
+`CREATE VIEW v_... AS SELECT s.id, jsonb_build_object(...) AS data FROM ...` to expose
+the result through FraiseQL.
+
 ### 1. Running Totals
 
-Calculate cumulative sum up to current row.
+Calculate a cumulative sum up to the current row.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
-    data->>'category' AS category,
-    occurred_at,
-    revenue,
-    SUM(revenue) OVER (
-        PARTITION BY data->>'category'
-        ORDER BY occurred_at
+    s.category,
+    s.occurred_at,
+    s.revenue,
+    SUM(s.revenue) OVER (
+        PARTITION BY s.category
+        ORDER BY s.occurred_at
         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
     ) AS cumulative_revenue
-FROM tf_sales
-ORDER BY data->>'category', occurred_at;
-```text
-<!-- Code example in TEXT -->
+FROM tb_sales s
+ORDER BY s.category, s.occurred_at;
+```
 
 ### 2. Moving Averages
 
-Calculate average over sliding window (e.g., 7-day moving average).
+Calculate an average over a sliding window (e.g. a 7-day moving average). Note the
+window runs over already-aggregated daily totals.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
-    data->>'category' AS category,
-    occurred_at::DATE AS day,
-    SUM(revenue) AS daily_revenue,
-    AVG(SUM(revenue)) OVER (
-        PARTITION BY data->>'category'
-        ORDER BY occurred_at::DATE
+    s.category,
+    s.occurred_at::DATE AS day,
+    SUM(s.revenue) AS daily_revenue,
+    AVG(SUM(s.revenue)) OVER (
+        PARTITION BY s.category
+        ORDER BY s.occurred_at::DATE
         ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
     ) AS moving_avg_7d
-FROM tf_sales
-GROUP BY data->>'category', occurred_at::DATE
-ORDER BY data->>'category', occurred_at::DATE;
-```text
-<!-- Code example in TEXT -->
+FROM tb_sales s
+GROUP BY s.category, s.occurred_at::DATE
+ORDER BY s.category, s.occurred_at::DATE;
+```
 
 ### 3. Year-Over-Year Comparison
 
-Compare current period to same period last year using LAG.
+Compare the current period to the same period last year using `LAG`.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
-    DATE_TRUNC('month', occurred_at) AS month,
-    SUM(revenue) AS monthly_revenue,
-    LAG(SUM(revenue), 12) OVER (ORDER BY DATE_TRUNC('month', occurred_at)) AS same_month_last_year,
-    SUM(revenue) - LAG(SUM(revenue), 12) OVER (ORDER BY DATE_TRUNC('month', occurred_at)) AS yoy_change
-FROM tf_sales
-GROUP BY DATE_TRUNC('month', occurred_at)
+    DATE_TRUNC('month', s.occurred_at) AS month,
+    SUM(s.revenue) AS monthly_revenue,
+    LAG(SUM(s.revenue), 12) OVER (ORDER BY DATE_TRUNC('month', s.occurred_at)) AS same_month_last_year,
+    SUM(s.revenue) - LAG(SUM(s.revenue), 12) OVER (ORDER BY DATE_TRUNC('month', s.occurred_at)) AS yoy_change
+FROM tb_sales s
+GROUP BY DATE_TRUNC('month', s.occurred_at)
 ORDER BY month;
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 4. Top-N Per Category
 
-Rank items within each category and filter to top N.
+Rank items within each category and filter to the top N. Because window results cannot
+be filtered at the same query level, compute the rank in an inner subquery and filter
+the outer one.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT * FROM (
     SELECT
-        data->>'category' AS category,
-        data->>'product_name' AS product,
-        SUM(revenue) AS total_revenue,
+        s.category,
+        s.product_name AS product,
+        SUM(s.revenue) AS total_revenue,
         ROW_NUMBER() OVER (
-            PARTITION BY data->>'category'
-            ORDER BY SUM(revenue) DESC
+            PARTITION BY s.category
+            ORDER BY SUM(s.revenue) DESC
         ) AS rank
-    FROM tf_sales
-    GROUP BY data->>'category', data->>'product_name'
+    FROM tb_sales s
+    GROUP BY s.category, s.product_name
 ) ranked
 WHERE rank <= 10
 ORDER BY category, rank;
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 5. Percentile Ranking
 
-Assign percentile ranks to rows.
+Assign percentile ranks and quartiles to rows.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
-    data->>'product_name' AS product,
-    SUM(revenue) AS total_revenue,
-    PERCENT_RANK() OVER (ORDER BY SUM(revenue) DESC) AS percentile_rank,
-    NTILE(4) OVER (ORDER BY SUM(revenue) DESC) AS quartile
-FROM tf_sales
-GROUP BY data->>'product_name'
+    s.product_name AS product,
+    SUM(s.revenue) AS total_revenue,
+    PERCENT_RANK() OVER (ORDER BY SUM(s.revenue) DESC) AS percentile_rank,
+    NTILE(4)       OVER (ORDER BY SUM(s.revenue) DESC) AS quartile
+FROM tb_sales s
+GROUP BY s.product_name
 ORDER BY total_revenue DESC;
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 6. Trend Analysis
 
-Compare to previous period to identify trends.
+Compare to the previous period to identify trends.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
-    occurred_at::DATE AS day,
-    SUM(revenue) AS daily_revenue,
-    LAG(SUM(revenue), 1) OVER (ORDER BY occurred_at::DATE) AS prev_day_revenue,
-    SUM(revenue) - LAG(SUM(revenue), 1) OVER (ORDER BY occurred_at::DATE) AS day_over_day_change,
+    s.occurred_at::DATE AS day,
+    SUM(s.revenue) AS daily_revenue,
+    LAG(SUM(s.revenue), 1) OVER (ORDER BY s.occurred_at::DATE) AS prev_day_revenue,
+    SUM(s.revenue) - LAG(SUM(s.revenue), 1) OVER (ORDER BY s.occurred_at::DATE) AS day_over_day_change,
     ROUND(
-        100.0 * (SUM(revenue) - LAG(SUM(revenue), 1) OVER (ORDER BY occurred_at::DATE)) /
-        NULLIF(LAG(SUM(revenue), 1) OVER (ORDER BY occurred_at::DATE), 0),
+        100.0 * (SUM(s.revenue) - LAG(SUM(s.revenue), 1) OVER (ORDER BY s.occurred_at::DATE)) /
+        NULLIF(LAG(SUM(s.revenue), 1) OVER (ORDER BY s.occurred_at::DATE), 0),
         2
     ) AS day_over_day_pct
-FROM tf_sales
-GROUP BY occurred_at::DATE
-ORDER BY occurred_at::DATE;
-```text
-<!-- Code example in TEXT -->
+FROM tb_sales s
+GROUP BY s.occurred_at::DATE
+ORDER BY s.occurred_at::DATE;
+```
 
 ---
 
@@ -484,243 +404,66 @@ ORDER BY occurred_at::DATE;
 
 ### Indexing Strategy
 
-**PARTITION BY Columns**:
+Index the columns your windows partition and order by. Window functions read the table
+in partition/order sequence, so matching indexes let PostgreSQL avoid extra sorts.
 
 ```sql
-<!-- Code example in SQL -->
 -- Index columns used in PARTITION BY
-CREATE INDEX idx_sales_category ON tf_sales ((dimensions->>'category'));
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_sales_category ON tb_sales (category);
 
-**ORDER BY Columns**:
+-- Index columns used in ORDER BY within the window
+CREATE INDEX idx_sales_occurred ON tb_sales (occurred_at);
 
-```sql
-<!-- Code example in SQL -->
--- Index columns used in ORDER BY within window
-CREATE INDEX idx_sales_occurred ON tf_sales(occurred_at);
-```text
-<!-- Code example in TEXT -->
+-- Composite index for a common (partition, order) pattern
+CREATE INDEX idx_sales_category_occurred ON tb_sales (category, occurred_at);
+```
 
-**Composite Indexes**:
+### Cost Notes
 
-```sql
-<!-- Code example in SQL -->
--- Composite index for common window pattern
-CREATE INDEX idx_sales_category_occurred
-    ON tf_sales ((dimensions->>'category'), occurred_at);
-```text
-<!-- Code example in TEXT -->
-
-### Window Function Evaluation
-
-**Execution Order**:
-
-1. WHERE clause filters rows
-2. GROUP BY aggregates (if present)
-3. HAVING filters aggregated results (if present)
-4. **Window functions compute** ← Happens here
-5. Final ORDER BY sorts results
-6. LIMIT/OFFSET applies
-
-**Performance Impact**:
-
-- Window functions evaluated AFTER WHERE/GROUP BY/HAVING
-- Can be expensive for large windows (UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
-- Proper indexes on PARTITION BY and ORDER BY columns critical
+- Window functions are evaluated **after** `WHERE`/`GROUP BY`/`HAVING`, so filtering
+  early reduces the rows the window has to scan.
+- Large frames (`UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`) are more expensive than
+  bounded frames.
+- Proper indexes on `PARTITION BY` and `ORDER BY` columns are critical for large tables.
 
 ### Optimization Tips
 
-1. **Use Specific Frame Clauses**:
+1. **Use specific frame clauses** — bound the frame whenever the calculation allows it:
 
    ```sql
-<!-- Code example in SQL -->
-   -- ❌ SLOW: Large frame
-   SUM(revenue) OVER (
-       ORDER BY occurred_at
+   -- Slower: unbounded frame
+   SUM(s.revenue) OVER (
+       ORDER BY s.occurred_at
        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
    )
 
-   -- ✅ FAST: Bounded frame
-   SUM(revenue) OVER (
-       ORDER BY occurred_at
+   -- Faster: bounded frame
+   SUM(s.revenue) OVER (
+       ORDER BY s.occurred_at
        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
    )
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
-2. **Partition Data Appropriately**:
-   - Balance partition size (not too large, not too many)
-   - Use meaningful partitions (category, region, etc.)
+2. **Partition data appropriately** — balance partition size (not too large, not too
+   many) and use meaningful partitions (category, region, etc.).
 
-3. **Consider Materialized Views**:
+3. **Promote heavy views to `tv_` table-backed views** — for window calculations that
+   are queried often, precompute them into a `tv_` projection table refreshed by a
+   function or trigger, rather than recomputing on every read. See
+   [tv-table pattern](../database/tv-table-pattern.md) and the
+   [view-selection guide](../database/view-selection-guide.md) for when to choose a
+   plain `v_` view versus a `tv_` table.
 
-   ```sql
-<!-- Code example in SQL -->
-   -- For frequently-used window calculations
-   CREATE MATERIALIZED VIEW mv_sales_running_totals AS
-   SELECT
-       data->>'category' AS category,
-       occurred_at,
-       revenue,
-       SUM(revenue) OVER (
-           PARTITION BY data->>'category'
-           ORDER BY occurred_at
-           ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-       ) AS cumulative_revenue
-   FROM tf_sales;
-
-   CREATE INDEX idx_mv_category_occurred
-       ON mv_sales_running_totals(category, occurred_at);
-   ```text
-<!-- Code example in TEXT -->
-
-4. **Limit Window Size**:
-   - Prefer `ROWS BETWEEN 6 PRECEDING` over `UNBOUNDED PRECEDING` when possible
-   - Use WHERE clause to reduce data volume before window computation
+4. **Reduce data volume first** — prefer `ROWS BETWEEN 6 PRECEDING` over
+   `UNBOUNDED PRECEDING` when possible, and use a `WHERE` clause to shrink the input
+   before window computation.
 
 ---
 
-## GraphQL API (Proposed)
+## Related Documentation
 
-**Status**: Proposed for future enhancement
-
-### Query Structure
-
-```graphql
-<!-- Code example in GraphQL -->
-input WindowFunctionInput {
-  function: WindowFunction!
-  field: String
-  alias: String!
-  partition_by: [String!]
-  order_by: [OrderByInput!]
-  frame: WindowFrameInput
-  offset: Int  # For LAG/LEAD
-  default: JSON  # For LAG/LEAD default value
-}
-
-enum WindowFunction {
-  # Ranking
-  ROW_NUMBER
-  RANK
-  DENSE_RANK
-  NTILE
-  PERCENT_RANK
-  CUME_DIST
-
-  # Value
-  LAG
-  LEAD
-  FIRST_VALUE
-  LAST_VALUE
-  NTH_VALUE
-
-  # Aggregates
-  SUM
-  AVG
-  COUNT
-  MIN
-  MAX
-}
-
-input WindowFrameInput {
-  type: WindowFrameType!
-  start: WindowFrameBoundary!
-  end: WindowFrameBoundary!
-}
-
-enum WindowFrameType {
-  ROWS
-  RANGE
-  GROUPS  # PostgreSQL only
-}
-
-input WindowFrameBoundary {
-  type: BoundaryType!
-  offset: Int
-}
-
-enum BoundaryType {
-  UNBOUNDED_PRECEDING
-  N_PRECEDING
-  CURRENT_ROW
-  N_FOLLOWING
-  UNBOUNDED_FOLLOWING
-}
-```text
-<!-- Code example in TEXT -->
-
-### Example Query
-
-```graphql
-<!-- Code example in GraphQL -->
-query {
-  sales_window(
-    select: ["category", "occurred_at", "revenue"]
-    windows: [
-      {
-        function: ROW_NUMBER
-        alias: "rank_by_revenue"
-        partition_by: ["category"]
-        order_by: [{field: "revenue", direction: DESC}]
-      }
-      {
-        function: SUM
-        field: "revenue"
-        alias: "running_total"
-        partition_by: ["category"]
-        order_by: [{field: "occurred_at", direction: ASC}]
-        frame: {
-          type: ROWS
-          start: {type: UNBOUNDED_PRECEDING}
-          end: {type: CURRENT_ROW}
-        }
-      }
-      {
-        function: AVG
-        field: "revenue"
-        alias: "moving_avg_7d"
-        partition_by: ["category"]
-        order_by: [{field: "occurred_at", direction: ASC}]
-        frame: {
-          type: ROWS
-          start: {type: N_PRECEDING, offset: 6}
-          end: {type: CURRENT_ROW}
-        }
-      }
-      {
-        function: LAG
-        field: "revenue"
-        offset: 1
-        alias: "prev_day_revenue"
-        partition_by: ["category"]
-        order_by: [{field: "occurred_at", direction: ASC}]
-      }
-    ]
-    where: {occurred_at: {_gte: "2026-01-01"}}
-    orderBy: [{field: "category"}, {field: "occurred_at"}]
-  ) {
-    category
-    occurred_at
-    revenue
-    rank_by_revenue
-    running_total
-    moving_avg_7d
-    prev_day_revenue
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Related Specifications
-
-- **Aggregation Model** (`aggregation-model.md`) - GROUP BY and basic aggregates
-- **Window Operators Reference** (`../specs/window-operators.md`) - Complete function reference
-- **Analytics Patterns** (`../guides/analytics-patterns.md`) - Practical examples
-
----
-
-*End of Window Functions Architecture*
+- [Aggregation Model](./aggregation-model.md) — `GROUP BY`, `HAVING`, and basic aggregates
+- [Fact / Dimension Pattern](./fact-dimension-pattern.md) — modeling fact tables for analytics
+- [Calendar Dimensions](./calendar-dimensions.md) — date attributes for time-based windows
+- [tv-table Pattern](../database/tv-table-pattern.md) — materializing heavy views into projection tables
+- [View Selection Guide](../database/view-selection-guide.md) — choosing `v_` vs `tv_`

--- a/docs/architecture/database/tv-table-pattern.md
+++ b/docs/architecture/database/tv-table-pattern.md
@@ -1,9 +1,7 @@
-<!-- Skip to main content -->
 ---
-
-title: tv_* Table Pattern: Table-Backed JSON Views
-description: - Physical storage on disk (materialized JSONB data)
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+title: "tv_* Table Pattern: Table-Backed JSON Views"
+description: Physically stored, pre-composed JSONB projections for high-performance nested GraphQL reads.
+keywords: ["design", "scalability", "performance", "patterns", "postgresql"]
 tags: ["documentation", "reference"]
 ---
 
@@ -11,53 +9,59 @@ tags: ["documentation", "reference"]
 
 ## Overview
 
-**tv_* tables** are PostgreSQL-specific, materialized table-backed views that pre-compute and physically store pre-composed JSONB data structures for high-performance GraphQL query execution on complex nested data.
+**`tv_*` tables** are PostgreSQL tables that pre-compute and physically store a
+pre-composed `data` JSONB column for high-performance GraphQL reads over complex,
+deeply nested data. A `tv_*` table looks exactly like a `v_*` read view to FraiseQL
+(`id` + `data` JSONB), but the JSONB is materialized on disk instead of being
+composed on every query.
 
-**Analogous to**: `ta_*` tables for Arrow plane (analytics), but `tv_*` for JSON plane (GraphQL).
+**Key difference from logical views (`v_*`):** unlike a logical view, a `tv_*`
+relation is a real table with:
 
-**Key difference**: Unlike logical views (`v_*`), tv_* tables are actual PostgreSQL tables with:
+- Physical storage on disk (materialized `data` JSONB)
+- A trigger-based or scheduled refresh mechanism
+- Denormalized JSONB composition for complex nested queries
+- Substantially faster read performance on deeply nested data
 
-- Physical storage on disk (materialized JSONB data)
-- Trigger-based or scheduled refresh mechanism
-- Denormalized JSONB composition for complex queries
-- 5-50x faster query performance on deeply nested data
+FraiseQL queries a `tv_*` table the same way it queries a `v_*` view — via
+`db.find("tv_user_profile")` / `db.find_one(...)` from a `@fraiseql.query`
+resolver. Choosing between `v_*` and `tv_*` is purely a database design decision;
+the GraphQL layer is unchanged.
 
 ## When to Use tv_* Tables
 
-### ✅ **Use tv_* when**
+### Use tv_* when
 
 - **Complex JSONB composition** with multiple JOINs (3+ related entities)
-- **Deep nesting** required (e.g., User → Posts → Comments → Likes)
+- **Deep nesting** is required (e.g., User → Posts → Comments → Likes)
 - **High-frequency read, low-frequency write** workloads
 - **Pre-aggregated dashboards** with complex data structures
-- **GraphQL queries** with consistent nested patterns
+- **GraphQL queries** follow consistent nested patterns
 - **GraphQL subscriptions** need fast access to composed data
 
-### ❌ **Don't use tv_* when**
+### Don't use tv_* when
 
-- **Simple queries** (single or 2-table joins) - use `v_*` logical views instead
-- **Frequently changing data** with millisecond latency requirements
-- **Storage is constrained** (tv_* duplicates JSONB data)
-- **Dynamic query patterns** where composition varies by request
+- **Simple queries** (single or 2-table joins) — use a `v_*` logical view instead
+- **Frequently changing data** with millisecond freshness requirements
+- **Storage is constrained** (a `tv_*` table duplicates the JSONB data)
+- **Dynamic query patterns** where the composition varies per request
 
 ## Performance Comparison
 
-### Scenario: Complex User Profile with Posts, Comments, and Likes (10K users)
+### Scenario: complex user profile with posts, comments, and likes (10K users)
 
-| Metric | v_user_full (View) | tv_user_profile (Table) | Improvement |
-|--------|-------------------|------------------------|-------------|
-| Query time | 2-5s | 100-200ms | **10-50x faster** |
-| JSONB composition | Real-time (multiple JOINs) | Pre-computed | **Zero JOIN cost** |
-| Memory usage | 500MB-1GB | 150-300MB | **3-6x lower** |
-| CPU | 50-80% | 5-10% | **5-16x reduction** |
+| Metric | `v_user_full` (view) | `tv_user_profile` (table) | Improvement |
+|--------|----------------------|---------------------------|-------------|
+| Query time | 2–5 s | 100–200 ms | 10–50x faster |
+| JSONB composition | Real-time (multiple JOINs) | Pre-computed | Zero JOIN cost |
+| Memory usage | 500 MB–1 GB | 150–300 MB | 3–6x lower |
+| CPU | 50–80% | 5–10% | 5–16x reduction |
 
-### Query Breakdown
+### Query breakdown
 
-**Logical view (v_user_full)** - Real-time composition:
+**Logical view (`v_user_full`)** — real-time composition:
 
 ```text
-<!-- Code example in TEXT -->
-
 1. Fetch user (1ms)
 2. Fetch posts (2-3s via JOIN)
 3. Compose posts array (500-800ms)
@@ -66,25 +70,20 @@ tags: ["documentation", "reference"]
 6. Fetch likes per comment (1-2s)
 7. Build final JSONB (200-300ms)
 Total: 5-10 seconds
+```
+
+**Table-backed view (`tv_user_profile`)** — pre-computed:
+
 ```text
-<!-- Code example in TEXT -->
-
-**Table-backed view (tv_user_profile)** - Pre-computed:
-
-```text
-<!-- Code example in TEXT -->
-
 1. Fetch pre-composed JSONB (100-200ms)
 Total: 100-200ms
-```text
-<!-- Code example in TEXT -->
+```
 
 ## DDL Pattern
 
-### Basic Structure
+### Basic structure
 
 ```sql
-<!-- Code example in SQL -->
 -- 1. Create physical table with pre-composed JSONB
 CREATE TABLE tv_user_profile (
     id TEXT NOT NULL PRIMARY KEY,
@@ -102,13 +101,11 @@ CREATE TRIGGER trg_refresh_tv_user_profile
     AFTER INSERT OR UPDATE OR DELETE ON tb_user
     FOR EACH ROW
     EXECUTE FUNCTION refresh_tv_user_profile_trigger();
-```text
-<!-- Code example in TEXT -->
+```
 
-### JSONB Composition Pattern
+### JSONB composition pattern
 
 ```sql
-<!-- Code example in SQL -->
 -- Helper view to compose nested data (intermediate step)
 CREATE VIEW v_user_posts_composed AS
 SELECT
@@ -162,28 +159,26 @@ LEFT JOIN v_user_posts_composed p ON p.fk_user = u.pk_user
 ON CONFLICT (id) DO UPDATE SET
     data = EXCLUDED.data,
     updated_at = NOW();
-```text
-<!-- Code example in TEXT -->
+```
 
 ## Refresh Strategies
 
-Choose based on your latency and overhead requirements:
+Choose based on your latency and overhead requirements.
 
-### Option 1: Trigger-Based (Real-Time)
+### Option 1: Trigger-based (real-time)
 
-**Best for**: GraphQL subscriptions, <1min latency requirements
+**Best for:** GraphQL subscriptions, sub-minute latency requirements.
 
-**Characteristics**:
+**Characteristics:**
 
 - Fires after every INSERT/UPDATE/DELETE on source tables
-- Latency: <100ms per operation
-- Overhead: Per-row cost (scales with write volume)
-- Control: Fully automatic
+- Latency: <100 ms per operation
+- Overhead: per-row cost (scales with write volume)
+- Control: fully automatic
 
-**Implementation**:
+**Implementation:**
 
 ```sql
-<!-- Code example in SQL -->
 CREATE OR REPLACE FUNCTION refresh_tv_user_profile_trigger()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -221,24 +216,22 @@ CREATE TRIGGER trg_refresh_tv_user_profile_on_comment
     AFTER INSERT OR UPDATE OR DELETE ON tb_comment
     FOR EACH ROW
     EXECUTE FUNCTION refresh_tv_user_profile_trigger();
-```text
-<!-- Code example in TEXT -->
+```
 
-### Option 2: Scheduled Batch (Low Overhead)
+### Option 2: Scheduled batch (low overhead)
 
-**Best for**: Nightly dashboards, acceptable staleness (minutes to hours)
+**Best for:** nightly dashboards, acceptable staleness (minutes to hours).
 
-**Characteristics**:
+**Characteristics:**
 
 - Batched refresh at fixed intervals
-- Latency: Minutes to hours
-- Overhead: Batch cost (no per-row overhead)
-- Control: Scheduled via pg_cron
+- Latency: minutes to hours
+- Overhead: batch cost (no per-row overhead)
+- Control: scheduled via pg_cron
 
-**Implementation**:
+**Implementation:**
 
 ```sql
-<!-- Code example in SQL -->
 -- Enable pg_cron extension
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 
@@ -280,24 +273,22 @@ BEGIN
     RETURN QUERY SELECT v_inserted, v_updated;
 END;
 $$ LANGUAGE plpgsql;
-```text
-<!-- Code example in TEXT -->
+```
 
-### Option 3: Command-Based Explicit Refresh
+### Option 3: Command-based explicit refresh
 
-**Best for**: Development, bulk data loads, manual ETL
+**Best for:** development, bulk data loads, manual ETL.
 
-**Characteristics**:
+**Characteristics:**
 
 - Manual refresh on demand
-- Latency: On-demand
-- Overhead: Only when called
-- Control: Explicit API calls
+- Latency: on-demand
+- Overhead: only when called
+- Control: explicit invocation
 
-**Implementation**:
+**Implementation:**
 
 ```sql
-<!-- Code example in SQL -->
 CREATE OR REPLACE FUNCTION refresh_tv_user_profile(user_id_filter UUID DEFAULT NULL)
 RETURNS TABLE(rows_inserted BIGINT, rows_updated BIGINT) AS $$
 DECLARE
@@ -335,83 +326,88 @@ SELECT * FROM refresh_tv_user_profile('550e8400-e29b-41d4-a716-446655440000'::UU
 
 -- Usage: Refresh all profiles
 SELECT * FROM refresh_tv_user_profile();
-```text
-<!-- Code example in TEXT -->
+```
 
 ## Refresh Strategy Decision Matrix
 
 | Write Volume | Read Volume | Data Complexity | Recommended |
-|-------------|-------------|-----------------|------------|
+|--------------|-------------|-----------------|-------------|
 | Low (<100/min) | High | Complex (3+ JOINs) | Trigger-based |
-| Low (<100/min) | High | Simple | Scheduled (15min) |
-| Medium (100-1K/min) | High | Complex | Trigger-based + batch cleanup |
-| Medium (100-1K/min) | High | Simple | Scheduled (5-15min) |
+| Low (<100/min) | High | Simple | Scheduled (15 min) |
+| Medium (100–1K/min) | High | Complex | Trigger-based + batch cleanup |
+| Medium (100–1K/min) | High | Simple | Scheduled (5–15 min) |
 | High (>1K/min) | High | Any | Batch refresh only |
 
 ## Migration Guide
 
-### Step 1: Create Intermediate Views
+### Step 1: Create intermediate views
 
-Create helper views for composition logic (reusable across tv_*, REST APIs, etc.):
-
-```bash
-<!-- Code example in BASH -->
-psql -h localhost -U postgres fraiseql_dev < examples/sql/postgres/v_user_posts_composed.sql
-psql -h localhost -U postgres fraiseql_dev < examples/sql/postgres/v_user_profile_composed.sql
-```text
-<!-- Code example in TEXT -->
-
-### Step 2: Create tv_* Table
+Create helper views for the composition logic (reusable across `tv_*` tables,
+other reports, etc.):
 
 ```bash
-<!-- Code example in BASH -->
-psql -h localhost -U postgres fraiseql_dev < examples/sql/postgres/tv_user_profile.sql
-```text
-<!-- Code example in TEXT -->
+psql -h localhost -U postgres fraiseql_dev < examples/sql/v_user_posts_composed.sql
+psql -h localhost -U postgres fraiseql_dev < examples/sql/v_user_profile_composed.sql
+```
 
-### Step 3: Initial Population
+### Step 2: Create the tv_* table
+
+```bash
+psql -h localhost -U postgres fraiseql_dev < examples/sql/tv_user_profile.sql
+```
+
+### Step 3: Initial population
 
 ```sql
-<!-- Code example in SQL -->
 -- Populate table from logical view
 SELECT * FROM refresh_tv_user_profile();
 
 -- Verify row counts
-SELECT COUNT(*) as tv_profile_count FROM tv_user_profile;
-SELECT COUNT(*) as v_user_count FROM v_user;
+SELECT COUNT(*) AS tv_profile_count FROM tv_user_profile;
+SELECT COUNT(*) AS v_user_count FROM v_user;
 
 -- They should be equal
-```text
-<!-- Code example in TEXT -->
+```
 
-### Step 4: Update GraphQL Schema
+### Step 4: Point the GraphQL type at the table
 
-In your authoring layer (Python/TypeScript), bind the `User` type to use `tv_user_profile` instead of `v_user`:
+Bind the `User` type to `tv_user_profile` instead of `v_user`. The `data` JSONB
+column is read exactly as for a logical view, so only `sql_source` changes:
 
 ```python
-<!-- Code example in Python -->
-# Before: Uses v_user (logical view)
-@FraiseQL.type()
+import fraiseql
+from fraiseql.types import ID
+
+# Before: reads v_user (logical view, real-time composition)
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
-    id: UUID  # UUID v4 for GraphQL ID
+    id: ID
     name: str
     posts: list[Post]
 
-# After: Uses tv_user_profile (table-backed view)
-@FraiseQL.type(view="tv_user_profile")
+# After: reads tv_user_profile (table-backed, pre-composed JSONB)
+@fraiseql.type(sql_source="tv_user_profile", jsonb_column="data")
 class User:
-    id: UUID  # UUID v4 for GraphQL ID
+    id: ID
     name: str
     posts: list[Post]
-```text
-<!-- Code example in TEXT -->
+```
 
-### Step 5: Monitor Performance
+Query resolvers do not change — they still call `db.find(...)` against the
+configured source at runtime:
+
+```python
+@fraiseql.query
+async def users(info) -> list[User]:
+    db = info.context["db"]
+    return await db.find("tv_user_profile")
+```
+
+### Step 5: Monitor performance
 
 ```sql
-<!-- Code example in SQL -->
 -- Check staleness (how old is the pre-computed data?)
-SELECT MAX(updated_at) - NOW() as staleness
+SELECT MAX(updated_at) - NOW() AS staleness
 FROM tv_user_profile;
 
 -- Monitor refresh function performance
@@ -420,123 +416,119 @@ SELECT * FROM refresh_tv_user_profile();
 
 -- Check data accuracy (profile count should match user count)
 SELECT
-    (SELECT COUNT(*) FROM tv_user_profile) as profiles,
-    (SELECT COUNT(*) FROM v_user) as users,
-    (SELECT COUNT(*) FROM tv_user_profile) = (SELECT COUNT(*) FROM v_user) as counts_match;
-```text
-<!-- Code example in TEXT -->
+    (SELECT COUNT(*) FROM tv_user_profile) AS profiles,
+    (SELECT COUNT(*) FROM v_user) AS users,
+    (SELECT COUNT(*) FROM tv_user_profile) = (SELECT COUNT(*) FROM v_user) AS counts_match;
+```
 
 ## Limitations and Considerations
 
 ### Storage
 
-- **Data duplication**: tv_*tables duplicate JSONB from tb_* tables
-- **Storage overhead**: Typically 20-50% of source data size (JSONB is less dense than columnar)
-- **Index overhead**: GIN indexes add ~5-10% overhead
+- **Data duplication**: `tv_*` tables duplicate JSONB derived from `tb_*` tables.
+- **Storage overhead**: typically 20–50% of source data size.
+- **Index overhead**: GIN indexes add roughly 5–10% overhead.
 
-### Refresh Latency
+### Refresh latency
 
-- **Trigger-based**: <100ms per operation (suitable for real-time GraphQL)
-- **Scheduled batch**: Minutes (suitable for dashboards)
-- **Manual refresh**: On-demand (suitable for development/testing)
+- **Trigger-based**: <100 ms per operation (suitable for real-time GraphQL).
+- **Scheduled batch**: minutes (suitable for dashboards).
+- **Manual refresh**: on-demand (suitable for development/testing).
 
-### Staleness Risk
+### Staleness risk
 
-- **Trigger-based**: Nearly real-time (slight delay during high-volume writes)
-- **Scheduled batch**: By design (e.g., 5-minute staleness)
-- **Manual refresh**: Until explicitly called
+- **Trigger-based**: nearly real-time (slight delay during high-volume writes).
+- **Scheduled batch**: by design (e.g., 5-minute staleness).
+- **Manual refresh**: stale until explicitly refreshed.
 
-### Schema Drift Risk
+### Schema drift risk
 
-- **JSONB structure must match GraphQL schema**: Mismatch causes validation errors
-- **Nested entity changes**: Changes to related entities (Post, Comment) require trigger updates
-- **Mitigation**: Comprehensive unit and integration tests verify schema consistency
+- **JSONB structure must match the GraphQL schema**: a mismatch causes validation errors.
+- **Nested entity changes**: changes to related entities (Post, Comment) require trigger updates.
+- **Mitigation**: unit and integration tests verify schema consistency.
 
-### Cascading Triggers
+### Cascading triggers
 
-- Multiple triggers (on user, post, comment) can create overhead
-- Consider batch refresh if write volume is very high (>1K/min)
-- Monitor trigger execution time
+- Multiple triggers (on user, post, comment) can create overhead.
+- Consider batch refresh when write volume is very high (>1K/min).
+- Monitor trigger execution time.
 
 ## Best Practices
 
-1. **Use intermediate composed views** for reusability (also useful for REST APIs)
-2. **Test trigger logic** before production deployment with high-volume writes
-3. **Monitor staleness** with `updated_at` column
-4. **Use command-based refresh** for bulk import verification
-5. **Schedule batch refresh** as fallback for trigger failures
-6. **Keep tv_* schema synchronized** with GraphQL schema definitions
-7. **Document refresh strategy** in architecture decisions
-8. **Use JSONB indexes** (GIN) for faster queries
-9. **Benchmark vs. logical view** to confirm performance improvement
+1. **Use intermediate composed views** for reusability.
+2. **Test trigger logic** before deploying to high-volume write workloads.
+3. **Monitor staleness** with the `updated_at` column.
+4. **Use command-based refresh** for bulk-import verification.
+5. **Schedule a batch refresh** as a fallback for trigger failures.
+6. **Keep the `tv_*` JSONB shape synchronized** with the GraphQL type definition.
+7. **Document the chosen refresh strategy** in architecture decisions.
+8. **Use GIN indexes** on the `data` column for faster queries.
+9. **Benchmark against the logical view** to confirm the performance gain.
 
 ## Troubleshooting
 
 ### Issue: tv_* table empty after trigger creation
 
-**Cause**: Trigger only fires on future changes, not existing data.
+**Cause:** the trigger only fires on future changes, not existing data.
 
-**Solution**: Run initial population:
+**Solution:** run the initial population.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT * FROM refresh_tv_user_profile();
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Issue: tv_* data stale after writes
 
-**Cause**: Trigger not firing or delayed.
+**Cause:** the trigger is not firing or is delayed.
 
-**Solution**: Check trigger status:
+**Solution:** check trigger status.
 
 ```sql
-<!-- Code example in SQL -->
 SELECT * FROM information_schema.triggers
 WHERE trigger_name LIKE 'trg_refresh_tv%';
 
 -- Manually refresh
 SELECT * FROM refresh_tv_user_profile();
-```text
-<!-- Code example in TEXT -->
+```
 
-### Issue: High CPU from cascading triggers
+### Issue: high CPU from cascading triggers
 
-**Cause**: Multiple triggers (on related tables) causing many refreshes.
+**Cause:** multiple triggers (on related tables) cause many refreshes.
 
-**Solution**: Switch to batched refresh:
+**Solution:** switch to a batched refresh.
 
 ```sql
-<!-- Code example in SQL -->
 -- Drop per-row triggers
 DROP TRIGGER IF EXISTS trg_refresh_tv_user_profile_on_post ON tb_post;
 DROP TRIGGER IF EXISTS trg_refresh_tv_user_profile_on_comment ON tb_comment;
 
 -- Schedule batch refresh instead
 SELECT cron.schedule('refresh-tv-profile', '*/5 * * * *', 'SELECT refresh_tv_user_profile();');
-```text
-<!-- Code example in TEXT -->
+```
 
-### Issue: JSONB composition mismatch with GraphQL schema
+### Issue: JSONB composition mismatch with the GraphQL schema
 
-**Cause**: DDL changed without updating schema binding.
+**Cause:** the DDL changed without updating the type binding.
 
-**Solution**:
+**Solution:**
 
-1. Update PostgreSQL DDL (helper views + tv_* table)
-2. Update GraphQL schema binding (authoring layer)
-3. Re-populate tv_* table
-4. Run integration tests to verify
+1. Update the PostgreSQL DDL (helper views + `tv_*` table).
+2. Update the `@fraiseql.type` binding (`sql_source` / field set).
+3. Re-populate the `tv_*` table.
+4. Run integration tests to verify.
 
 ## Examples
 
-See `/home/lionel/code/FraiseQL/examples/sql/postgres/` for complete DDL examples:
+See `examples/sql/` for complete DDL examples:
 
-- `tv_user_profile.sql` - User profile with nested posts and comments
-- `tv_order_summary.sql` - Order with line items and customer details
+- `tv_user_profile.sql` — user profile with nested posts and comments
+- `tv_order_summary.sql` — order with line items and customer details
 
 ## See Also
 
 - [View Selection Guide](./view-selection-guide.md)
 - [Schema Conventions](../../specs/schema-conventions.md)
-- [FraiseQL Database Architecture](../../architecture/)
+- [Naming Patterns](../../reference/naming-patterns.md)
+- [Database-Centric Architecture](../../foundation/03-database-centric-architecture.md)
+</content>
+</invoke>

--- a/docs/architecture/database/view-selection-guide.md
+++ b/docs/architecture/database/view-selection-guide.md
@@ -1,75 +1,70 @@
-<!-- Skip to main content -->
 ---
-
-title: View Selection Guide: Choosing Between v_*, tv_*, va_*, and ta_*
-description: FraiseQL supports **four distinct view patterns** across two query planes. This guide helps you choose the right pattern for your use case.
+title: "View Selection Guide: Choosing Between v_* and tv_*"
+description: FraiseQL exposes GraphQL reads through PostgreSQL views. This guide helps you choose between a logical view (v_*) and a table-backed projection view (tv_*).
 keywords: ["design", "scalability", "performance", "patterns", "security"]
 tags: ["documentation", "reference"]
 ---
 
-# View Selection Guide: Choosing Between v_*, tv_*, va_*, and ta_*
+# View Selection Guide: Choosing Between v_* and tv_*
 
 ## Overview
 
-FraiseQL supports **four distinct view patterns** across two query planes. This guide helps you choose the right pattern for your use case.
+In FraiseQL v1, every GraphQL read resolves against a PostgreSQL view that returns a
+`data` JSONB column. There are **two view patterns** to choose from, and the choice is
+the single biggest lever for read performance. This guide helps you pick the right one.
 
-## View Patterns at a Glance
+| Pattern | Type | Storage | Use Case | Latency | Maintenance |
+|---------|------|---------|----------|---------|-------------|
+| `v_*` | Logical view | None | Simple GraphQL queries | Medium (100-500ms) | None |
+| `tv_*` | Table-backed projection | JSONB table | Complex nested GraphQL | Fast (50-200ms) | Trigger/scheduled refresh |
 
-| Pattern | Plane | Type | Storage | Use Case | Latency | Maintenance |
-|---------|-------|------|---------|----------|---------|------------|
-| `v_*` | JSON | Logical | None | Simple GraphQL queries | Medium (100-500ms) | None |
-| `tv_*` | JSON | Table | JSONB | Complex nested GraphQL | Fast (50-200ms) | Trigger/scheduled refresh |
-| `va_*` | Arrow | Logical | None | Simple analytics queries | Medium (500ms-5s) | None |
-| `ta_*` | Arrow | Table | Columnar | Large-scale analytics | Very Fast (50-100ms) | Trigger/scheduled refresh |
+A `v_*` view composes its `data` JSONB at query time with a plain `SELECT`. A `tv_*` view
+is a real table holding pre-composed JSONB, refreshed by triggers or a scheduled job —
+you pay storage and refresh cost up front to make reads fast and predictable.
+
+Both are bound to a GraphQL type the same way, at runtime, when the app starts:
+
+```python
+import fraiseql
+from fraiseql.types import ID
+
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
+class User:
+    id: ID
+    name: str
+    email: str
+```
+
+Switching a type from a logical view to a table-backed projection is just a one-line
+change to `sql_source` — clients never see the difference.
 
 ## Decision Tree
 
 ```text
-<!-- Code example in TEXT -->
-START: What query plane are you working in?
+START: How complex is the read?
 
-├─ JSON PLANE (GraphQL queries)
-│  ├─ Simple query? (1-2 tables, flat structure)
-│  │  └─ YES → Use v_*
-│  │        Why: No JOIN overhead, instant to deploy
-│  │        Example: Query single user or user list
-│  │
-│  └─ Complex query? (3+ tables, nested data)
-│     ├─ HIGH read volume (>100 reqs/sec)?
-│     │  └─ Use tv_* (table-backed)
-│     │     Why: Pre-computed JSONB, sub-second latency
-│     │     Example: User profiles with posts/comments
-│     │
-│     └─ LOW read volume (<100 reqs/sec)?
-│        ├─ Query time > 1 second?
-│        │  └─ Use tv_* (table-backed)
-│        │     Why: Composition cost exceeds storage cost
-│        │
-│        └─ Query time < 1 second?
-│           └─ Use v_* (logical)
-│              Why: Storage overhead not justified
+├─ Simple query? (1-2 tables, flat structure)
+│  └─ YES → Use v_*
+│        Why: No JOIN overhead, nothing to maintain
+│        Example: Query a single user or a user list
 │
-└─ ARROW PLANE (Analytics queries)
-   ├─ Small dataset? (<100K rows)
-   │  └─ Use va_* (logical)
-   │     Why: No storage overhead, simple to maintain
-   │     Example: Daily sales summary (10K rows)
+└─ Complex query? (3+ tables, nested data)
+   ├─ HIGH read volume (>100 reqs/sec)?
+   │  └─ Use tv_* (table-backed projection)
+   │     Why: Pre-composed JSONB, sub-second latency
+   │     Example: User profiles with posts/comments
    │
-   └─ Large dataset? (>1M rows)
+   └─ LOW read volume (<100 reqs/sec)?
       ├─ Query time > 1 second?
-      │  └─ Use ta_* (table-backed)
-      │     Why: Columnar format, BRIN indexes
-      │     Example: 10M historical transactions
+      │  └─ Use tv_* (table-backed projection)
+      │     Why: Composition cost exceeds storage cost
       │
       └─ Query time < 1 second?
-         └─ Use va_* (logical)
+         └─ Use v_* (logical view)
             Why: Storage overhead not justified
-```text
-<!-- Code example in TEXT -->
+```
 
 ## Quick Reference by Scenario
-
-### GraphQL Queries
 
 **Simple Cases (Use v_*)**:
 
@@ -84,348 +79,177 @@ START: What query plane are you working in?
 - ✅ Dashboard requiring pre-aggregated data
 - ✅ GraphQL subscriptions (real-time updates)
 
-### Analytics Queries
-
-**Small Datasets (Use va_*)**:
-
-- ✅ Daily sales summary (computed once per day)
-- ✅ Weekly user metrics (5K rows)
-- ✅ Monthly revenue report (1K rows)
-
-**Large Datasets (Use ta_*)**:
-
-- ✅ 10M+ transaction history
-- ✅ 100K+ event stream (append-only)
-- ✅ Time-series analytics (millions of data points)
-
 ## Performance Comparison Matrix
 
 ### Query Execution Time (Lower is Better)
 
-| Query Type | v_* | tv_* | va_* | ta_* |
-|-----------|-----|------|------|------|
-| Single entity (User by ID) | **50-100ms** | 50-100ms | - | - |
-| Entity with 1 related (User + Posts) | 100-300ms | **100-200ms** | - | - |
-| Entity with 3+ related (User + Posts + Comments + Likes) | 2-5s | **50-200ms** | - | - |
-| Analytics: 10K rows, simple filter | - | - | **100-200ms** | 100-150ms |
-| Analytics: 1M rows, range query | - | - | 2-10s | **50-100ms** |
-| Analytics: 100M rows, aggregation | - | - | >30s | **200-500ms** |
+| Query Type | v_* | tv_* |
+|-----------|-----|------|
+| Single entity (User by ID) | **50-100ms** | 50-100ms |
+| Entity with 1 related (User + Posts) | 100-300ms | **100-200ms** |
+| Entity with 3+ related (User + Posts + Comments + Likes) | 2-5s | **50-200ms** |
 
 ### Memory Usage (Lower is Better)
 
-| Scenario | v_* | tv_* | va_* | ta_* |
-|----------|-----|------|------|------|
-| 1K records with deep nesting | 50-100MB | **20-30MB** | - | - |
-| 10K records with deep nesting | 500-800MB | **100-200MB** | - | - |
-| 100K row analytics query | - | - | 200-500MB | **50-100MB** |
-| 10M row analytics query | - | - | 2-5GB | **500MB-1GB** |
+| Scenario | v_* | tv_* |
+|----------|-----|------|
+| 1K records with deep nesting | 50-100MB | **20-30MB** |
+| 10K records with deep nesting | 500-800MB | **100-200MB** |
 
 ### Storage Overhead (Lower is Better)
 
 | Pattern | Overhead | Notes |
 |---------|----------|-------|
 | `v_*` | 0% | No storage (logical view) |
-| `tv_*` | 20-50% | JSONB pre-composition |
-| `va_*` | 0% | No storage (logical view) |
-| `ta_*` | 10-30% | Columnar format, BRIN indexes |
+| `tv_*` | 20-50% | JSONB pre-composition stored in a table |
 
 ## When to Migrate
 
-### Migrate from v_*to tv_* when
+### Migrate from v_* to tv_* when
 
 ✅ **GraphQL query times exceed 1 second**
 
 - Measure: Run production queries and log execution time
-- Action: Create tv_* table with pre-composed JSONB
+- Action: Create a `tv_*` table with pre-composed JSONB
 - Benefit: 10-50x faster queries
 
 ✅ **Query complexity has 3+ JOINs**
 
-- Indicator: Query hits database for nested data multiple times
-- Action: Pre-compose nested data into tv_* JSONB
-- Benefit: Single table scan vs. multiple JOINs
+- Indicator: Query composes nested data from multiple tables on every read
+- Action: Pre-compose nested data into a `tv_*` JSONB column
+- Benefit: Single indexed lookup vs. multiple JOINs
 
-✅ **High read volume (>100 requests/sec) to same data structure**
+✅ **High read volume (>100 requests/sec) to the same data structure**
 
 - Indicator: Database CPU high during peak traffic
-- Action: Cache computations in tv_* table
+- Action: Cache the composition in a `tv_*` table
 - Benefit: Query cost moves from compute-heavy to storage-read
 
 ✅ **Real-time GraphQL subscriptions require fast updates**
 
-- Indicator: Subscription latency varies based on nesting depth
-- Action: Trigger-based tv_* refresh ensures consistent latency
+- Indicator: Subscription latency varies with nesting depth
+- Action: Trigger-based `tv_*` refresh ensures consistent latency
 - Benefit: Subscription updates in <100ms
-
-### Migrate from va_*to ta_* when
-
-✅ **Analytics query times exceed 1 second**
-
-- Measure: Run EXPLAIN on Arrow queries
-- Action: Create ta_* table with columnar storage
-- Benefit: 50-100x faster on time-series queries
-
-✅ **Dataset larger than 1M rows**
-
-- Indicator: VA query memory usage > 1GB
-- Action: Use BRIN indexes on time-series columns
-- Benefit: Queries scan fewer pages
-
-✅ **Read volume high, staleness acceptable**
-
-- Indicator: Multiple concurrent analytics queries affecting other workloads
-- Action: Batch refresh ta_* tables during off-hours
-- Benefit: Analytics isolated from OLTP
 
 ### Don't Migrate when
 
-❌ **Query already fast** (<500ms for GraphQL, <1s for analytics)
+❌ **Query already fast** (<500ms)
 
-- Keep logical views unless write overhead forces migration
+- Keep the logical view unless write overhead forces migration
 
 ❌ **Storage is severely constrained**
 
-- Keep logical views; optimize queries instead
+- Keep the logical view; optimize the underlying query instead
 
 ❌ **Write volume is unpredictable**
 
-- Triggers may become overhead; use scheduled batch instead
+- Refresh triggers may become overhead; use a scheduled batch refresh instead
 
-## Migration Path Examples
+## Migration Path Example
 
-### Example 1: Complex User Profile (v_*→ tv_*)
+### Complex User Profile (v_* → tv_*)
 
 **Current State**:
 
 ```sql
-<!-- Code example in SQL -->
--- v_user_full: Logical view with real-time composition
+-- v_user_full: logical view with real-time composition
 -- Query time: 3-5 seconds
-SELECT * FROM v_user_full WHERE id = ?;
-```text
-<!-- Code example in TEXT -->
+SELECT * FROM v_user_full WHERE id = $1;
+```
 
 **Problem**: Users reported slow profile loading on high-traffic pages.
 
-**Decision**: Migrate to tv_* for pre-composed data.
+**Decision**: Migrate to a `tv_*` table-backed projection for pre-composed data.
 
 **Implementation**:
 
 ```sql
-<!-- Code example in SQL -->
--- Step 1: Create intermediate composed views (helper)
-CREATE VIEW v_user_posts_composed AS ...
-CREATE VIEW v_user_full_composed AS ...
+-- Step 1: Create the projection table holding pre-composed JSONB
+CREATE TABLE tv_user_profile AS
+SELECT id, data FROM v_user_full;
 
--- Step 2: Create tv_user_profile table
-CREATE TABLE tv_user_profile AS SELECT * FROM v_user_full_composed;
+-- Step 2: Keep it fresh with a trigger on the source write table
+CREATE TRIGGER trg_refresh_tv_user_profile
+    AFTER INSERT OR UPDATE OR DELETE ON tb_user
+    FOR EACH ROW EXECUTE FUNCTION fn_refresh_tv_user_profile();
+```
 
--- Step 3: Add refresh trigger
-CREATE TRIGGER trg_refresh_tv_user_profile ON tb_user ...
+```python
+# Step 3: Point the GraphQL type at the projection view (runtime binding)
+import fraiseql
+from fraiseql.types import ID
 
--- Step 4: Update GraphQL binding
-@FraiseQL.type(view="tv_user_profile")
-class User: ...
-
--- Step 5: Verify performance
--- Query time: 100-200ms ✅
--- User experience: 25-50x faster ✅
-```text
-<!-- Code example in TEXT -->
+@fraiseql.type(sql_source="tv_user_profile", jsonb_column="data")
+class User:
+    id: ID
+    name: str
+    posts: list["Post"]
+```
 
 **Before/After**:
 
 - **Before**: 3-5 second page load + database spike during peak traffic
 - **After**: 100-200ms page load, consistent performance
 
-### Example 2: Large Analytics Dataset (va_*→ ta_*)
+## Client API
 
-**Current State**:
+Clients never choose a view. They issue the same GraphQL query regardless of whether the
+type is backed by a `v_*` or a `tv_*` view — the server-side binding determines which one
+runs:
 
-```sql
-<!-- Code example in SQL -->
--- va_orders: Logical view over 10M rows
--- Query time: 5-10 seconds
-SELECT * FROM va_orders WHERE created_at >= ? AND created_at < ?;
-```text
-<!-- Code example in TEXT -->
-
-**Problem**: BI dashboard queries timing out, blocking other queries.
-
-**Decision**: Migrate to ta_* for optimized columnar storage.
-
-**Implementation**:
-
-```sql
-<!-- Code example in SQL -->
--- Step 1: Create ta_orders table with BRIN indexes
-CREATE TABLE ta_orders (
-    id TEXT PRIMARY KEY,
-    total NUMERIC,
-    created_at TIMESTAMPTZ,
-    ...
-);
-CREATE INDEX idx_ta_orders_created_at_brin ON ta_orders USING BRIN(created_at);
-
--- Step 2: Populate from va_orders
-INSERT INTO ta_orders SELECT * FROM va_orders;
-
--- Step 3: Add refresh trigger (or scheduled batch)
-CREATE TRIGGER trg_refresh_ta_orders ON tb_order ...
-
--- Step 4: Update Arrow schema binding
-registry.get("ta_orders")
-
--- Step 5: Verify performance
--- Query time: 50-100ms ✅
--- Memory: 500MB-1GB (vs 2-5GB) ✅
-```text
-<!-- Code example in TEXT -->
-
-**Before/After**:
-
-- **Before**: 5-10 second queries, dashboard timeouts, other queries blocked
-- **After**: 50-100ms queries, instant dashboard, no impact to OLTP
-
-## Client API Patterns
-
-### GraphQL (JSON Plane)
-
-Clients don't explicitly choose views; the schema binding determines which view to use:
-
-```typescript
-<!-- Code example in TypeScript -->
-// Client query (same for both v_* and tv_*)
-const query = gql`
-  query {
-    user(id: "550e8400...") {
+```graphql
+query {
+  user(id: "550e8400-e29b-41d4-a716-446655440000") {
+    id
+    name
+    posts {
       id
-      name
-      posts {
+      title
+      comments {
         id
-        title
-        comments {
-          id
-          text
-        }
+        text
       }
     }
   }
-`;
-
-// FraiseQL schema binding (server-side)
-@FraiseQL.type(view="tv_user_profile")  // Uses tv_* for performance
-class User:
-    id: UUID  # UUID v4 for GraphQL ID
-    name: str
-    posts: list[Post]
-```text
-<!-- Code example in TEXT -->
-
-**When to use which**:
-
-- Simple queries: `@FraiseQL.type(view="v_user")` (no view specified)
-- Complex queries: `@FraiseQL.type(view="tv_user_profile")` (explicit view)
-
-### Arrow Flight (Analytics Plane)
-
-Clients explicitly choose the view when creating tickets:
-
-```python
-<!-- Code example in Python -->
-import pyarrow.flight as flight
-
-client = flight.connect("grpc://localhost:50051")
-
-# Use logical view (va_orders)
-ticket_small = {
-    "view": "va_orders",  # Explicit choice
-    "filter": "created_at > '2026-01-01'",
-    "limit": 10000
 }
-stream = client.do_get(flight.Ticket(json.dumps(ticket_small).encode()))
+```
 
-# Use table-backed view (ta_orders)
-ticket_large = {
-    "view": "ta_orders",  # Explicit choice - faster for large datasets
-    "filter": "created_at > '2026-01-01'",
-    "limit": 1000000
-}
-stream = client.do_get(flight.Ticket(json.dumps(ticket_large).encode()))
-```text
-<!-- Code example in TEXT -->
+To move from a logical view to a projection view, change only `sql_source`:
 
-**View Discovery**:
-
-```python
-<!-- Code example in Python -->
-# List available views
-views = client.list_flights(criteria=None)
-for flight_info in views:
-    print(f"View: {flight_info.name}")
-    print(f"  Type: {'table' if flight_info.name.startswith('ta_') else 'logical'}")
-    print(f"  Rows: {flight_info.total_records}")
-```text
-<!-- Code example in TEXT -->
+- Simple queries: `@fraiseql.type(sql_source="v_user", jsonb_column="data")`
+- Complex queries: `@fraiseql.type(sql_source="tv_user_profile", jsonb_column="data")`
 
 ## Decision Checklist
 
 Before creating a new view, answer these questions:
-
-### For GraphQL (JSON Plane)
 
 - [ ] Is the query for a single entity? → Use `v_*`
 - [ ] Does the query require 3+ JOINs? → Consider `tv_*`
 - [ ] Are query times > 1 second? → Use `tv_*`
 - [ ] Is read volume > 100 reqs/sec to this view? → Use `tv_*`
 - [ ] Can you accept 100-300ms latency? → Use `v_*`
-- [ ] Do you need real-time subscriptions? → Use `tv_*` with triggers
+- [ ] Do you need real-time subscriptions? → Use `tv_*` with refresh triggers
 
-**Recommendation**: Default to `v_*`. Migrate to `tv_*` only if performance metrics require it.
-
-### For Arrow Flight (Analytics)
-
-- [ ] Is the dataset < 100K rows? → Use `va_*`
-- [ ] Is query time < 1 second? → Use `va_*`
-- [ ] Is the dataset > 1M rows? → Use `ta_*`
-- [ ] Are query times > 1 second? → Use `ta_*`
-- [ ] Is storage constrained? → Use `va_*`
-
-**Recommendation**: Default to `va_*`. Migrate to `ta_*` for large datasets.
+**Recommendation**: Default to `v_*`. Migrate to `tv_*` only when production metrics
+require it.
 
 ## Performance Testing
 
-### Test GraphQL Performance (v_*vs tv_*)
+Measure both views with `EXPLAIN (ANALYZE, BUFFERS)` and compare the reported
+**Execution Time**:
 
 ```sql
-<!-- Code example in SQL -->
--- Measure v_* execution time
-EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM v_user_full WHERE id = ?;
--- Note query time (look for "Execution Time")
+-- Measure the logical view
+EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM v_user_full WHERE id = $1;
 
--- Measure tv_* execution time
-EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM tv_user_profile WHERE id = ?;
--- Should be 10-50x faster
-```text
-<!-- Code example in TEXT -->
-
-### Test Analytics Performance (va_*vs ta_*)
-
-```sql
-<!-- Code example in SQL -->
--- Measure va_* execution time
-EXPLAIN (ANALYZE, BUFFERS)
-SELECT * FROM va_orders WHERE created_at >= ? AND created_at < ?;
-
--- Measure ta_* execution time
-EXPLAIN (ANALYZE, BUFFERS)
-SELECT * FROM ta_orders WHERE created_at >= ? AND created_at < ?;
--- Should be 50-100x faster for large datasets
-```text
-<!-- Code example in TEXT -->
+-- Measure the table-backed projection (should be 10-50x faster)
+EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM tv_user_profile WHERE id = $1;
+```
 
 ## See Also
 
-- [tv_* Table Pattern (JSON Plane Details)](./tv-table-pattern.md)
+- [tv_* Table Pattern](./tv-table-pattern.md)
 - [Schema Conventions](../../specs/schema-conventions.md)
-- [FraiseQL Database Architecture](../../architecture/)
+- [Naming Patterns](../../reference/naming-patterns.md)
+- [Aggregation Model](../analytics/aggregation-model.md)
+- [Database-Centric Architecture](../../foundation/03-database-centric-architecture.md)


### PR DESCRIPTION
Phase 2 of the docs cleanup (follows #418, #419). Rewrites the **Architecture → Database** and **Architecture → Analytics** nav pages, which carried v2 framing (Arrow plane, multi-DB, compile-time, fictional decorators).

All 6 pages now describe v1 reality: **PostgreSQL** view/table modeling patterns and the **real runtime auto-aggregation** feature.

## Per-file summary

| File | Key v2→v1 changes |
|------|-------------------|
| `database/view-selection-guide` | drop the entire Arrow plane (`va_`/`ta_`, Arrow Flight client); decision tree collapsed to `v_` (logical) vs `tv_` (table-backed projection) |
| `database/tv-table-pattern` | remove `ta_*` Arrow comparisons + stale `/code/FraiseQL` abs path; runtime framing |
| `analytics/calendar-dimensions` | "auto-detection at schema compilation" → view/table SQL; keep calendar-in-JSONB + trigger + GIN pattern |
| `analytics/fact-dimension-pattern` | drop `fact_table=True` + compiler/Phase framing; keep fact-table design, measures/dimensions/filters, ETL, DDL |
| `analytics/aggregation-model` | reframe around v1's **real** runtime auto-aggregation (`_derive_auto_aggregation` in `db.py`; `native_dimensions` via `register_type_for_view`); keep COUNT/SUM/AVG/MIN/MAX/STDDEV/VARIANCE + `GROUP BY`/`HAVING`/`FILTER` |
| `analytics/window-functions` | reframe as a PostgreSQL window-function reference you write **inside your view SQL**; drop "Phase 5 / proposed GraphQL API / compiler" + multi-DB |

Cross-cutting: `@FraiseQL.*` → `@fraiseql.*`, removed malformed code fences and `<!-- Code example -->` artifacts, repointed dangling links (incl. the removed `architecture/` dir README), PostgreSQL-only.

## Verification

- `grep`: **zero** `@FraiseQL.` / Arrow / `va_`/`ta_` / `fact_table=` / `GroupByExecutionPlan` / multi-DB / compile artifacts; the one remaining "compile" is an explicit *negation*.
- The aggregation API claims are **source-verified**: `register_type_for_view(..., aggregation={"native_dimensions": [...]})` matches `src/fraiseql/db.py` (lines 315, 755, 784).
- All cross-links resolve; code fences balanced; no Rust/TS leftover syntax.
- `mkdocs build`: no new warnings.

Net: **+1195 / −2045** lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)