### PR TITLE
docs(architecture): rewrite the Reliability pages for v1 (Phase 2)

### DIFF
--- a/docs/architecture/reliability/consistency-model.md
+++ b/docs/architecture/reliability/consistency-model.md
@@ -1,39 +1,41 @@
-<!-- Skip to main content -->
 ---
-
 title: Consistency Model
-description: FraiseQL provides **strict serializable consistency** within a single database instance and **causal consistency** across federated instances. This document spe
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+description: FraiseQL v1 inherits PostgreSQL's strict serializable consistency. This document specifies the consistency guarantees clients can rely on.
+keywords: ["consistency", "acid", "isolation", "postgresql", "transactions"]
 tags: ["documentation", "reference"]
 ---
 
 # Consistency Model
 
-**Version:** 1.0
-**Status:** Complete
-**Date:** January 11, 2026
+**Status:** Stable
 **Audience:** Architects, database engineers, enterprise evaluators
 
 ---
 
 ## 1. Overview
 
-FraiseQL provides **strict serializable consistency** within a single database instance and **causal consistency** across federated instances. This document specifies the consistency guarantees clients can rely on.
+FraiseQL v1 is a Python runtime GraphQL framework backed by a **single PostgreSQL
+database**. Its consistency guarantees are exactly PostgreSQL's consistency
+guarantees: FraiseQL does not add a consistency layer of its own, and it does not
+weaken what PostgreSQL provides.
 
 ### 1.1 Core Principle
 
-> **What the database guarantees, FraiseQL guarantees.**
+> **What PostgreSQL guarantees, FraiseQL guarantees.**
 
-FraiseQL does not weaken database consistency. If the database provides serializable transactions, FraiseQL preserves that. If the database provides eventual consistency, FraiseQL preserves that.
+FraiseQL queries call PostgreSQL read views (`v_`/`tv_`) and mutations call
+PostgreSQL functions (`fn_`). Every statement runs inside a PostgreSQL transaction,
+so the ACID and isolation properties you configure on the database are the
+properties your GraphQL API exposes.
 
-### 1.2 Consistency Levels Supported
+### 1.2 Consistency Foundation
 
-| Database | Consistency Level | Isolation | Multi-Version | TTL |
-|----------|-------------------|-----------|---------------|-----|
-| **PostgreSQL** | Serializable | ✅ Full ACID | ✅ MVCC | N/A |
-| **MySQL** | Serializable | ✅ Full ACID | ✅ InnoDB MVCC | N/A |
-| **SQL Server** | Serializable | ✅ Full ACID | ✅ Snapshot | N/A |
-| **SQLite** | Serializable | ✅ Full ACID | ⚠️ Limited | N/A |
+| Property | PostgreSQL Mechanism |
+|----------|----------------------|
+| Atomicity | Transactional `BEGIN`/`COMMIT`, all-or-nothing |
+| Consistency (logical) | Constraints, foreign keys, check constraints |
+| Isolation | MVCC, Read Committed by default, Serializable available |
+| Durability | Write-ahead logging (WAL) |
 
 ---
 
@@ -41,40 +43,46 @@ FraiseQL does not weaken database consistency. If the database provides serializ
 
 ### 2.1 ACID Transaction Guarantees
 
-FraiseQL queries and mutations respect the database's ACID properties:
+FraiseQL queries and mutations respect PostgreSQL's ACID properties.
 
 #### 2.1.1 Atomicity
 
-**What it means:** Mutation either fully succeeds or fully fails. No partial updates.
+**What it means:** A mutation either fully succeeds or fully fails. No partial
+updates.
 
-**Scope:** Single mutation operation
+**Scope:** A single mutation, which executes one `fn_` PostgreSQL function inside
+one transaction.
 
-- Mutation: `createUser(name: "Bob", email: "bob@example.com")`
-- All side effects apply, or none apply
-- No partial state visible to other queries
+- All side effects of the function apply, or none apply.
+- No partial state is visible to other queries.
 
 **Guarantee:**
 
-```python
-<!-- Code example in Python -->
-# Before mutation
-SELECT COUNT(*) FROM users  # 100
+```sql
+-- Before mutation
+SELECT COUNT(*) FROM tb_user;  -- 100
+```
 
-# Mutation fails (email constraint violation)
+```graphql
+# Mutation fails (email uniqueness constraint violation)
 mutation {
-  createUser(name: "Bob", email: "duplicate@example.com") { id }
+  createUser(input: { name: "Bob", email: "duplicate@example.com" }) {
+    ... on CreateUserSuccess { user { id } }
+    ... on CreateUserError { message code }
+  }
 }
+```
 
-# After mutation
-SELECT COUNT(*) FROM users  # Still 100 (no partial insert)
-```text
-<!-- Code example in TEXT -->
+```sql
+-- After mutation
+SELECT COUNT(*) FROM tb_user;  -- Still 100 (no partial insert)
+```
 
 #### 2.1.2 Consistency (Logical)
 
 **What it means:** Database integrity constraints are never violated.
 
-**Scope:** All queries, mutations, subscriptions
+**Scope:** All queries, mutations, and subscriptions.
 
 - Foreign key constraints enforced
 - Unique constraints enforced
@@ -83,95 +91,96 @@ SELECT COUNT(*) FROM users  # Still 100 (no partial insert)
 
 **Guarantee:**
 
-```python
-<!-- Code example in Python -->
-# Foreign key constraint: order.user_id → user.id
-# This mutation will fail (invalid user_id):
+```graphql
+# Foreign key constraint: tb_order.fk_user → tb_user.pk_user
+# This mutation fails because the referenced user does not exist:
 mutation {
-  createOrder(user_id: 9999, amount: 100) { id }  # Returns error
+  createOrder(input: { userId: "00000000-0000-0000-0000-000000009999", amount: 100 }) {
+    ... on CreateOrderSuccess { order { id } }
+    ... on CreateOrderError { message code }
+  }
 }
-
-# After error, database state is unchanged
-```text
-<!-- Code example in TEXT -->
+# After the error, database state is unchanged.
+```
 
 #### 2.1.3 Isolation
 
-**What it means:** Concurrent operations don't interfere with each other.
+**What it means:** Concurrent operations do not interfere with each other beyond
+what the configured isolation level permits.
 
 **Isolation levels** (in order of strictness):
 
-| Level | Dirty Reads | Non-Repeatable | Phantom | Implementation |
-|-------|-------------|----------------|---------|-----------------|
-| **Read Uncommitted** | ❌ Not in FraiseQL | - | - | - |
-| **Read Committed** | ✅ Prevented | ⚠️ Possible | ⚠️ Possible | PostgreSQL default |
-| **Repeatable Read** | ✅ Prevented | ✅ Prevented | ⚠️ Possible | MySQL default |
-| **Serializable** | ✅ Prevented | ✅ Prevented | ✅ Prevented | ✅ FraiseQL default |
+| Level | Dirty Reads | Non-Repeatable | Phantom | Notes |
+|-------|-------------|----------------|---------|-------|
+| **Read Uncommitted** | Prevented | Possible | Possible | PostgreSQL treats this as Read Committed |
+| **Read Committed** | Prevented | Possible | Possible | PostgreSQL default |
+| **Repeatable Read** | Prevented | Prevented | Prevented (PostgreSQL) | Snapshot isolation |
+| **Serializable** | Prevented | Prevented | Prevented | Serializable Snapshot Isolation (SSI) |
 
-**FraiseQL isolation guarantee:** Queries and mutations operate at **Serializable** isolation level.
+**FraiseQL isolation:** Each request runs at PostgreSQL's configured isolation
+level (Read Committed by default). If your `fn_` functions or session require
+stronger guarantees, set `SET TRANSACTION ISOLATION LEVEL SERIALIZABLE` (or
+configure it on the connection) inside the database; FraiseQL faithfully reflects
+whatever PostgreSQL is configured to enforce.
 
-```python
-<!-- Code example in Python -->
-# Two concurrent mutations (serializable isolation)
+```graphql
+# Two concurrent mutations updating the same row
 # Client A:
-mutation {
-  updateUser(id: 1, name: "Alice Update 1") { name }
-}
+mutation { updateUser(input: { id: "...", name: "Alice Update 1" }) {
+  ... on UpdateUserSuccess { user { name } }
+} }
 
 # Client B:
-mutation {
-  updateUser(id: 1, name: "Alice Update 2") { name }
-}
+mutation { updateUser(input: { id: "...", name: "Alice Update 2" }) {
+  ... on UpdateUserSuccess { user { name } }
+} }
 
-# Result: One succeeds, one fails (conflict detected)
-# Never: Both succeed with mixed updates
-```text
-<!-- Code example in TEXT -->
+# Under Serializable isolation: one commits, the other fails with a
+# serialization conflict and can be retried. Under Read Committed:
+# the second write overwrites the first (last-writer-wins).
+```
 
 #### 2.1.4 Durability
 
-**What it means:** Once mutation succeeds, it persists even after failure.
+**What it means:** Once a mutation succeeds, the change persists even after a
+crash.
 
-**Scope:** Confirmed mutations
+**Scope:** Confirmed mutations.
 
-- Mutation returns success response (in GraphQL `data` field, not `errors`)
-- Database has written change to durable storage
-- Change survives server restart, power loss, etc.
+- The mutation returns a success result (in the GraphQL `data` field, not `errors`).
+- PostgreSQL has flushed the change to durable storage via the WAL.
+- The change survives a server restart or power loss.
 
 **Guarantee:**
 
-```python
-<!-- Code example in Python -->
+```graphql
 # Mutation succeeds (returns in data field)
 mutation {
-  createUser(name: "Bob") { id }
-  # Response received by client with data: { createUser: { id: 123 } }
+  createUser(input: { name: "Bob", email: "bob@example.com" }) {
+    ... on CreateUserSuccess { user { id } }
+  }
 }
+# The client receives data: { createUser: { user: { id: "..." } } }
 
-# Server crashes immediately after
-# Database restart: Change still there
-
-# Later query:
-query {
-  user(id: 123) { name }  # Returns "Bob"
-}
-```text
-<!-- Code example in TEXT -->
+# The server crashes immediately afterward.
+# After PostgreSQL restarts, the change is still present:
+query { user(id: "...") { name } }  # Returns "Bob"
+```
 
 **Non-guarantee:**
 
-```python
-<!-- Code example in Python -->
-# Mutation fails (returns in errors field)
+```graphql
+# Mutation fails (returns in the errors field or as a typed error union)
 mutation {
-  createUser(name: "Alice", email: "duplicate@example.com") { id }
-  # Response received with errors: [...], data: null
+  createUser(input: { name: "Alice", email: "duplicate@example.com" }) {
+    ... on CreateUserError { message }
+  }
 }
+# data: null on the field / typed error returned
 
-# Server crashes
-# Database restart: Change was never applied (not durable)
-```text
-<!-- Code example in TEXT -->
+# If the server crashes now, the change was never applied
+# (it was never committed, so there is nothing to be durable).
+```
 
 ---
 
@@ -179,660 +188,399 @@ mutation {
 
 ### 3.1 Read-After-Write Consistency (RAW)
 
-**What it means:** After a write succeeds, subsequent reads see the write.
+**What it means:** After a write commits, subsequent reads see the write.
 
-**Scope:** Same client connection
+**Scope:** A single PostgreSQL primary.
 
-```python
-<!-- Code example in Python -->
-# Write succeeds
+```graphql
+# Write commits
 mutation {
-  updateUser(id: 1, name: "Alice") { name }
-  # Response: data: { updateUser: { name: "Alice" } }
+  updateUser(input: { id: "...", name: "Alice" }) {
+    ... on UpdateUserSuccess { user { name } }
+  }
 }
 
-# Subsequent read sees the write
-query {
-  user(id: 1) { name }  # Returns "Alice"
-}
-```text
-<!-- Code example in TEXT -->
+# A subsequent read sees the write
+query { user(id: "...") { name } }  # Returns "Alice"
+```
 
-**Strong guarantee:** Applies at all times, for all clients.
+**Guarantee:** Against a single PostgreSQL primary, read-after-write is
+immediate. A committed write is visible to every later read of that primary.
 
 ### 3.2 Read-Your-Writes Consistency (RYW)
 
-**What it means:** Client always sees results of its own writes, even if different server processes handle the requests.
+**What it means:** A client always sees the results of its own committed writes.
 
-**Scope:** Same authenticated user
+**Scope:** A single PostgreSQL primary.
 
-```python
-<!-- Code example in Python -->
-# Request 1: Write to Server A
-mutation {
-  updateUserProfile(name: "NewName") { name }
-}
+```graphql
+# Request 1: write
+mutation { updateUserProfile(input: { name: "NewName" }) {
+  ... on UpdateUserSuccess { user { name } }
+} }
 
-# Request 2: Read from Server B (different process)
-query {
-  me { name }  # Returns "NewName"
-}
-```text
-<!-- Code example in TEXT -->
+# Request 2: read (any FraiseQL worker, same database)
+query { me { name } }  # Returns "NewName"
+```
 
-**Implementation:** Achieved via:
-
-- Database replication (all writes go to primary)
-- Session affinity (client sticky to server)
-- Causal token tracking (server sends version, client tracks)
+Because every FraiseQL worker reads from the same PostgreSQL primary, multiple
+application processes do not break read-your-writes: the database is the single
+source of truth.
 
 ### 3.3 Monotonic Reads
 
-**What it means:** Client never sees a version of data earlier than a previous read.
+**What it means:** A client never sees a version of data earlier than a previous
+read.
 
-**Scope:** Same client over time
+**Scope:** A single PostgreSQL primary.
 
-```python
-<!-- Code example in Python -->
-# Read 1: User has 5 posts
-query { user(id: 1) { posts { count } } }
-# Returns: 5
+```graphql
+# Read 1: user has 5 posts
+query { user(id: "...") { posts { totalCount } } }  # Returns 5
 
-# Wait 1 second, some other client adds a post
+# Another client adds a post.
 
-# Read 2: User still sees 5 posts (at worst)
-query { user(id: 1) { posts { count } } }
-# Returns: >= 5 (5 or 6, never less than 5)
-```text
-<!-- Code example in TEXT -->
+# Read 2: still at least 5
+query { user(id: "...") { posts { totalCount } } }  # Returns >= 5, never < 5
+```
 
-**Strong guarantee:** FraiseQL never shows older versions of data.
+Against a single primary, committed data does not disappear, so reads are
+monotonic by construction.
 
-### 3.4 Consistent Prefix Reads
+### 3.4 Read Replicas (Deployment Note)
 
-**What it means:** Client sees causally-consistent sequence of updates, not out-of-order.
+PostgreSQL supports streaming **read replicas** as a deployment option. Replicas
+apply WAL asynchronously and therefore lag the primary, so reads served by a
+replica are **eventually consistent** with respect to recent writes on the
+primary.
 
-**Scope:** Related data across reads
+This is a property of your PostgreSQL deployment, **not a FraiseQL feature**:
 
-```python
-<!-- Code example in Python -->
-# Event 1: Create order (id: 100)
-mutation { createOrder(user_id: 1, amount: 100) { id } }
-
-# Event 2: Create order update (status: shipped)
-mutation { updateOrder(id: 100, status: "shipped") { status } }
-
-# Client reads:
-query { order(id: 100) { status } }
-# Never sees: order doesn't exist yet (would be out-of-order)
-# Always sees: order with status = "shipped" (or not created yet)
-```text
-<!-- Code example in TEXT -->
+- FraiseQL connects to whatever `database_url` you give it via a single
+  `psycopg_pool.AsyncConnectionPool`. It does **not** route queries to replicas,
+  split reads from writes, or perform automatic failover.
+- If you point FraiseQL at a replica, reads can be stale relative to the primary.
+  If you point it at the primary (the common single-node setup), all of the
+  read-consistency guarantees in 3.1-3.3 hold.
+- Read/write splitting and failover are handled below FraiseQL, for example by a
+  connection proxy (PgBouncer, pgpool) or your infrastructure, and are out of
+  scope for the framework.
 
 ---
 
 ## 4. Write Consistency
 
-### 4.1 Serializable Writes
+### 4.1 Serialized Writes
 
-**What it means:** Concurrent writes are serialized (don't interleave).
+**What it means:** Concurrent writes to the same row do not interleave; PostgreSQL
+serializes them.
 
-**Scope:** All mutations
+**Scope:** All mutations.
 
-```python
-<!-- Code example in Python -->
-# Concurrent mutations on same row
-# Client A: UPDATE user SET balance = balance - 100 WHERE id = 1
-# Client B: UPDATE user SET balance = balance - 50 WHERE id = 1
-
+```graphql
+# Concurrent mutations on the same row, each implemented by a fn_ function:
+#   fn_debit_balance: UPDATE tb_user SET balance = balance - $1 WHERE id = $2
+# Client A: debit 100
+# Client B: debit 50
 # Initial balance: 1000
 
-# Result: One succeeds first, second uses updated value
-# Possible: A succeeds (900), B succeeds (850) ✅
-# Never: Both use original (900 and 950) ❌
-```text
-<!-- Code example in TEXT -->
+# PostgreSQL row locks serialize the two updates:
+# Possible: A then B -> 900 then 850
+# Never: both read 1000 independently -> 900 and 950
+```
 
-### 4.2 Transaction Isolation for Multi-Statement
+### 4.2 Multi-Statement Atomicity
 
-**What it means:** Multi-statement mutations are atomic.
+**What it means:** A mutation's PostgreSQL function may perform many statements;
+they all commit together or all roll back.
 
-**Scope:** Multiple queries within single mutation (future feature)
+**Scope:** A single `fn_` function call.
 
-```python
-<!-- Code example in Python -->
-mutation {
-  # Statement 1
-  createOrder(user_id: 1) { id }
-  # Statement 2
-  updateUser(id: 1, balance: balance - 100) { balance }
-  # Statement 3
-  createAuditLog(action: "order_created") { id }
+```sql
+-- Inside fn_create_order, all statements share one transaction:
+CREATE FUNCTION fn_create_order(p_input jsonb) RETURNS jsonb AS $$
+BEGIN
+  INSERT INTO tb_order (...) VALUES (...);          -- statement 1
+  UPDATE tb_user SET balance = balance - ... ;      -- statement 2
+  INSERT INTO tb_audit_log (...) VALUES (...);      -- statement 3
+  RETURN jsonb_build_object('success', true, ...);
+END;
+$$ LANGUAGE plpgsql;
+```
 
-  # All succeed or all fail together
-  # No partial state visible
-}
-```text
-<!-- Code example in TEXT -->
+If any statement raises, the entire function rolls back and the mutation returns a
+typed error. No partial state is ever visible.
 
 ### 4.3 Write Conflicts
 
-**What it means:** Conflicting writes are detected and one fails.
+**What it means:** Conflicting concurrent writes are detected and one of them
+fails, so it can be retried.
 
-**Scope:** Concurrent modifications
+**Scope:** Concurrent modifications, when using optimistic concurrency.
 
-```python
-<!-- Code example in Python -->
-# Client A: updateUser(id: 1, name: "Alice", version: 5)
-# Client B: updateUser(id: 1, name: "Bob", version: 5)
+```sql
+-- Optimistic concurrency inside fn_update_user using a version column:
+UPDATE tb_user
+SET name = p_name, version = version + 1
+WHERE id = p_id AND version = p_expected_version;
+-- 0 rows affected => caller's version was stale => return a conflict error
+```
 
-# Both use same version (5)
-# Result: A succeeds (version → 6), B fails with conflict error
-```text
-<!-- Code example in TEXT -->
+```graphql
+# Client A: updateUser(id, name: "Alice", expectedVersion: 5)
+# Client B: updateUser(id, name: "Bob",   expectedVersion: 5)
+# A commits first (version -> 6). B's UPDATE matches 0 rows and
+# returns a typed conflict error.
+```
 
----
-
-## 5. Multi-Database Consistency (Federation)
-
-### 5.1 Causal Consistency Guarantee
-
-When FraiseQL fetches federated entities from multiple databases, it provides **causal consistency**:
-
-**Definition:** If operation A causally affects operation B, every observer sees A before B.
-
-**Example:**
-
-```python
-<!-- Code example in Python -->
-# Database 1: Users
-# Database 2: Orders
-
-# Operation A: Create order in Database 2
-mutation {
-  createOrder(user_id: 1) { id }  # → order_123
-}
-
-# Operation B: Query user + their orders (from both databases)
-query {
-  user(id: 1) {
-    name
-    orders { id }  # Includes order_123
-  }
-}
-
-# Causal guarantee:
-# - Client always sees order_123 in the user's orders
-# - Never sees state before order was created
-# - Even if databases are replicas with lag
-```text
-<!-- Code example in TEXT -->
-
-### 5.2 Consistency Across Databases
-
-**Single-Database Query (Strict Serializable):**
-
-```text
-<!-- Code example in TEXT -->
-Database: PostgreSQL
-Consistency: Serializable ACID
-Latency: <10ms
-```text
-<!-- Code example in TEXT -->
-
-**Federated Query (Causal Consistent):**
-
-```text
-<!-- Code example in TEXT -->
-Database 1: PostgreSQL (Users)
-Database 2: MySQL (Orders)
-Consistency: Causal
-Latency: <100ms (slower due to coordination)
-```text
-<!-- Code example in TEXT -->
-
-**Trade-off:** Federation sacrifices strict serializability for scalability.
-
-### 5.3 No Cross-Database Transactions
-
-**Important:** FraiseQL does NOT provide distributed transactions across federated databases.
-
-```python
-<!-- Code example in Python -->
-# This does NOT have cross-database atomicity:
-mutation {
-  createUser(name: "Alice") { id }  # Database 1
-  createOrder(user_id: NEW_ID) { id }  # Database 2
-}
-
-# Why: Distributed 2-phase commit is too expensive
-# If operation fails: Rollback may be partial
-
-# Instead: Client should handle failure
-if not mutation_succeeded:
-  client should retry both or roll back manually
-```text
-<!-- Code example in TEXT -->
-
-### 5.4 Federation via Database Linking (Optimized)
-
-When using database-level federation (FDW, Linked Servers), consistency is **stricter**:
-
-```python
-<!-- Code example in Python -->
-# PostgreSQL FDW federation
-# Both databases: PostgreSQL
-Consistency: Serializable ACID (via FDW)
-
-# vs HTTP federation
-# Any databases, via HTTP
-Consistency: Causal
-```text
-<!-- Code example in TEXT -->
+Optimistic concurrency is a pattern you implement inside your `fn_` functions; see
+[Error Handling Model](./error-handling-model.md) for how conflicts surface as
+typed errors.
 
 ---
 
-## 6. Subscription Consistency
+## 5. Subscription Consistency
 
-### 6.1 Event Ordering Guarantees
+### 5.1 Event Ordering Guarantees
 
-Subscriptions provide **per-entity ordering** of events:
+Subscriptions provide **per-entity ordering** of events.
 
-```python
-<!-- Code example in Python -->
-# Subscription: orderUpdated(where: { id: 100 })
-orderUpdated { id, status, timestamp }
+```graphql
+# Subscription on a single order
+subscription { orderUpdated(id: "...") { id status timestamp } }
+```
 
-# Events for same entity are ordered:
-Event 1: status = "pending" (timestamp: T1)
-Event 2: status = "shipped" (timestamp: T2)
-Event 3: status = "delivered" (timestamp: T3)
-
-# Client always sees events in this order
-# Never: Event 3 before Event 1
 ```text
-<!-- Code example in TEXT -->
+Events for the same entity are ordered:
+  Event 1: status = "pending"   (timestamp: T1)
+  Event 2: status = "shipped"   (timestamp: T2)
+  Event 3: status = "delivered" (timestamp: T3)
 
-### 6.2 Event Delivery Consistency
+The client always sees them in this order; never Event 3 before Event 1.
+```
 
-**At-least-once delivery:**
+### 5.2 Event Delivery
 
-- Events are delivered at least once
-- Client may receive duplicates (same event twice)
-- Client should be idempotent
+Delivery is **at-least-once**:
 
-```python
-<!-- Code example in Python -->
-# Same event delivered twice (network retry)
-{
-  "event_id": "evt_12345",
-  "data": { "id": 100, "status": "shipped" }
-}
-{
-  "event_id": "evt_12345",  # Same ID
-  "data": { "id": 100, "status": "shipped" }
-}
+- Each event is delivered at least once.
+- A client may receive a duplicate (for example after a network retry).
+- Clients should be idempotent and de-duplicate by event identifier.
 
-# Client should check event_id and skip duplicates
+```json
+{ "eventId": "evt_12345", "data": { "id": "...", "status": "shipped" } }
+{ "eventId": "evt_12345", "data": { "id": "...", "status": "shipped" } }
+```
+
+The client checks `eventId` and skips events it has already processed.
+
+### 5.3 No Cross-Entity Ordering
+
+Events from different entities may arrive out of order:
+
 ```text
-<!-- Code example in TEXT -->
+Database timeline:
+  T1: Order A updated -> Event 1
+  T2: User B updated  -> Event 2
+  T3: Order C updated -> Event 3
 
-### 6.3 No Cross-Entity Ordering
+A client subscribed to multiple entities may receive: Event 2, Event 3, Event 1.
+Events are per-entity ordered, not globally ordered.
+```
 
-Events from different entities may arrive out-of-order:
-
-```python
-<!-- Code example in Python -->
-# Subscription: orderUpdated + userUpdated
-
-# Database timeline:
-T1: Order 100 updated → Event A
-T2: User 5 updated → Event B
-T3: Order 200 updated → Event C
-
-# Client may receive:
-Event B, Event C, Event A  # Out of original order!
-
-# Why: Events are per-entity ordered, not globally ordered
-```text
-<!-- Code example in TEXT -->
+See [Subscriptions](../realtime/subscriptions.md) for the full subscription model.
 
 ---
 
-## 7. Caching Consistency
+## 6. Caching Consistency
 
-### 7.1 Cache Invalidation on Write
+### 6.1 Cache Invalidation on Write
 
-When a mutation succeeds, all related cache entries are invalidated:
+When a mutation commits, related cache entries are invalidated so subsequent reads
+reflect the new state.
 
-```python
-<!-- Code example in Python -->
-# Initial query (cached)
-query { user(id: 1) { name posts { id } } }
-# Cache key: user:1, user:1:posts
-# Cached result: name="Alice", posts=[100, 101]
+```graphql
+# Initial query, result cached
+query { user(id: "...") { name posts { id } } }
+# Cached: name="Alice", posts=[...]
 
 # Mutation
-mutation { updateUser(id: 1, name: "Bob") { name } }
+mutation { updateUser(input: { id: "...", name: "Bob" }) {
+  ... on UpdateUserSuccess { user { name } }
+} }
+# Related cache entries for that user are invalidated.
 
-# Automatic cache invalidation:
-# - user:1 invalidated ✓
-# - user:1:posts invalidated ✓
-# - related:user:1 queries invalidated ✓
+# Next query reads fresh data from PostgreSQL
+query { user(id: "...") { name } }  # name="Bob"
+```
 
-# Next query (cache miss, fresh from database)
-query { user(id: 1) { name } }
-# Cache hit: name="Bob"
+### 6.2 Cache TTL (Time-to-Live)
+
+Cached results may carry a maximum age. A result younger than its TTL is served
+from cache; once it expires, the next read re-fetches from PostgreSQL.
+
 ```text
-<!-- Code example in TEXT -->
+Cache entry max age: 60 seconds
+  age < 60s  -> served from cache
+  age >= 60s -> stale, re-fetched from the database
+```
 
-### 7.2 Cache TTL (Time-to-Live)
+### 6.3 Cache Coherence
 
-Some queries use stale-cache-acceptable-time (SCAT):
-
-```python
-<!-- Code example in Python -->
-# Query cached for 60 seconds max
-query @cacheControl(maxAge: 60) {
-  products { id name }
-}
-
-# Fresh if: query < 60s old
-# Stale if: query > 60s old, re-fetch from database
-```text
-<!-- Code example in TEXT -->
-
-### 7.3 Cache Coherence
-
-**Strong cache coherence:** All clients see consistent cache results.
-
-- Cache invalidations are broadcast
-- All servers invalidate same keys
-- No stale data persists across servers
+In a single-node deployment, the cache is invalidated on write, so reads after a
+committed mutation observe the new value. In a multi-worker deployment, configure
+a shared cache backend so invalidations are visible to all workers; otherwise each
+worker maintains its own cache and stale entries persist only until their TTL
+expires.
 
 ---
 
-## 8. Consistency Under Failures
+## 7. Consistency Under Failures
 
-### 8.1 Database Unavailable
+### 7.1 Database Unavailable
 
-**Query:** Returns error, no partial data
+**Query:** Returns an error, no partial data.
 
-```python
-<!-- Code example in Python -->
-query { user(id: 1) { name } }
-# Database is down
-# Returns: ERROR, data: null
-```text
-<!-- Code example in TEXT -->
+```graphql
+query { user(id: "...") { name } }
+# PostgreSQL is unreachable -> error; data is null.
+```
 
-**Mutation:** Returns error, no changes applied
+**Mutation:** Returns an error, no changes applied.
 
-```python
-<!-- Code example in Python -->
-mutation { updateUser(id: 1, name: "Bob") { name } }
-# Database is down
-# Returns: ERROR, data: null
-# Database unchanged
-```text
-<!-- Code example in TEXT -->
+```graphql
+mutation { updateUser(input: { id: "...", name: "Bob" }) { ... } }
+# PostgreSQL is unreachable -> error; the database is unchanged.
+```
 
-### 8.2 Connection Lost Mid-Query
+### 7.2 Connection Lost Mid-Request
 
-**Before response sent:** Client sees error, no data
-**After response sent:** Data is consistent (database committed)
+- **Before the response is sent:** The client sees an error; if the transaction
+  did not commit, no data changed.
+- **After the response is sent:** The data is consistent because PostgreSQL has
+  already committed.
 
-### 8.3 Server Crash
+### 7.3 Server Crash
 
-**Durable mutations:** Persisted to database (ACID durability)
-**Cache:** Invalidated on restart (refreshed from database)
-**In-flight requests:** Clients receive errors, must retry
+- **Committed mutations:** Persisted by PostgreSQL (WAL durability).
+- **Cache:** Rebuilt from PostgreSQL after restart.
+- **In-flight requests:** Clients receive errors and should retry.
+
+See [Failure Modes and Recovery](./failure-modes-and-recovery.md) for detailed
+recovery procedures.
 
 ---
 
-## 9. Eventual Consistency (Not Provided)
+## 8. Strong Consistency by Default
 
-**Important:** FraiseQL does NOT provide eventual consistency by default.
+Against a single PostgreSQL primary, FraiseQL is **immediately consistent**: a
+committed write is visible to the very next read.
 
-```python
-<!-- Code example in Python -->
-# This is NOT eventually consistent:
-mutation { updateUser(id: 1, name: "Alice") }
-query { user(id: 1) { name } }  # Sees "Alice" immediately
+```graphql
+mutation { updateUser(input: { id: "...", name: "Alice" }) { ... } }
+query { user(id: "...") { name } }  # Sees "Alice" immediately
+```
 
-# FraiseQL always returns immediately-consistent results
-```text
-<!-- Code example in TEXT -->
-
-**If you need eventual consistency:** Use event-driven architecture with subscriptions + external systems.
-
----
-
-## 10. Consistency Levels by Operation
-
-| Operation | Consistency | Isolation | Write Atomicity | Read Freshness |
-|-----------|-------------|-----------|-----------------|-----------------|
-| **Query** | Serializable | Serializable | N/A | Immediate |
-| **Mutation** | Serializable | Serializable | Atomic | Immediate |
-| **Subscription** | Per-entity ordered | Serializable | N/A | At-least-once |
-| **Federated Query** | Causal | Serializable per DB | N/A | Causal |
-| **Federated Mutation** | Causal | Serializable per DB | Per-DB atomic | Causal |
-| **Cached Query** | Within TTL | Serializable | N/A | Max TTL stale |
+If you need eventual consistency for a particular workload (for example fan-out to
+external systems or read offloading to replicas), build it explicitly with
+subscriptions plus downstream services, or with a replica deployment as described
+in section 3.4. FraiseQL itself does not silently relax consistency.
 
 ---
 
-## 11. Consistency Configuration
+## 9. Consistency Levels by Operation
 
-### 11.1 Per-Query Consistency Control
-
-```python
-<!-- Code example in Python -->
-query @consistency(level: "serializable") {
-  user(id: 1) { name }
-}
-
-# Levels:
-# - "serializable" (default): Strongest consistency
-# - "causal" (federation): Weaker but faster
-# - "eventual" (future): Weakest but fastest
-```text
-<!-- Code example in TEXT -->
-
-### 11.2 Per-Mutation Consistency Control
-
-```python
-<!-- Code example in Python -->
-mutation @consistency(level: "serializable", timeout: 30000) {
-  updateUser(id: 1, name: "Bob") { name }
-}
-
-# Options:
-# - timeout: Max time to wait for lock (ms)
-# - retry: Auto-retry on conflict (true/false)
-```text
-<!-- Code example in TEXT -->
+| Operation | Consistency (single primary) | Isolation | Write Atomicity | Read Freshness |
+|-----------|------------------------------|-----------|-----------------|----------------|
+| **Query** | Strong | PostgreSQL level | N/A | Immediate |
+| **Mutation** | Strong | PostgreSQL level | Atomic (per `fn_`) | Immediate |
+| **Subscription** | Per-entity ordered | PostgreSQL level | N/A | At-least-once |
+| **Cached Query** | Within TTL | PostgreSQL level | N/A | At most TTL stale |
+| **Replica Read** | Eventual (replica lag) | PostgreSQL level | N/A | Lag-bounded |
 
 ---
 
-## 12. Consistency Guarantees by Database
+## 10. Consistency Anti-Patterns
 
-### 12.1 PostgreSQL
+### 10.1 Assuming Stale Reads Against the Primary
 
-**Consistency Level:** Serializable ACID
-**Mechanism:** Serializable Snapshot Isolation (SSI)
-**Guarantee:**
-
-```text
-<!-- Code example in TEXT -->
-✅ Serializable isolation
-✅ MVCC (Multi-Version Concurrency Control)
-✅ Write-ahead logging (durability)
-✅ Atomic transactions
-```text
-<!-- Code example in TEXT -->
-
-### 12.2 MySQL (InnoDB)
-
-**Consistency Level:** Repeatable Read (default) → Serializable (FraiseQL default)
-**Mechanism:** MVCC + Gap locks
-**Guarantee:**
-
-```text
-<!-- Code example in TEXT -->
-✅ Serializable isolation (with locks)
-✅ MVCC
-✅ Binary logging (durability)
-✅ Atomic transactions
-```text
-<!-- Code example in TEXT -->
-
-### 12.3 SQL Server
-
-**Consistency Level:** Serializable ACID
-**Mechanism:** Snapshot isolation + row versioning
-**Guarantee:**
-
-```text
-<!-- Code example in TEXT -->
-✅ Serializable isolation
-✅ Snapshot isolation available
-✅ Write-ahead logging (durability)
-✅ Atomic transactions
-```text
-<!-- Code example in TEXT -->
-
-### 12.4 SQLite
-
-**Consistency Level:** Serializable ACID
-**Mechanism:** Write-ahead logging + locking
-**Guarantee:**
-
-```text
-<!-- Code example in TEXT -->
-⚠️ Limited MVCC (single file)
-✅ Atomic transactions
-✅ Durability
-❌ Limited concurrency (file-level locking)
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 13. Consistency Anti-Patterns
-
-### 13.1 Assuming Eventual Consistency
-
-**❌ WRONG:**
+**Wrong:**
 
 ```python
-<!-- Code example in Python -->
-# This is NOT eventually consistent!
-mutation { updateUser(id: 1, name: "Alice") }
-time.sleep(1)
-result = query { user(id: 1) { name } }
-# Assuming result might be stale
+# This is NOT necessary against a single primary.
+mutation { updateUser(input: { id: "...", name: "Alice" }) { ... } }
+time.sleep(1)  # waiting for "propagation"
+result = query { user(id: "...") { name } }
+```
 
-# Result: Always sees "Alice" immediately
-```text
-<!-- Code example in TEXT -->
-
-**✅ RIGHT:**
+**Right:**
 
 ```python
-<!-- Code example in Python -->
-mutation { updateUser(id: 1, name: "Alice") }
-# Result: Always consistent immediately, no need to wait
-result = query { user(id: 1) { name } }  # Sees "Alice"
-```text
-<!-- Code example in TEXT -->
+mutation { updateUser(input: { id: "...", name: "Alice" }) { ... } }
+result = query { user(id: "...") { name } }  # Sees "Alice" immediately
+```
 
-### 13.2 Assuming Cross-Database Transactions
+### 10.2 Assuming Global Event Ordering
 
-**❌ WRONG:**
+**Wrong:**
 
-```python
-<!-- Code example in Python -->
-mutation {
-  createUser(name: "Alice") { id }  # Database 1
-  createOrder(user_id: NEW_ID) { id }  # Database 2
-}
-
-# Assuming both succeed or both fail
-# Actually: May partially succeed
-```text
-<!-- Code example in TEXT -->
-
-**✅ RIGHT:**
-
-```python
-<!-- Code example in Python -->
-# Handle failure manually
-try {
-  user = mutation { createUser(name: "Alice") { id } }
-  order = mutation { createOrder(user_id: user.id) { id } }
-} catch error {
-  # May have created user but not order
-  # Client should rollback/compensate
-}
-```text
-<!-- Code example in TEXT -->
-
-### 13.3 Assuming Global Event Ordering
-
-**❌ WRONG:**
-
-```python
-<!-- Code example in Python -->
+```graphql
 subscription {
-  orderUpdated { id, status }
-  userUpdated { name }
+  orderUpdated { id status }
+  userUpdated { id name }
 }
+# Assuming events arrive in global timestamp order.
+```
 
-# Assuming events are globally ordered by timestamp
-# Actually: Only per-entity ordered
-```text
-<!-- Code example in TEXT -->
+**Right:**
 
-**✅ RIGHT:**
+```graphql
+subscription { orderUpdated { id status timestamp } }
+```
 
 ```python
-<!-- Code example in Python -->
-subscription {
-  orderUpdated { id, status, timestamp }
-}
-
-# Use timestamp to order events in client
+# Order events on the client using their timestamps.
 events.sort(key=lambda e: e["timestamp"])
-```text
-<!-- Code example in TEXT -->
+```
 
----
+### 10.3 Expecting FraiseQL to Route to Replicas
 
-## 14. Consistency SLA (Service Level Agreement)
+**Wrong:** Assuming FraiseQL load-balances reads across replicas or fails over
+automatically.
 
-| Metric | Target | Measured |
-|--------|--------|----------|
-| **Serializable consistency** | 99.99% | All mutations |
-| **Read-after-write latency** | <10ms | p99 |
-| **ACID durability** | 100% | Confirmed mutations |
-| **Causal consistency (federation)** | 99.9% | Federated queries |
-| **Cache coherence** | 99.99% | Cross-server caches |
+**Right:** FraiseQL connects to one `database_url`. Read/write splitting,
+failover, and replica routing belong to your PostgreSQL deployment or a connection
+proxy in front of it.
 
 ---
 
 ## Summary
 
-**FraiseQL consistency model:**
+FraiseQL v1 consistency model:
 
-✅ **Single database:** Serializable ACID (strict)
-✅ **Federated:** Causal consistency (weaker but scalable)
-✅ **Subscriptions:** Per-entity ordered (eventual delivery)
-✅ **Caching:** Strong cache coherence
-✅ **Durability:** Write-ahead logging
-✅ **Atomicity:** All-or-nothing mutations
+- **Single PostgreSQL primary:** strong, immediately consistent reads after
+  committed writes.
+- **Isolation:** whatever PostgreSQL is configured to enforce (Read Committed by
+  default, Serializable available).
+- **Mutations:** atomic per `fn_` function; all-or-nothing.
+- **Durability:** PostgreSQL write-ahead logging.
+- **Subscriptions:** per-entity ordered, at-least-once delivery.
+- **Caching:** invalidated on write, otherwise bounded by TTL.
+- **Replicas/failover:** a PostgreSQL deployment concern, not a FraiseQL feature.
 
-**Golden rule:** What the database guarantees, FraiseQL guarantees. Nothing more, nothing less.
+**Golden rule:** What PostgreSQL guarantees, FraiseQL guarantees. Nothing more,
+nothing less.
 
 ---
 
-*End of Consistency Model*
+## Related Documents
+
+- [Error Handling Model](./error-handling-model.md)
+- [Failure Modes and Recovery](./failure-modes-and-recovery.md)
+- [Versioning Strategy](./versioning-strategy.md)
+- [Subscriptions](../realtime/subscriptions.md)
+- [View Selection Guide](../database/view-selection-guide.md)
+- [Performance Characteristics](../../foundation/12-performance-characteristics.md)
+- [Schema Conventions](../../specs/schema-conventions.md)
+</content>
+</invoke>

--- a/docs/architecture/reliability/error-handling-model.md
+++ b/docs/architecture/reliability/error-handling-model.md
@@ -1,9 +1,7 @@
-<!-- Skip to main content -->
 ---
-
 title: Error Handling Model
-description: FraiseQL's error handling model is **deterministic, predictable, and classifiable**. Unlike traditional GraphQL servers where error handling varies by resolver
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+description: FraiseQL's error handling model is deterministic, predictable, and classifiable. Unlike traditional GraphQL servers where error handling varies by resolver, FraiseQL has a unified, classifiable error model.
+keywords: ["design", "errors", "reliability", "patterns", "security"]
 tags: ["documentation", "reference"]
 ---
 
@@ -11,16 +9,17 @@ tags: ["documentation", "reference"]
 
 **Version:** 1.0
 **Status:** Complete
-**Date:** January 11, 2026
 **Audience:** All developers, integrators, operations engineers, architecture reviewers
 
 ---
 
 ## 1. Overview
 
-FraiseQL's error handling model is **deterministic, predictable, and classifiable**. Unlike traditional GraphQL servers where error handling varies by resolver implementation, FraiseQL has a unified, specification-driven error model.
+FraiseQL's error handling model is **deterministic, predictable, and classifiable**. Unlike traditional GraphQL servers where error handling varies by resolver implementation, FraiseQL has a unified, classifiable error model.
 
-**Core principle:** All errors are either **preventable** (caught at compile time) or **recoverable** (clear classification at runtime).
+FraiseQL v1 is a Python runtime framework: you define types, queries, and mutations with decorators, and the GraphQL schema is **built in memory at application startup** and served over FastAPI. There is no compile step and no build artifact. Errors fall into two broad phases:
+
+**Core principle:** All errors are either **preventable** (caught when the schema is validated at app startup) or **recoverable** (clearly classified at runtime).
 
 ### 1.1 Design Philosophy
 
@@ -28,7 +27,7 @@ FraiseQL's error handling model is **deterministic, predictable, and classifiabl
 
 **Classifiable.** Every error falls into a well-defined category with clear semantics.
 
-**Remediable.** Every error either tells you exactly how to fix it (compile-time) or how to recover from it (runtime).
+**Remediable.** Every error either tells you exactly how to fix it (schema-validation errors) or how to recover from it (runtime errors).
 
 **Auditable.** Error context includes enough information for debugging without leaking sensitive data.
 
@@ -36,55 +35,52 @@ FraiseQL's error handling model is **deterministic, predictable, and classifiabl
 
 ## 2. Error Categories
 
-### 2.1 Compile-Time Errors (Schema Definition Phase)
+### 2.1 Schema-Validation Errors (App Startup)
 
-**When:** During schema authoring and compilation
-**Who sees them:** Schema authors, build systems
-**Recovery:** Fix schema, recompile
-**Visibility:** Never reaches clients
+**When:** While the schema is being assembled and validated at application startup
+**Who sees them:** Schema authors, operators starting the app
+**Recovery:** Fix the Python type/query/mutation definitions or the database, then restart
+**Visibility:** Never reaches clients — the app fails to start
+
+FraiseQL validates the in-memory schema as `build_fraiseql_schema(...)` / `create_fraiseql_app(...)` runs. If a type is missing, a view does not exist, or a column does not match, startup fails with a clear message. No partially valid schema is ever served.
 
 #### 2.1.1 Schema Validation Errors
 
 ```text
-<!-- Code example in TEXT -->
 Category: SCHEMA_INVALID
 Code: E_SCHEMA_<subtype>_<number>
 
 Examples:
   E_SCHEMA_TYPE_NOT_DEFINED_001
   E_SCHEMA_FIELD_NOT_FOUND_002
-  E_SCHEMA_BINDING_MISSING_003
+  E_SCHEMA_SOURCE_MISSING_003
   E_SCHEMA_OPERATOR_UNSUPPORTED_004
   E_SCHEMA_AUTHORIZATION_INVALID_005
-```text
-<!-- Code example in TEXT -->
+```
 
 **Causes:**
 
-- Type referenced but not declared
-- Field referenced but not in database view
-- Query/mutation without binding
-- WHERE operator not supported by target database
-- Authorization rule references non-existent auth context field
+- Type referenced but not declared with `@fraiseql.type`
+- Field referenced but not present in the backing database view
+- Query/mutation without an `sql_source`
+- WHERE operator not supported by PostgreSQL
+- Authorization rule references a non-existent auth context field
 
 **Example:**
 
 ```text
-<!-- Code example in TEXT -->
-Error: Schema compilation failed
+Error: Schema validation failed at startup
   Type: Type closure violation
   Code: E_SCHEMA_TYPE_NOT_DEFINED_001
   Query 'users' returns 'list[User]'
   Type 'User' is not defined
-  Suggestion: Add @FraiseQL.type class User or check spelling
+  Suggestion: Add @fraiseql.type class User or check spelling
   File: schema.py, line 42
-```text
-<!-- Code example in TEXT -->
+```
 
 #### 2.1.2 Database Binding Errors
 
 ```text
-<!-- Code example in TEXT -->
 Category: BINDING_INVALID
 Code: E_BINDING_<subtype>_<number>
 
@@ -92,68 +88,59 @@ Examples:
   E_BINDING_VIEW_NOT_FOUND_010
   E_BINDING_COLUMN_NOT_FOUND_011
   E_BINDING_TYPE_MISMATCH_012
-  E_BINDING_PROCEDURE_SIGNATURE_MISMATCH_013
-```text
-<!-- Code example in TEXT -->
+  E_BINDING_FUNCTION_SIGNATURE_MISMATCH_013
+```
 
 **Causes:**
 
-- Binding references view that doesn't exist in database
-- Field maps to column that doesn't exist
-- Field type doesn't match database column type
-- Mutation input doesn't match stored procedure parameters
+- A type's `sql_source` references a view (`v_`/`tv_`) that does not exist in the database
+- Field maps to a column that does not exist in the view's `data` JSONB
+- Field type does not match the database column type
+- A mutation calls a PostgreSQL `fn_` function whose signature does not match the input
 
 **Example:**
 
 ```text
-<!-- Code example in TEXT -->
-Error: Database binding failed
+Error: Database binding failed at startup
   Type: View not found
   Code: E_BINDING_VIEW_NOT_FOUND_010
   Query 'users' bound to view 'v_user_missing'
   Database: postgresql (localhost:5432/mydb)
-  Suggestion: Create view v_user or fix binding to existing view
+  Suggestion: Create view v_user or fix sql_source to an existing view
   Available views: v_user, v_user_archived, v_user_deleted
-```text
-<!-- Code example in TEXT -->
+```
 
 #### 2.1.3 Capability Errors
 
 ```text
-<!-- Code example in TEXT -->
 Category: DATABASE_CAPABILITY_UNSUPPORTED
-Code: E_CAPABILITY_<database>_<operator>
+Code: E_CAPABILITY_<operator>_<number>
 
 Examples:
-  E_CAPABILITY_SQLITE_REGEX_001
-  E_CAPABILITY_MYSQL_COSINE_DISTANCE_002
-  E_CAPABILITY_SQLSERVER_JSONB_CONTAINS_003
-```text
-<!-- Code example in TEXT -->
+  E_CAPABILITY_VECTOR_DISTANCE_001
+  E_CAPABILITY_TRIGRAM_SIMILARITY_002
+  E_CAPABILITY_GEOSPATIAL_CONTAINS_003
+```
 
 **Causes:**
 
-- Schema uses operator not supported by target database
-- Database lacks required extension (pgvector, PostGIS)
+- Schema uses an operator that requires a PostgreSQL extension that is not installed
+- Database lacks a required extension (`pgvector`, `pg_trgm`, PostGIS)
 
 **Example:**
 
 ```text
-<!-- Code example in TEXT -->
-Error: Operator not supported by database
+Error: Operator requires a missing PostgreSQL extension
   Type: Database capability mismatch
-  Code: E_CAPABILITY_SQLITE_REGEX_001
-  Operator: _regex (regular expression matching)
-  Target database: sqlite
-  Field: User.email
-  Suggestion: Use _like operator instead, or target postgresql
-```text
-<!-- Code example in TEXT -->
+  Code: E_CAPABILITY_VECTOR_DISTANCE_001
+  Operator: _cosine_distance (vector similarity)
+  Field: Document.embedding
+  Suggestion: Install the pgvector extension (CREATE EXTENSION vector), or use a supported operator
+```
 
 #### 2.1.4 Authorization Configuration Errors
 
 ```text
-<!-- Code example in TEXT -->
 Category: AUTHORIZATION_INVALID
 Code: E_AUTH_<subtype>_<number>
 
@@ -161,14 +148,15 @@ Examples:
   E_AUTH_CONTEXT_FIELD_NOT_FOUND_020
   E_AUTH_ROLE_UNDEFINED_021
   E_AUTH_RULE_CIRCULAR_DEPENDENCY_022
-```text
-<!-- Code example in TEXT -->
+```
 
 **Causes:**
 
-- Authorization rule references non-existent auth context field
-- Authorization rule references undefined role
+- Authorization rule references a non-existent auth context field
+- Authorization rule references an undefined role
 - Authorization rules have circular dependencies
+
+See [`../../foundation/10-error-handling-validation.md`](../../foundation/10-error-handling-validation.md) for how validation and authorization are wired into the schema, and [`../../specs/schema-conventions.md`](../../specs/schema-conventions.md) for the database naming conventions (`tb_`, `v_`, `tv_`, `fn_`) referenced above.
 
 ---
 
@@ -177,12 +165,11 @@ Examples:
 **When:** During runtime query execution
 **Who sees them:** Client applications
 **Recovery:** Application-specific (retry, notify user, log, etc.)
-**Visibility:** Always returned in GraphQL error list
+**Visibility:** Always returned in the GraphQL error list
 
 #### 2.2.1 Validation Errors
 
 ```text
-<!-- Code example in TEXT -->
 GraphQL error
 Category: VALIDATION_FAILED
 Code: E_VALIDATION_<subtype>
@@ -202,8 +189,7 @@ Structure:
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 **Error Types:**
 
@@ -220,7 +206,6 @@ Structure:
 **Example:**
 
 ```json
-<!-- Code example in JSON -->
 {
   "errors": [{
     "message": "Field 'invalid_field' not found on type 'User'",
@@ -236,20 +221,17 @@ Structure:
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 #### 2.2.2 Authorization Errors
 
 ```text
-<!-- Code example in TEXT -->
 GraphQL error
 Category: AUTHORIZATION_DENIED
 Code: E_AUTH_<subtype>
 
 Structure: Same as validation errors above
-```text
-<!-- Code example in TEXT -->
+```
 
 **Error Types:**
 
@@ -266,7 +248,6 @@ Structure: Same as validation errors above
 **Example:**
 
 ```json
-<!-- Code example in JSON -->
 {
   "errors": [{
     "message": "Insufficient permissions to query 'adminUsers'",
@@ -281,50 +262,49 @@ Structure: Same as validation errors above
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 #### 2.2.3 Database Execution Errors
 
 ```text
-<!-- Code example in TEXT -->
 GraphQL error
 Category: DATABASE_ERROR
-Code: E_DB_<database>_<error_class>
+Code: E_DB_<error_class>_<number>
 
 Structure: Same as others
-```text
-<!-- Code example in TEXT -->
+```
+
+These surface when a query reads a `v_`/`tv_` view, or when a mutation calls a PostgreSQL `fn_` function. PostgreSQL reports failures via SQLSTATE codes; FraiseQL maps them onto the codes below and includes the underlying `SQLSTATE <code>` note in the extensions when available.
 
 **Error Types:**
 
-| Subtype | Code | Cause | Retryable | Example |
-|---------|------|-------|-----------|---------|
-| CONNECTION_FAILED | E_DB_POSTGRES_CONNECTION_FAILED_300 | Cannot connect to database | **Yes** | Connection timeout, network down |
-| CONNECTION_POOL_EXHAUSTED | E_DB_MYSQL_POOL_EXHAUSTED_301 | No available connections | **Yes** | All connections in use, retry later |
-| QUERY_TIMEOUT | E_DB_SQLSERVER_QUERY_TIMEOUT_302 | Query execution exceeded timeout | **Yes** | Long-running query, retry or optimize |
-| DEADLOCK | E_DB_POSTGRES_DEADLOCK_303 | Transaction deadlock detected | **Yes** | Concurrent transaction conflict |
-| CONSTRAINT_VIOLATION | E_DB_MYSQL_CONSTRAINT_VIOLATION_304 | Unique/foreign key constraint violated | No | Duplicate key, referential integrity |
-| SYNTAX_ERROR | E_DB_SQLITE_SYNTAX_ERROR_305 | Generated SQL is malformed | No | Compiler bug or unsupported operation |
-| PERMISSION_DENIED | E_DB_POSTGRES_PERMISSION_DENIED_306 | Database user lacks permission | No | Misconfigured database credentials |
-| OUT_OF_MEMORY | E_DB_SQLSERVER_OUT_OF_MEMORY_307 | Database ran out of memory | **Yes** | Query too large, reduce batch size |
-| DISK_FULL | E_DB_MYSQL_DISK_FULL_308 | Database disk full | **Yes** | Free up disk space |
-| UNKNOWN | E_DB_UNKNOWN_ERROR_309 | Unclassified database error | **Yes** | See error details |
+| Subtype | Code | SQLSTATE | Cause | Retryable | Example |
+|---------|------|----------|-------|-----------|---------|
+| CONNECTION_FAILED | E_DB_CONNECTION_FAILED_300 | 08006 | Cannot connect to database | **Yes** | Connection timeout, network down |
+| CONNECTION_POOL_EXHAUSTED | E_DB_POOL_EXHAUSTED_301 | — | No available connections | **Yes** | All connections in use, retry later |
+| QUERY_TIMEOUT | E_DB_QUERY_TIMEOUT_302 | 57014 | Statement exceeded `statement_timeout` | **Yes** | Long-running query, retry or optimize |
+| DEADLOCK | E_DB_DEADLOCK_303 | 40P01 | Transaction deadlock detected | **Yes** | Concurrent transaction conflict |
+| CONSTRAINT_VIOLATION | E_DB_CONSTRAINT_VIOLATION_304 | 23505 / 23503 | Unique/foreign key constraint violated | No | Duplicate key, referential integrity |
+| SERIALIZATION_FAILURE | E_DB_SERIALIZATION_FAILURE_305 | 40001 | Could not serialize concurrent transactions | **Yes** | Retry the transaction |
+| PERMISSION_DENIED | E_DB_PERMISSION_DENIED_306 | 42501 | Database role lacks permission | No | Misconfigured database credentials |
+| OUT_OF_MEMORY | E_DB_OUT_OF_MEMORY_307 | 53200 | Database ran out of memory | **Yes** | Query too large, reduce batch size |
+| DISK_FULL | E_DB_DISK_FULL_308 | 53100 | Database disk full | **Yes** | Free up disk space |
+| UNKNOWN | E_DB_UNKNOWN_ERROR_309 | — | Unclassified database error | **Yes** | See error details |
 
 **Example (Retryable):**
 
 ```json
-<!-- Code example in JSON -->
 {
   "errors": [{
     "message": "Database connection timeout after 5s",
     "extensions": {
-      "code": "E_DB_POSTGRES_CONNECTION_FAILED_300",
+      "code": "E_DB_CONNECTION_FAILED_300",
       "category": "DATABASE_ERROR",
       "remediable": false,
       "retryable": true,
       "retry_after_ms": 1000,
       "database": "postgresql",
+      "sqlstate": "08006",
       "host": "db.example.com",
       "port": 5432,
       "attempt": 1,
@@ -332,22 +312,21 @@ Structure: Same as others
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 **Example (Non-Retryable):**
 
 ```json
-<!-- Code example in JSON -->
 {
   "errors": [{
     "message": "Unique constraint violation on users.email",
     "extensions": {
-      "code": "E_DB_MYSQL_CONSTRAINT_VIOLATION_304",
+      "code": "E_DB_CONSTRAINT_VIOLATION_304",
       "category": "DATABASE_ERROR",
       "remediable": true,
       "retryable": false,
       "user_actionable": true,
+      "sqlstate": "23505",
       "constraint": "unique_email",
       "table": "users",
       "field": "email",
@@ -356,26 +335,25 @@ Structure: Same as others
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
+
+A mutation's `fn_` function can also signal a domain failure in its returned JSONB (for example, `{"success": false, "message": "...", "code": "VALIDATION_ERROR"}`). The resolver translates that into a typed `@fraiseql.error` result, which is then surfaced in the GraphQL response. This is distinct from a raw PostgreSQL execution error: a domain failure is an expected, recoverable outcome, while a SQLSTATE error indicates the statement itself could not run.
 
 #### 2.2.4 Execution Logic Errors
 
 ```text
-<!-- Code example in TEXT -->
 GraphQL error
 Category: EXECUTION_ERROR
 Code: E_EXEC_<subtype>
 
 Structure: Same as others
-```text
-<!-- Code example in TEXT -->
+```
 
 **Error Types:**
 
 | Subtype | Code | Cause | Retryable | Example |
 |---------|------|-------|-----------|---------|
-| FIELD_NOT_FOUND | E_EXEC_FIELD_NOT_FOUND_400 | Field doesn't exist in result | No | Compiler bug |
+| FIELD_NOT_FOUND | E_EXEC_FIELD_NOT_FOUND_400 | Field absent from the view's `data` JSONB | No | View out of sync with schema |
 | PROJECTION_FAILED | E_EXEC_PROJECTION_FAILED_401 | Cannot project field from data | No | Type mismatch |
 | AGGREGATION_FAILED | E_EXEC_AGGREGATION_FAILED_402 | Cannot aggregate result | No | Type mismatch in aggregation |
 | PAGINATION_INVALID | E_EXEC_PAGINATION_INVALID_403 | Invalid pagination parameters | No | Invalid cursor or offset |
@@ -385,7 +363,6 @@ Structure: Same as others
 **Example:**
 
 ```json
-<!-- Code example in JSON -->
 {
   "errors": [{
     "message": "Query result would exceed maximum size of 100MB",
@@ -401,65 +378,17 @@ Structure: Same as others
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-#### 2.2.5 Federation Errors
-
-```text
-<!-- Code example in TEXT -->
-GraphQL error
-Category: FEDERATION_ERROR
-Code: E_FED_<subtype>
-
-Structure: Same as others
-```text
-<!-- Code example in TEXT -->
-
-**Error Types:**
-
-| Subtype | Code | Cause | Retryable | Example |
-|---------|------|-------|-----------|---------|
-| ENTITY_RESOLUTION_FAILED | E_FED_ENTITY_RESOLUTION_FAILED_500 | Cannot resolve federated entity | **Yes** | Subgraph unavailable |
-| ENTITY_NOT_FOUND | E_FED_ENTITY_NOT_FOUND_501 | Federated entity doesn't exist | No | Entity ID invalid or deleted |
-| SUBGRAPH_UNAVAILABLE | E_FED_SUBGRAPH_UNAVAILABLE_502 | Federation subgraph unreachable | **Yes** | Network/DNS issue |
-| SUBGRAPH_TIMEOUT | E_FED_SUBGRAPH_TIMEOUT_503 | Subgraph response too slow | **Yes** | Slow subgraph, retry |
-| ENTITY_TYPE_MISMATCH | E_FED_TYPE_MISMATCH_504 | Entity has unexpected type | No | Schema mismatch |
-
-**Example:**
-
-```json
-<!-- Code example in JSON -->
-{
-  "errors": [{
-    "message": "Federation subgraph 'orders' unreachable",
-    "extensions": {
-      "code": "E_FED_SUBGRAPH_UNAVAILABLE_502",
-      "category": "FEDERATION_ERROR",
-      "remediable": false,
-      "retryable": true,
-      "retry_after_ms": 2000,
-      "subgraph": "orders",
-      "subgraph_url": "https://orders.internal/graphql",
-      "attempt": 1,
-      "max_attempts": 3
-    }
-  }]
-}
-```text
-<!-- Code example in TEXT -->
-
-#### 2.2.6 Subscription/Event Errors
+#### 2.2.5 Subscription/Event Errors
 
 ```text
-<!-- Code example in TEXT -->
 GraphQL error
 Category: SUBSCRIPTION_ERROR
 Code: E_SUB_<subtype>
 
 Structure: Same as others (sent to client over WebSocket)
-```text
-<!-- Code example in TEXT -->
+```
 
 **Error Types:**
 
@@ -475,7 +404,6 @@ Structure: Same as others (sent to client over WebSocket)
 **Example:**
 
 ```json
-<!-- Code example in JSON -->
 {
   "type": "error",
   "id": "1",
@@ -494,51 +422,45 @@ Structure: Same as others (sent to client over WebSocket)
     }]
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-#### 2.2.7 Internal Errors
+#### 2.2.6 Internal Errors
 
 ```text
-<!-- Code example in TEXT -->
 GraphQL error
 Category: INTERNAL_ERROR
 Code: E_INTERNAL_<subtype>
 
 Structure: Same as others
-```text
-<!-- Code example in TEXT -->
+```
 
 **Error Types:**
 
 | Subtype | Code | Cause | Retryable | Example |
 |---------|------|-------|-----------|---------|
-| COMPILED_SCHEMA_INVALID | E_INTERNAL_SCHEMA_INVALID_700 | Compiled schema corrupted or invalid | No | Deployment/upgrade bug |
-| RUNTIME_PANIC | E_INTERNAL_PANIC_701 | Runtime encountered unexpected condition | No | Compiler/runtime bug |
-| CACHE_CORRUPTED | E_INTERNAL_CACHE_CORRUPTED_702 | Cache backend returned invalid data | **Yes** | Cache corruption, retry |
-| UNKNOWN_ERROR | E_INTERNAL_UNKNOWN_ERROR_703 | Unclassified internal error | **Yes** | Unknown issue, retry |
+| RESOLVER_FAILED | E_INTERNAL_RESOLVER_FAILED_700 | A resolver raised an unexpected exception | No | Bug in resolver code |
+| CACHE_CORRUPTED | E_INTERNAL_CACHE_CORRUPTED_701 | Cache backend returned invalid data | **Yes** | Cache corruption, retry |
+| UNKNOWN_ERROR | E_INTERNAL_UNKNOWN_ERROR_702 | Unclassified internal error | **Yes** | Unknown issue, retry |
 
 **Example:**
 
 ```json
-<!-- Code example in JSON -->
 {
   "errors": [{
-    "message": "Internal server error: unexpected panic",
+    "message": "Internal server error",
     "extensions": {
-      "code": "E_INTERNAL_PANIC_701",
+      "code": "E_INTERNAL_RESOLVER_FAILED_700",
       "category": "INTERNAL_ERROR",
       "remediable": false,
       "retryable": false,
       "timestamp": "2026-01-11T15:35:00Z",
       "trace_id": "req_550e8400",
       "stack_trace": "Available only in debug mode",
-      "support_link": "https://github.com/FraiseQL/FraiseQL/issues"
+      "support_link": "https://github.com/fraiseql/fraiseql/issues"
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -549,7 +471,6 @@ Structure: Same as others
 All runtime errors follow the GraphQL spec with FraiseQL extensions:
 
 ```json
-<!-- Code example in JSON -->
 {
   "errors": [
     {
@@ -566,8 +487,6 @@ All runtime errors follow the GraphQL spec with FraiseQL extensions:
         "user_actionable": true,
         "timestamp": "2026-01-11T15:35:00Z",
         "trace_id": "req_550e8400",
-
-        // Context-specific fields (optional)
         "suggestion": "Did you mean field 'email'?",
         "available_options": ["id", "name", "email"],
         "retry_after_ms": null,
@@ -578,8 +497,9 @@ All runtime errors follow the GraphQL spec with FraiseQL extensions:
   ],
   "data": null
 }
-```text
-<!-- Code example in TEXT -->
+```
+
+The fields under `extensions` after `trace_id` are context-specific and optional; they appear only when relevant to the error.
 
 ### 3.2 Error Context Fields
 
@@ -593,16 +513,16 @@ All runtime errors follow the GraphQL spec with FraiseQL extensions:
 
 **Conditional fields:**
 
-- `remediable` — Can client fix this? (schema/query fixes)
-- `retryable` — Should client retry? (transient errors)
-- `user_actionable` — Should client show to user? (not security details)
+- `remediable` — Can the client fix this? (schema/query fixes)
+- `retryable` — Should the client retry? (transient errors)
+- `user_actionable` — Should the client show this to a user? (not security details)
 - `suggestion` — How to fix it
 - `retry_after_ms` — Milliseconds to wait before retry
 
 **Context-specific:**
 
-- `database` — Which database (E_DB_* errors)
-- `constraint` — Which constraint violated (database errors)
+- `sqlstate` — The PostgreSQL SQLSTATE code (`E_DB_*` errors)
+- `constraint` — Which constraint was violated (database errors)
 - `field` — Which field caused the error
 - `available_options` — Valid choices for this field
 
@@ -610,7 +530,7 @@ All runtime errors follow the GraphQL spec with FraiseQL extensions:
 
 **Never expose:**
 
-- SQL queries (even if query is client-safe)
+- SQL queries (even if the query is client-safe)
 - Internal file paths
 - Stack traces (unless debug mode)
 - Database credentials
@@ -619,10 +539,10 @@ All runtime errors follow the GraphQL spec with FraiseQL extensions:
 
 **Safe to expose:**
 
-- Field names (part of schema)
+- Field names (part of the schema)
 - Constraint names (helps debugging)
 - Error codes (for client classification)
-- Database type (postgresql, mysql, etc.)
+- SQLSTATE codes (standard PostgreSQL classification)
 - Operation type (query, mutation, subscription)
 
 ---
@@ -631,7 +551,7 @@ All runtime errors follow the GraphQL spec with FraiseQL extensions:
 
 ### 4.1 Remediable vs Non-Remediable
 
-**Remediable:** Error indicates client code/schema is wrong. Client can fix it.
+**Remediable:** The error indicates client code or schema is wrong. The client can fix it.
 
 Examples:
 
@@ -640,7 +560,7 @@ Examples:
 - Constraint violation
 - Deprecated field usage
 
-**Non-Remediable:** Error indicates system state issue. Client cannot fix it.
+**Non-Remediable:** The error indicates a system state issue. The client cannot fix it.
 
 Examples:
 
@@ -651,17 +571,17 @@ Examples:
 
 ### 4.2 Retryable vs Non-Retryable
 
-**Retryable:** Error is transient. Retrying may succeed.
+**Retryable:** The error is transient. Retrying may succeed.
 
 Examples:
 
 - Database connection timeout
 - Connection pool exhausted
-- Query timeout (retry with better query)
-- Subgraph unavailable
+- Query timeout (retry with a better query)
+- Serialization failure (SQLSTATE 40001)
 - Event buffer overflow
 
-**Non-Retryable:** Error is deterministic. Retrying will fail identically.
+**Non-Retryable:** The error is deterministic. Retrying will fail identically.
 
 Examples:
 
@@ -672,7 +592,7 @@ Examples:
 
 ### 4.3 User-Actionable vs Hidden
 
-**User-Actionable:** Error message safe to show end-users.
+**User-Actionable:** The error message is safe to show end users.
 
 Examples:
 
@@ -680,13 +600,13 @@ Examples:
 - "You don't have permission to access this"
 - "Invalid input format"
 
-**Hidden:** Error message for developers only, not end-users.
+**Hidden:** The error message is for developers only, not end users.
 
 Examples:
 
-- "Database connection lost" (not user's problem)
+- "Database connection lost" (not the user's problem)
 - "Query timeout after 30s" (implementation detail)
-- "Insufficient permissions" (doesn't explain why)
+- "Insufficient permissions" (does not explain why)
 
 ---
 
@@ -697,7 +617,6 @@ Examples:
 When an error occurs during query execution, FraiseQL follows this strategy:
 
 ```text
-<!-- Code example in TEXT -->
 Query: { user { id name } posts { id title } }
 
 Execution:
@@ -715,28 +634,26 @@ Result:
     "user": {
       "id": "123",
       "name": "Alice",
-      "posts": null  // Field set to null due to error
+      "posts": null
     }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Rule:** Field with error is set to `null` in partial response. Parent queries continue executing. This allows clients to use partial data.
+**Rule:** The field with the error is set to `null` in the partial response. Parent queries continue executing. This allows clients to use partial data.
 
 ### 5.2 Mutation Error Propagation
 
-Mutations are **atomic**: if ANY part fails, the entire mutation fails with no partial data.
+Mutations are **atomic**: if any part fails, the entire mutation fails with no partial data. Each mutation runs inside a PostgreSQL transaction in its `fn_` function, so a failure rolls back every write.
 
 ```text
-<!-- Code example in TEXT -->
 Mutation: mutation {
-  createUser(name: "Bob", email: "bob@example.com") { id }
-  createPost(title: "Hello", userId: "123") { id }
+  createUser(input: {name: "Bob", email: "bob@example.com"}) { ... on CreateUserSuccess { user { id } } }
+  createPost(input: {title: "Hello", userId: "123"}) { ... on CreatePostSuccess { post { id } } }
 }
 
 Execution:
-  1. Create user (succeeds, userId = 999)
+  1. Create user (succeeds)
   2. Create post (fails with CONSTRAINT_VIOLATION - userId invalid)
 
 Result:
@@ -744,21 +661,19 @@ Result:
   "errors": [{
     "message": "Foreign key constraint violated: userId not found",
     "path": ["createPost"],
-    "extensions": { ... }
+    "extensions": { "code": "E_DB_CONSTRAINT_VIOLATION_304", "sqlstate": "23503", ... }
   }],
-  "data": null  // ENTIRE mutation fails, no partial data
+  "data": null
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Rule:** Mutations provide all-or-nothing semantics. If any part fails, all changes roll back (database transaction semantics).
+**Rule:** Mutations provide all-or-nothing semantics. If any part fails, all changes roll back via the database transaction.
 
 ### 5.3 Subscription Error Propagation
 
-Subscription errors are **per-event**. One event's error doesn't stop subscription.
+Subscription errors are **per-event**. One event's error does not stop the subscription.
 
 ```text
-<!-- Code example in TEXT -->
 Subscription: subscription {
   orderCreated { id amount }
 }
@@ -796,10 +711,11 @@ Event 3: Success (continues after error)
     }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Rule:** Subscription continues after error. One error event doesn't close subscription (unless close_code indicates connection close).
+**Rule:** A subscription continues after an error. One error event does not close the subscription (unless `close_code` indicates a connection close).
+
+For how these semantics interact with transactional guarantees, see [`./consistency-model.md`](./consistency-model.md). For recovery procedures when database or transport errors occur, see [`./failure-modes-and-recovery.md`](./failure-modes-and-recovery.md).
 
 ---
 
@@ -807,45 +723,44 @@ Event 3: Success (continues after error)
 
 ### 6.1 Recommended Client Error Handling
 
-**Step 1: Check for errors in response**
+**Step 1: Check for errors in the response**
 
 ```python
-<!-- Code example in Python -->
 response = await client.execute(query)
 if response.get("errors"):
     # Handle errors
-    pass
-```text
-<!-- Code example in TEXT -->
+    ...
+```
 
 **Step 2: Classify errors by category**
 
 ```python
-<!-- Code example in Python -->
 for error in response["errors"]:
     code = error["extensions"]["code"]
     category = error["extensions"]["category"]
 
     if category == "VALIDATION_FAILED":
         # Fix query and retry immediately
-        pass
+        ...
     elif category == "AUTHORIZATION_DENIED":
         # Request authentication, then retry
-        pass
+        ...
     elif category == "DATABASE_ERROR" and error["extensions"]["retryable"]:
         # Exponential backoff retry
-        pass
+        ...
     elif category == "INTERNAL_ERROR":
         # Log and notify support
-        pass
-```text
-<!-- Code example in TEXT -->
+        ...
+```
 
 **Step 3: Implement retry logic**
 
 ```python
-<!-- Code example in Python -->
-async def retry_query(query, max_attempts=3, backoff_base=1000):
+import asyncio
+
+
+async def retry_query(query: str, max_attempts: int = 3, backoff_base: int = 1000) -> dict:
+    response: dict = {}
     for attempt in range(1, max_attempts + 1):
         response = await client.execute(query)
 
@@ -863,13 +778,11 @@ async def retry_query(query, max_attempts=3, backoff_base=1000):
         if attempt < max_attempts:
             wait_ms = response["errors"][0]["extensions"].get(
                 "retry_after_ms",
-                backoff_base * (2 ** (attempt - 1))
+                backoff_base * (2 ** (attempt - 1)),
             )
             await asyncio.sleep(wait_ms / 1000)
-        else:
-            return response  # Max attempts reached
-```text
-<!-- Code example in TEXT -->
+    return response  # Max attempts reached
+```
 
 ### 6.2 Error Display to End-Users
 
@@ -878,7 +791,7 @@ async def retry_query(query, max_attempts=3, backoff_base=1000):
 - Validation errors with suggestions (query/input fixes)
 - Constraint violations ("Email already exists")
 - Authorization denials (general message, not details)
-- Timeouts (with retry option)
+- Timeouts (with a retry option)
 
 **Hide these errors from users:**
 
@@ -886,7 +799,7 @@ async def retry_query(query, max_attempts=3, backoff_base=1000):
 - Internal stack traces
 - SQL queries
 - Auth token issues
-- Internal server errors (show support contact instead)
+- Internal server errors (show a support contact instead)
 
 ---
 
@@ -897,7 +810,6 @@ async def retry_query(query, max_attempts=3, backoff_base=1000):
 Every error includes a `trace_id` for correlation:
 
 ```text
-<!-- Code example in TEXT -->
 Client sees:
 {
   "errors": [{
@@ -911,22 +823,20 @@ Client sees:
 Server logs:
 [2026-01-11 15:35:00] TRACE req_550e8400: query { users { id } }
 [2026-01-11 15:35:01] ERROR req_550e8400: connection timeout after 5s
-```text
-<!-- Code example in TEXT -->
+```
 
 **Use trace_id to:**
 
 - Correlate client-side errors with server logs
-- Track error through entire system (across services in federation)
+- Track an error through the system
 - Debug transient errors that are hard to reproduce
 
 ### 7.2 Debug Mode
 
-FraiseQL can enable debug mode to include additional error context:
+FraiseQL can run with debug mode enabled to include additional error context. Set `production=False` in `create_fraiseql_app(...)` or the `FRAISEQL_DEBUG` environment variable in development environments only:
 
 ```text
-<!-- Code example in TEXT -->
-# Enable debug mode (dev environments only!)
+# Enable debug mode (dev environments only)
 FRAISEQL_DEBUG=true
 
 Response with debug mode:
@@ -934,33 +844,32 @@ Response with debug mode:
   "errors": [{
     "message": "Query timeout",
     "extensions": {
-      "code": "E_DB_POSTGRES_QUERY_TIMEOUT_302",
-      "stack_trace": [
-        "FraiseQL::runtime::execute_query (src/runtime.rs:312)",
-        "FraiseQL::db::execute (src/db.rs:45)",
-        "postgres::client::query (src/db/postgres.rs:128)"
+      "code": "E_DB_QUERY_TIMEOUT_302",
+      "sqlstate": "57014",
+      "traceback": [
+        "fraiseql/db.py:312 in find",
+        "psycopg/cursor_async.py:128 in execute"
       ],
-      "query": "SELECT ... FROM users WHERE id = $1",
+      "query": "SELECT data FROM v_user WHERE id = $1",
       "bindings": ["12345"],
       "duration_ms": 30001
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 7.3 Error Context Logging
 
 Enable structured logging to capture error context:
 
 ```json
-<!-- Code example in JSON -->
 {
   "timestamp": "2026-01-11T15:35:00Z",
   "level": "ERROR",
   "trace_id": "req_550e8400",
   "category": "DATABASE_ERROR",
-  "code": "E_DB_POSTGRES_DEADLOCK_303",
+  "code": "E_DB_DEADLOCK_303",
+  "sqlstate": "40P01",
   "operation": "mutation",
   "query_hash": "5f5a3c2b1e0d9f8c",
   "database": "postgresql",
@@ -970,8 +879,7 @@ Enable structured logging to capture error context:
   "duration_ms": 5234,
   "retryable": true
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -988,11 +896,8 @@ Enable structured logging to capture error context:
 | E_VALIDATION_* (100-109) | Query validation | 10 |
 | E_DB_* (300-309) | Database execution | 10 |
 | E_EXEC_* (400-405) | Execution logic | 6 |
-| E_FED_* (500-504) | Federation | 5 |
 | E_SUB_* (600-605) | Subscriptions | 6 |
-| E_INTERNAL_* (700-703) | Internal errors | 4 |
-
-**Total:** 150+ distinct error codes
+| E_INTERNAL_* (700-702) | Internal errors | 3 |
 
 ---
 
@@ -1000,34 +905,34 @@ Enable structured logging to capture error context:
 
 ### 9.1 Error Code Stability Guarantee
 
-**Error codes are stable:** Once assigned, error codes will never change.
+**Error codes are stable:** Once assigned, an error code will never change meaning.
 
 **Adding errors:** New error codes may be added in minor releases (X.Y.Z → X.Y+1.Z).
 
 **Removing errors:** Error codes are never removed, only deprecated.
 
-**Example:** If E_DB_POSTGRES_CONNECTION_FAILED_300 is used today, it will have the same meaning in v2.1, v3.0, v10.0, etc.
+**Example:** If `E_DB_CONNECTION_FAILED_300` is used today, it will have the same meaning in 1.10, 1.11, and later releases.
+
+See [`./versioning-strategy.md`](./versioning-strategy.md) for the full compatibility and deprecation policy.
 
 ### 9.2 Deprecation of Error Types
 
-When an error becomes obsolete, it's marked deprecated:
+When an error becomes obsolete, it is marked deprecated:
 
 ```json
-<!-- Code example in JSON -->
 {
   "errors": [{
     "message": "...",
     "extensions": {
       "code": "E_OLD_ERROR_123",
       "deprecated": true,
-      "deprecated_since": "v2.3.0",
+      "deprecated_since": "1.5.0",
       "use_instead": "E_NEW_ERROR_456",
       "removal_date": "2027-01-11"
     }
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -1039,7 +944,7 @@ When an error becomes obsolete, it's marked deprecated:
 - Hide all error details (debugging requires transparency)
 - Support custom error codes (standard codes only)
 - Provide error translation per locale (use standard codes)
-- Guarantee error message format changes (messages evolve)
+- Guarantee error message format stability (messages evolve)
 
 ---
 
@@ -1047,12 +952,12 @@ When an error becomes obsolete, it's marked deprecated:
 
 FraiseQL's error handling is **deterministic and classifiable**:
 
-- ✅ All errors fall into well-defined categories
-- ✅ Each error code is stable and never changes
-- ✅ Errors include actionable context (retry, remediable, user-actionable)
-- ✅ Partial results possible (queries), atomic results (mutations)
-- ✅ Clients can implement robust error handling
-- ✅ Operations can debug using trace IDs and structured logs
+- All errors fall into well-defined categories
+- Each error code is stable and never changes meaning
+- Errors include actionable context (retry, remediable, user-actionable)
+- Partial results are possible for queries; mutations are atomic
+- Clients can implement robust error handling
+- Operations can debug using trace IDs and structured logs
 
 **Golden rule:** If the error code is the same, the error is the same. Clients can build deterministic error handling logic.
 

--- a/docs/architecture/reliability/failure-modes-and-recovery.md
+++ b/docs/architecture/reliability/failure-modes-and-recovery.md
@@ -1,1354 +1,767 @@
-<!-- Skip to main content -->
 ---
-
 title: Failure Modes and Recovery
-description: This document specifies how FraiseQL fails and recovers. Understanding failure modes enables operators to design resilient deployments and understand recovery t
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+description: How a FraiseQL v1 deployment fails and recovers, covering the FastAPI process, the PostgreSQL connection pool, query execution, caching, and authentication.
+keywords: ["reliability", "recovery", "postgresql", "connection pool", "operations"]
 tags: ["documentation", "reference"]
 ---
 
 # Failure Modes and Recovery
 
-**Version:** 1.0
-**Status:** Complete
-**Date:** January 11, 2026
 **Audience:** Operations engineers, SREs, infrastructure architects, security teams
 
 ---
 
 ## 1. Overview
 
-This document specifies how FraiseQL fails and recovers. Understanding failure modes enables operators to design resilient deployments and understand recovery time objectives (RTO) and recovery point objectives (RPO).
+This document describes how a FraiseQL v1 deployment fails and recovers. FraiseQL v1
+is a Python runtime GraphQL framework that runs as a FastAPI/ASGI application in front
+of a single PostgreSQL database. Understanding the failure modes of each part — the
+application process, the database connection pool, query execution, caching, and
+authentication — helps operators design resilient deployments.
+
+A note on scope: FraiseQL itself is a single application process. It does **not**
+provide built-in multi-instance coordination, automatic failover, or read-replica
+routing. Those are deployment and PostgreSQL concerns. Where this document discusses
+clustering, load balancing, or failover, treat it as **optional deployment guidance**,
+not a feature FraiseQL manages on your behalf.
 
 ### 1.1 Design Philosophy
 
 > **Fail fast, recover gracefully.**
 
-When FraiseQL encounters failure, it:
+When FraiseQL encounters a failure, it:
 
-1. **Detects** the failure immediately
-2. **Stops processing** (no partial/corrupt state)
-3. **Reports** error to client
-4. **Recovers** automatically where possible
-5. **Notifies** operations team for manual intervention if needed
+1. **Detects** the failure as early as possible
+2. **Stops processing** the affected request (no partial or corrupt state)
+3. **Reports** a structured error to the client
+4. **Recovers** automatically where the underlying mechanism allows (for example,
+   reconnecting a dropped database connection)
+5. **Surfaces** the error in logs and metrics so operations can intervene if needed
 
 ### 1.2 Recovery Time Objectives (RTO)
 
-| Component | RTO | Automatic | Manual |
-|-----------|-----|-----------|--------|
-| **Single FraiseQL instance** | < 30 seconds | ✅ Restart | N/A |
-| **FraiseQL cluster (n instances)** | < 5 seconds | ✅ Failover | N/A |
-| **Database connection** | < 5 seconds | ✅ Reconnect | N/A |
-| **Entire database** | 5-60 minutes | ❌ No | ✅ DBA |
-| **Cache backend** | < 5 seconds | ✅ Miss → DB | N/A |
-| **Federation subgraph** | < 30 seconds | ✅ Retry | ✅ escalate |
-| **Authentication provider** | 5-30 minutes | ❌ No | ✅ Escalate |
+The figures below are **deployment-dependent guidance**, not guarantees made by
+FraiseQL. Actual recovery time depends on your container orchestrator, load balancer,
+PostgreSQL configuration, and network. Measure them in your own environment.
+
+| Component | Typical RTO | Recovery mechanism |
+|-----------|-------------|--------------------|
+| **Single FraiseQL process** | seconds to a minute | Orchestrator/supervisor restarts the process |
+| **Database connection** | seconds | Pool reconnects on next use |
+| **Connection pool exhaustion** | depends on query duration | Waiting requests proceed as connections free up |
+| **Cache backend** | seconds | Bypass cache, read from database |
+| **Entire database** | minutes (operational) | DBA restart / restore / replica promotion |
+| **Authentication provider** | minutes (operational) | Provider recovery |
 
 ### 1.3 Recovery Point Objectives (RPO)
 
-| Component | RPO | Data Loss |
+| Component | RPO | Data loss |
 |-----------|-----|-----------|
-| **Committed mutations** | 0 (durable) | None |
-| **In-flight mutations** | Transaction boundary | None (atomic) |
-| **Cache entries** | Variable (TTL) | Query re-execution needed |
-| **Subscription events** | Variable (buffer TTL) | Events may be missed |
-| **Federation caches** | < 1 second | Stale reads possible |
+| **Committed mutations** | 0 (durable in PostgreSQL) | None |
+| **In-flight mutations** | Transaction boundary | None (atomic — commits or rolls back) |
+| **Cache entries** | Variable (TTL) | None — query re-executes against the database |
+| **Subscription events** | Per connection | Events that occur while a client is disconnected are not delivered to that client unless your view/source captures them |
 
 ---
 
 ## 2. Failure Modes by Component
 
-### 2.1 FraiseQL Runtime Failures
+### 2.1 FraiseQL Process Failures
 
 #### 2.1.1 Application Crash (Process Dies)
 
-**When:** Runtime panic, OOM, segfault, kill -9
+**When:** Unhandled exception at startup, OOM kill, `SIGKILL`, host failure.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-Immediate: All in-flight requests fail
-Response: Connection reset / 502 Bad Gateway
-Error: E_INTERNAL_UNKNOWN_ERROR_703
-```text
-<!-- Code example in TEXT -->
+- All in-flight requests on that process fail.
+- Clients see a connection reset, or a 502/503 from a load balancer.
 
-**Detection:** Load balancer health check fails (TCP connection refused)
+**Detection:** A health check (or the load balancer's TCP probe) fails because the
+process is no longer accepting connections.
 
 **Recovery:**
 
-- **Automatic:** Kubernetes restarts pod / systemd restarts service
-- **RTO:** 5-30 seconds (depends on restart mechanism)
-- **Data Impact:** None (database not affected)
+- **Automatic (if configured):** Your supervisor restarts it — systemd restarts the
+  service, or Kubernetes restarts the pod.
+- **Data impact:** None. PostgreSQL holds all durable state; an in-flight mutation
+  either committed before the crash or was rolled back by PostgreSQL when the
+  connection dropped.
 
-**During Recovery:**
-
-```text
-<!-- Code example in TEXT -->
-T0: Process dies
-T1-2s: Load balancer detects unhealthy
-T3-5s: Requests rerouted to healthy instances
-T5-30s: New instance starts up
-T30s+: Instance healthy, accepts traffic
-```text
-<!-- Code example in TEXT -->
+A single-process deployment is unavailable for the duration of the restart. If you run
+multiple FraiseQL processes behind a load balancer (optional deployment topology),
+traffic continues on the surviving processes while the failed one restarts. FraiseQL
+does not coordinate this — your load balancer does.
 
 #### 2.1.2 Memory Exhaustion (OOM)
 
-**When:** Query result too large, memory leak, cache fills
+**When:** A query returns an unexpectedly large result set, a memory leak accumulates,
+or the cache grows unbounded.
 
-**Client Impact:**
+**Client impact:** Requests slow down, then the process is OOM-killed and behaves as in
+2.1.1.
 
-```text
-<!-- Code example in TEXT -->
-Gradual: Queries become slower
-Then: Connection timeouts / 503 Service Unavailable
-Error: E_EXEC_LIMIT_EXCEEDED_405 or E_INTERNAL_PANIC_701
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Monitoring: Memory usage > 90%
-- Automatic: Queries rejected if < 100MB free
+**Detection:** Memory usage trends toward the container/VM limit.
 
 **Recovery:**
 
-- **Automatic:** Kill process, restart
-- **Manual:** Reduce query complexity, add cache tuning
-- **RTO:** 5-30 seconds
-- **Prevention:** Set memory limits (container/VM)
+- **Automatic:** The OOM-killed process is restarted by your supervisor.
+- **Manual:** Reduce result-set sizes (paginate, add filters), bound cache size, raise
+  the memory limit.
+- **Prevention:** Set container/VM memory limits, paginate large reads, and put TTL and
+  size bounds on any cache.
 
 #### 2.1.3 CPU Saturation
 
-**When:** High query volume, expensive queries, denial of service
+**When:** High request volume or expensive queries saturate available CPU.
 
-**Client Impact:**
+**Client impact:** Latency rises; under sustained saturation, requests may time out.
 
-```text
-<!-- Code example in TEXT -->
-Gradual: Query latency increases (p99 > 30s)
-Then: Query timeouts / slow client requests
-Error: E_DB_POSTGRES_QUERY_TIMEOUT_302
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Monitoring: CPU usage > 90%
-- Automatic: Query timeout enforcement
+**Detection:** CPU usage approaches 100%; p99 latency climbs.
 
 **Recovery:**
 
-- **Automatic:** Queries rejected if CPU utilization > 95%
-- **Manual:** Scale out to more instances
-- **RTO:** Immediate (no restart needed, queries queue)
-- **Prevention:** Rate limiting, query complexity limits
+- **Manual:** Run more FraiseQL processes (horizontal scale-out behind a load
+  balancer), or optimize the hot queries.
+- **Prevention:** Rate limiting, statement timeouts, and bounding query complexity.
 
-#### 2.1.4 Goroutine Leak / Resource Leak
+#### 2.1.4 Resource Leak (Connections / Tasks)
 
-**When:** Unbounded connection pool growth, subscription client leaks
+**When:** Connections or background tasks (for example, abandoned WebSocket
+subscriptions) accumulate over time.
 
-**Client Impact:**
+**Client impact:** Memory and file-descriptor usage grow slowly, eventually leading to
+an OOM crash (2.1.2) or refused connections.
 
-```text
-<!-- Code example in TEXT -->
-Slow: Memory gradually increases over hours/days
-Then: OOM crash (see 2.1.2)
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Monitoring: Goroutine count increasing over time
-- Manual: pprof profiling
+**Detection:** Steadily rising open-connection or task counts over hours or days.
 
 **Recovery:**
 
-- **Manual:** Rolling restart of instances
-- **RTO:** 5-30 seconds per instance
-- **Prevention:** Connection limits, goroutine limits, monitoring
+- **Manual:** Restart the affected process.
+- **Prevention:** Bound the connection pool, set keep-alive/idle timeouts on WebSocket
+  subscriptions, and monitor connection and task counts.
 
 ---
 
 ### 2.2 Database Connection Failures
 
+FraiseQL uses `psycopg_pool.AsyncConnectionPool` for PostgreSQL connections. The pool
+manages a bounded set of connections, hands them to requests, and reconnects when a
+connection is found to be broken.
+
 #### 2.2.1 Connection Timeout
 
-**When:** Database unreachable, network partition, DNS failure
+**When:** PostgreSQL is unreachable — network partition, DNS failure, the server is not
+yet up.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-Immediate: Query returns error
-Response: HTTP 504 Gateway Timeout (after 5s wait)
-Error: E_DB_POSTGRES_CONNECTION_FAILED_300
-Retryable: YES
-```text
-<!-- Code example in TEXT -->
+- The query fails after the pool's connection timeout elapses.
+- The client receives an error; the operation is retryable.
 
-**Detection:**
-
-- Automatic: Connection attempt fails with timeout
-- Monitoring: Connection time > threshold
+**Detection:** The connection attempt fails or times out.
 
 **Recovery:**
 
-- **Automatic:** Retry connection after backoff (1s, 2s, 4s, 8s)
-- **Client:** Retry with exponential backoff
-- **RTO:** < 30 seconds (depends on retry strategy)
+- **Automatic:** The next request attempts a fresh connection. A client that retries
+  with backoff will succeed once PostgreSQL is reachable again.
+- **Client guidance:** Retry with exponential backoff.
 
-**Connection Pool State:**
-
-```text
-<!-- Code example in TEXT -->
-Before: 10/20 connections in use
-Error: Connection attempt fails
-After: Connection returned to pool marked stale
-Next query: Reconnection attempted
-```text
-<!-- Code example in TEXT -->
+**Connection pool state:** When a connection attempt fails, the pool discards the
+broken connection rather than handing it out. The next acquisition opens a new one.
 
 #### 2.2.2 Connection Pool Exhaustion
 
-**When:** More queries than pool size, slow query victims
+**When:** More concurrent queries arrive than the pool has connections, often because
+slow queries hold connections longer than expected.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-Immediate: Connection request blocks
-After 5s: Query times out
-Response: HTTP 504 Gateway Timeout
-Error: E_DB_CONNECTION_POOL_EXHAUSTED_301
-Retryable: YES (with backoff)
-```text
-<!-- Code example in TEXT -->
+- A query that needs a connection waits until one is free.
+- If none frees within the pool's wait timeout, the request fails (retryable with
+  backoff).
 
-**Detection:**
-
-- Automatic: Pool size < available connections
-- Monitoring: Active connections > 90% of pool
+**Detection:** Active connections sit at the pool maximum; requests spend time waiting
+to acquire a connection.
 
 **Recovery:**
 
-- **Automatic:** Increase pool size (if below max)
-- **Automatic:** Wait for active queries to complete
-- **Manual:** Scale out to more instances
-- **RTO:** Depends on query duration (typically <30s)
+- **Automatic:** Waiting requests proceed as in-flight queries finish and return their
+  connections to the pool.
+- **Manual:** Raise the pool maximum (within PostgreSQL's `max_connections`), speed up
+  slow queries, or run more FraiseQL processes.
 
-**Pool Configuration:**
+**Pool sizing considerations:**
 
 ```text
-<!-- Code example in TEXT -->
-min_connections: 5
-max_connections: 20
-queue_timeout: 5000ms  // How long to wait
+min_size:        minimum connections kept open
+max_size:        maximum connections the pool will open
+acquisition wait: how long a request waits for a free connection before failing
+```
 
-If 20 queries active + 5 queued:
-  Query 26 waits 5s then times out
-```text
-<!-- Code example in TEXT -->
+The product of `max_size` across all FraiseQL processes must stay within PostgreSQL's
+`max_connections`. Oversizing the pool moves the bottleneck onto the database; consider
+a server-side pooler such as PgBouncer for high process counts.
 
 #### 2.2.3 Connection Closed by Database
 
-**When:** Database restarts, network interruption, auth failure
+**When:** PostgreSQL closes a connection mid-use — server restart, idle-connection
+reaping, an administrative `pg_terminate_backend`, or a transient network drop.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-Request: Executing query
-Error: Connection closed mid-query
-Response: Partial/stale data or error
-Error: E_DB_POSTGRES_CONNECTION_FAILED_300
-Retryable: YES (connection reopened)
-```text
-<!-- Code example in TEXT -->
+- The in-flight query fails with a connection error (retryable).
+- A read can be retried on a fresh connection. A mutation that had not committed is
+  rolled back by PostgreSQL; the client must re-issue it.
 
-**Detection:**
-
-- Automatic: Network error reading response
-- Automatic: Connection marked unhealthy
+**Detection:** A network/connection error occurs while reading the response; the pool
+marks the connection broken.
 
 **Recovery:**
 
-- **Automatic:** Reopen connection
-- **Automatic:** Retry query on new connection
-- **Max retries:** 3 attempts
-- **RTO:** < 10 seconds
+- **Automatic:** The pool opens a replacement connection on the next acquisition.
+- **Client guidance:** Retry the operation. For mutations, ensure the operation is
+  idempotent or check whether it committed before retrying.
 
 #### 2.2.4 Database Restart
 
-**When:** Planned maintenance, crash, failover
+**When:** Planned maintenance, a crash, or a failover.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-During restart: All connections fail
-Error: E_DB_POSTGRES_CONNECTION_FAILED_300
-Duration: 10 seconds (pg restart) to 5 minutes (recovery)
-Requests: Queued and retry
-Queries: Some fail, some succeed after restart
-```text
-<!-- Code example in TEXT -->
+- During the restart, every connection fails and new connections are refused.
+- Queries error until PostgreSQL is back and the pool reconnects.
 
-**Detection:**
-
-- Automatic: Connection attempts fail
-- Monitoring: Database not responding
+**Detection:** Connection attempts fail; database health checks fail.
 
 **Recovery:**
 
-- **Automatic:** Retry connection exponentially
-- **All queries:** Fail initially, queued for retry
-- **RTO:** 10 seconds - 5 minutes (database dependent)
-- **Data Impact:** None (durable state persisted)
-
-**During Database Restart:**
-
-```text
-<!-- Code example in TEXT -->
-T0: Database starts shutdown
-T1-5s: In-flight queries error
-T5s: All connections fail
-T5-20s: Database restart process
-T20s: Database comes online
-T20-30s: Connections re-established
-T30s+: Queries succeed again
-```text
-<!-- Code example in TEXT -->
+- **Automatic (from FraiseQL's side):** Once PostgreSQL accepts connections again, the
+  pool opens fresh connections and queries succeed.
+- **RTO:** From a few seconds (clean restart) to several minutes (crash recovery or
+  failover) — this is governed by PostgreSQL, not FraiseQL.
+- **Data impact:** None for committed writes; PostgreSQL persists them durably.
 
 ---
 
 ### 2.3 Database Execution Failures
 
-#### 2.3.1 Query Timeout
+These are errors PostgreSQL returns for a query or function call. FraiseQL surfaces them
+as structured GraphQL errors. See [Error Handling Model](./error-handling-model.md) for
+how errors are shaped and classified.
 
-**When:** Slow query, missing index, resource contention
+#### 2.3.1 Statement / Query Timeout
 
-**Client Impact:**
+**When:** A slow query, a missing index, or resource contention causes execution to
+exceed the configured `statement_timeout`.
 
-```text
-<!-- Code example in TEXT -->
-Waiting: Client waits for result (up to 30s default)
-Timeout: Query killed by database
-Response: HTTP 504 Gateway Timeout
-Error: E_DB_POSTGRES_QUERY_TIMEOUT_302
-Retryable: YES (with better query)
-```text
-<!-- Code example in TEXT -->
+**Client impact:**
 
-**Detection:**
+- PostgreSQL cancels the statement; the client receives a timeout error (retryable
+  after narrowing the query).
 
-- Automatic: Query execution > timeout threshold
-- Monitoring: p99 query time > SLO
+**Detection:** Execution exceeds the timeout; p99 query time breaches your SLO.
 
 **Recovery:**
 
-- **Automatic:** Kill query, return error
-- **Client:** Retry with fewer results (add filter/limit)
-- **Manual:** Add index, optimize query
-- **RTO:** Immediate (query terminated)
-- **Data Impact:** None (query doesn't write)
+- **Automatic:** The statement is cancelled and the error returned. No data is written
+  by a cancelled read.
+- **Client guidance:** Retry with a tighter filter or smaller `LIMIT`.
+- **Manual:** Add an index, optimize the underlying `v_`/`tv_` view, or raise the
+  timeout.
+
+Set a `statement_timeout` (per-session or globally) so a runaway query cannot hold a
+connection indefinitely and starve the pool.
 
 #### 2.3.2 Deadlock
 
-**When:** Concurrent mutations conflicting
+**When:** Two concurrent transactions acquire locks in conflicting orders.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-Execution: Queries start conflicting
-Deadlock detected: One query victim selected
-Response: HTTP 502 Bad Gateway
-Error: E_DB_POSTGRES_DEADLOCK_303
-Retryable: YES (automatic on retry)
-```text
-<!-- Code example in TEXT -->
+- PostgreSQL detects the cycle, cancels one transaction as the victim, and returns a
+  serialization/deadlock error (retryable).
 
-**Detection:**
-
-- Automatic: Database detects and kills one query
-- Monitoring: Deadlock count increasing
+**Detection:** PostgreSQL's deadlock detector fires; the deadlock count rises in
+metrics.
 
 **Recovery:**
 
-- **Automatic:** Runtime retries query automatically (up to 3x)
-- **If persists:** Returns error, client retries
-- **RTO:** < 1 second per retry
-- **Data Impact:** First query's changes persist, second rolls back
+- **Automatic:** The victim transaction is rolled back; the winner commits.
+- **Client guidance:** Retry the victim transaction. Because writes go through `fn_`
+  PostgreSQL functions, keep those functions short and acquire locks in a consistent
+  order to minimize deadlocks.
 
-**Deadlock Scenario:**
+**Deadlock scenario:**
 
-```text
-<!-- Code example in TEXT -->
-Client A: UPDATE users SET balance -= 100 WHERE id = 1
-         UPDATE orders SET total += 100 WHERE user_id = 1
+```sql
+-- Transaction A
+UPDATE tb_user  SET balance = balance - 100 WHERE id = '...';
+UPDATE tb_order SET total   = total   + 100 WHERE fk_user = '...';
 
-Client B: UPDATE orders SET total -= 50 WHERE user_id = 1
-         UPDATE users SET balance += 50 WHERE id = 1
+-- Transaction B (opposite lock order)
+UPDATE tb_order SET total   = total   -  50 WHERE fk_user = '...';
+UPDATE tb_user  SET balance = balance +  50 WHERE id = '...';
+```
 
-Database: Detects circular dependency
-         Kills Client B's transaction
-         Client B retries and succeeds
-```text
-<!-- Code example in TEXT -->
+PostgreSQL detects the circular wait, cancels one transaction, and that transaction
+retries and succeeds.
 
 #### 2.3.3 Constraint Violation
 
-**When:** Unique constraint, foreign key, check constraint
+**When:** A unique, foreign-key, or check constraint rejects a write inside a `fn_`
+function.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-Execution: Constraint violation during INSERT/UPDATE
-Response: HTTP 400 Bad Request
-Error: E_DB_MYSQL_CONSTRAINT_VIOLATION_304
-Retryable: NO
-```text
-<!-- Code example in TEXT -->
+- The write is rejected; the mutation returns an error result. Not retryable without
+  changing the data.
 
-**Detection:**
-
-- Automatic: Database rejects write
-- User-actionable: Clear error message
+**Detection:** PostgreSQL rejects the write; the `fn_` function returns a failure
+payload that maps to your `@fraiseql.error` type.
 
 **Recovery:**
 
-- **Client:** Fix data (use different email, valid user_id, etc.)
-- **Retry:** Retry with corrected data
-- **RTO:** User must fix (not automatic)
+- **Client guidance:** Correct the input (use a different email, a valid foreign key,
+  etc.) and re-submit.
 
-**No Recovery Needed:**
+**No automatic recovery:**
 
 ```text
-<!-- Code example in TEXT -->
-Mutation { createUser(email: "taken@example.com") { id } }
-→ Error: Unique constraint violation on email
-→ User should: Use different email
-→ Automatic retry: Will fail identically
-```text
-<!-- Code example in TEXT -->
+mutation { createUser(input: { email: "taken@example.com" }) { ... } }
+→ Unique constraint violation on email
+→ Client should: use a different email
+→ Retrying the same input fails identically
+```
 
 #### 2.3.4 Out of Memory (Database)
 
-**When:** Query result too large, insufficient RAM
+**When:** A query (large sort, hash join, or aggregate) needs more memory than
+PostgreSQL has available.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-Execution: Query consumes too much memory
-Response: HTTP 503 Service Unavailable
-Error: E_DB_SQLSERVER_OUT_OF_MEMORY_307
-Retryable: YES (reduce query size)
-```text
-<!-- Code example in TEXT -->
+- The query fails; the client receives an error (retryable after reducing query size).
 
-**Detection:**
-
-- Monitoring: Database memory > 90%
-- Automatic: Query killed before consuming all memory
+**Detection:** PostgreSQL memory pressure; the statement fails before exhausting the
+host.
 
 **Recovery:**
 
-- **Client:** Retry with pagination (smaller batch size)
-- **Manual:** Add WHERE filter, reduce JOIN complexity
-- **Manual:** Increase database RAM
-- **RTO:** Immediate (query killed)
+- **Client guidance:** Paginate, add a `WHERE` filter, or simplify joins.
+- **Manual:** Tune `work_mem`, optimize the view, or add memory to the database host.
 
 #### 2.3.5 Disk Full
 
-**When:** Database cannot write (INSERT/UPDATE fails)
+**When:** The database volume fills and PostgreSQL can no longer write.
 
-**Client Impact:**
+**Client impact:**
 
-```text
-<!-- Code example in TEXT -->
-Execution: Database cannot allocate space
-Response: HTTP 503 Service Unavailable
-Error: E_DB_MYSQL_DISK_FULL_308
-Retryable: YES (after manual intervention)
-```text
-<!-- Code example in TEXT -->
+- Writes fail with an error; reads generally continue to work.
 
-**Detection:**
-
-- Monitoring: Disk usage > 95%
-- Automatic: Database rejects writes
+**Detection:** Disk usage crosses your alert threshold; PostgreSQL rejects writes.
 
 **Recovery:**
 
-- **Manual:** DBA frees disk space
-- **RTO:** 5-30 minutes (operational)
-- **Data Impact:** Writes fail until space available
-- **Reads:** Unaffected (can still query)
+- **Manual:** A DBA frees space (rotate WAL/logs, prune data, grow the volume).
+- **RTO:** Operational — minutes, depending on the fix.
+- **Data impact:** Writes fail until space is available; committed data is intact.
 
 ---
 
-### 2.4 Cache Backend Failures
+### 2.4 Cache Failures
 
-#### 2.4.1 Cache Server Down
+Caching in FraiseQL is an optional optimization. When a cache backend is unavailable or
+returns nothing useful, FraiseQL falls back to executing the query against PostgreSQL —
+correctness is preserved, only latency changes.
 
-**When:** Redis/Memcached instance crashes
+#### 2.4.1 Cache Backend Down
 
-**Client Impact:**
+**When:** An external cache (for example, Redis) is unreachable.
 
-```text
-<!-- Code example in TEXT -->
-Query: Cache miss (server unavailable)
-Result: Query executes against database
-Latency: Slower than cached (depends on query)
-Error: None (graceful degradation)
-```text
-<!-- Code example in TEXT -->
+**Client impact:**
 
-**Detection:**
+- Reads miss the cache and execute against the database. Higher latency, but correct
+  results.
 
-- Automatic: Cache connection fails
-- Monitoring: Cache server not responding
+**Detection:** Cache connection failures; the backend stops responding.
 
 **Recovery:**
 
-- **Automatic:** Cache marked unavailable, queries bypass cache
-- **Automatic:** Cache reconnection attempted
-- **RTO:** < 5 seconds (cache warming starts)
-- **Data Impact:** None (queries still work, slower)
+- **Automatic:** Requests bypass the cache and read from the database. When the cache
+  returns, it repopulates on subsequent reads.
+- **Data impact:** None — the database is the source of truth.
 
-**Graceful Degradation:**
-
-```text
-<!-- Code example in TEXT -->
-Before cache failure:
-  Query: 50ms (cache hit)
-
-During cache failure:
-  Query: 200-500ms (database direct)
-
-After cache recovery:
-  Query: 50ms again (cache warming in progress)
-```text
-<!-- Code example in TEXT -->
-
-#### 2.4.2 Cache Corruption
-
-**When:** Stale/invalid data in cache
-
-**Client Impact:**
+**Graceful degradation:**
 
 ```text
-<!-- Code example in TEXT -->
-Query: Cache returns invalid data
-Result: Inconsistent response to client
-Monitoring: Data inconsistency detected
-```text
-<!-- Code example in TEXT -->
+Cache available:    fast path (cache hit)
+Cache unavailable:  slower path (database read), results still correct
+Cache recovers:     cache warms again on subsequent reads
+```
 
-**Detection:**
+#### 2.4.2 Stale or Invalid Cache Entry
 
-- Monitoring: Hash validation fails
-- Automatic: Data type mismatch
+**When:** A cached entry no longer reflects the committed database state, or fails a
+validation check.
+
+**Client impact:**
+
+- A brief stale read is possible until the entry is invalidated or expires.
+
+**Detection:** TTL expiry, explicit invalidation on the relevant write, or a validation
+mismatch.
 
 **Recovery:**
 
-- **Automatic:** Invalidate entry, fetch from database
-- **Automatic:** Rebuild cache from fresh data
-- **RTO:** < 1 second
-- **Data Impact:** Brief stale read possible
+- **Automatic:** Invalidate the entry and fetch fresh data from the database.
 
-#### 2.4.3 Cache Too Full
+See [Consistency Model](./consistency-model.md) for the guarantees and the windows in
+which a stale read can occur.
 
-**When:** Memory limit reached
+#### 2.4.3 Cache At Capacity
 
-**Client Impact:**
+**When:** The cache reaches its memory limit.
 
-```text
-<!-- Code example in TEXT -->
-Write: Cannot add new entries to cache
-Behavior: Entries evicted (LRU policy)
-Result: More cache misses, slower queries
-Error: None (automatic eviction)
-```text
-<!-- Code example in TEXT -->
+**Client impact:**
 
-**Detection:**
-
-- Monitoring: Cache memory > 90%
-- Automatic: Eviction triggered
+- Entries are evicted (typically LRU), producing more misses and slightly slower
+  queries. No errors.
 
 **Recovery:**
 
-- **Automatic:** LRU entries evicted
-- **Manual:** Increase cache memory
-- **RTO:** Immediate (queries work, but slower)
+- **Automatic:** Eviction keeps the cache within bounds.
+- **Manual:** Raise the cache size limit or tighten TTLs.
 
 ---
 
-### 2.5 Authentication Provider Failures
+### 2.5 Authentication Failures
 
 #### 2.5.1 Auth Provider Unreachable
 
-**When:** OIDC provider down, Auth0 down, corporate SSO down
+**When:** An external identity provider (OIDC issuer, Auth0, corporate SSO) is down.
 
-**Client Impact:**
+**Client impact:** Depends on the token model:
 
-```text
-<!-- Code example in TEXT -->
-Request: No valid token
-Recovery: Request uses cached/local auth
-Behavior: Depends on auth provider type
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Automatic: Token validation request fails
-- Monitoring: Auth provider not responding
-
-**Recovery Strategy (depends on provider):**
-
-**Scenario A: JWT Token (self-contained)**
+**Self-contained JWT (signature verified with a cached public key):**
 
 ```text
-<!-- Code example in TEXT -->
-Token validation: Cached public key used
-Auth provider unreachable: Token still validated locally
-Impact: NONE (JWT self-contained)
-RTO: 0 (no recovery needed)
-```text
-<!-- Code example in TEXT -->
+The provider being unreachable does not block validation; the cached
+public key (JWKS) still verifies signatures locally. Impact: minimal,
+until the signing keys rotate and the cached JWKS becomes stale.
+```
 
-**Scenario B: OAuth2 Token (external validation)**
+**Tokens requiring a live call to the provider (introspection):**
 
 ```text
-<!-- Code example in TEXT -->
-Token validation: HTTP request to provider fails
-Behavior: Option 1: Cache last 5min, allow
-         Option 2: Deny all access
-Impact: Depends on policy (typically DENY)
-RTO: Until provider recovers (5-30 min)
-```text
-<!-- Code example in TEXT -->
+Validation makes an HTTP call to the provider, which fails.
+Policy decides the behaviour: deny new requests (fail closed,
+recommended) or briefly accept on a short-lived cache (fail open).
+Impact lasts until the provider recovers.
+```
 
-**Recommended:** Use JWT tokens for resilience.
+**Recommendation:** Prefer self-contained JWTs with cached JWKS for resilience against
+provider outages.
 
-#### 2.5.2 Token Expiration During Execution
+#### 2.5.2 Token Expiry During Execution
 
-**When:** Long-running query, token expires mid-execution
+**When:** A long-running request's token expires after authorization but before the
+request completes.
 
-**Client Impact:**
+**Client impact:** The request completes normally — authorization is evaluated at the
+start of the request, not mid-execution.
 
-```text
-<!-- Code example in TEXT -->
-Auth check: Passed (token valid at start)
-Execution: Query runs normally
-Result: Query completes successfully
-Token expiry: Ignored (already authenticated)
-```text
-<!-- Code example in TEXT -->
+**Recovery:** None needed for the in-flight request. The client must refresh its token
+before the next request.
 
-**Detection:** Not detected (query already authorized)
+#### 2.5.3 Invalid Token
 
-**Recovery:** None needed (query completes)
+**When:** A token is malformed, expired, or its signature does not verify.
 
----
+**Client impact:** The request is rejected with `401 Unauthorized`. Not retryable
+without re-authenticating.
 
-### 2.6 Federation Failures
+**Recovery:** The client re-authenticates to obtain a fresh token.
 
-#### 2.6.1 Subgraph Unavailable
+#### 2.5.4 Stale Authorization Context
 
-**When:** Federated subgraph is down or unreachable
+**When:** A user's roles or permissions change after their token was issued.
 
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Query: Needs federated entity
-Attempt: HTTP request to subgraph fails
-Response: HTTP 504 Gateway Timeout (after 5s wait)
-Error: E_FED_SUBGRAPH_UNAVAILABLE_502
-Retryable: YES
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Automatic: HTTP connection fails
-- Monitoring: Subgraph health check fails
+**Client impact:** Until the token is refreshed, authorization is evaluated against the
+permissions baked into the (still-valid) token, which may allow or deny incorrectly.
 
 **Recovery:**
 
-- **Automatic:** Retry with exponential backoff (1s, 2s, 4s)
-- **Automatic:** Fallback to stale cache (if available)
-- **Max retries:** 3 attempts × 5s = 15s total wait
-- **RTO:** < 30 seconds
-- **Fallback:** Return stale federated data if cached
+- Shorten token lifetimes so changes take effect sooner.
+- Revoke and re-issue tokens for an immediate change.
 
-**During Subgraph Outage:**
+#### 2.5.5 Row-Level Security (RLS) Denial
 
-```text
-<!-- Code example in TEXT -->
-Request 1 (T0): Subgraph unavailable
-  → Retry 1 (T1s): Still unavailable
-  → Retry 2 (T3s): Still unavailable
-  → Return error after 15s total wait
+**When:** A PostgreSQL row-level security policy prevents access to rows the caller is
+not entitled to.
 
-Request 2 (T0): Parallel requests
-  → Same retry loop
-  → Shared cache prevents redundant retries
-```text
-<!-- Code example in TEXT -->
+**Client impact:** The query returns no rows for the disallowed data (or an explicit
+authorization error). This is an intentional security boundary, not a fault. Not
+retryable — the caller lacks permission.
 
-#### 2.6.2 Entity Resolution Timeout
-
-**When:** Subgraph responds slowly
-
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Query: Needs federated entity
-Wait: 5s timeout
-Response: HTTP 504 Gateway Timeout
-Error: E_FED_SUBGRAPH_TIMEOUT_503
-Retryable: YES
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Automatic: HTTP request > timeout threshold
-- Monitoring: Subgraph response time > SLO
-
-**Recovery:**
-
-- **Automatic:** Retry with backoff
-- **Client:** Retry entire query
-- **Manual:** Optimize subgraph query, scale out
-- **RTO:** < 30 seconds (with retries)
-
-#### 2.6.3 Entity Type Mismatch
-
-**When:** Subgraph returns unexpected entity type
-
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Query: Expects User { name, email }
-Subgraph: Returns { name, org_id } (wrong shape)
-Error: Type validation fails
-Response: HTTP 500 Internal Server Error
-Error: E_FED_TYPE_MISMATCH_504
-Retryable: NO
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Automatic: Schema validation fails
-- Monitoring: Type mismatches detected
-
-**Recovery:**
-
-- **Manual:** Fix subgraph schema
-- **RTO:** Depends on schema update process (5-30 min)
-- **Interim:** Disable federation for this entity type
-
----
-
-### 2.7 Subscription Failures
-
-#### 2.7.1 WebSocket Connection Lost
-
-**When:** Network interruption, client disconnect, server restart
-
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Subscription: Active WebSocket
-Event: Network failure
-Connection: Closed
-Response: Close frame sent to client (code 1006)
-Error: E_SUB_CONNECTION_CLOSED_604
-Retryable: YES (reconnect)
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Automatic: Socket close detected
-- Automatic: Keep-alive timeout (60s)
-
-**Recovery:**
-
-- **Client:** Reconnect and resubscribe
-- **RTO:** < 5 seconds (reconnect + resubscribe)
-- **Events during outage:** Buffered in `tb_entity_change_log`
-- **Replay:** Client can query from last sequence_number
-
-**Recovery Sequence:**
-
-```text
-<!-- Code example in TEXT -->
-T0: Connection lost
-T1-5s: Client detects and reconnects
-T5s: New subscription established
-T5+: Resume receiving events from buffer
-```text
-<!-- Code example in TEXT -->
-
-#### 2.7.2 Event Buffer Overflow
-
-**When:** Too many events, subscriber is slow
-
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Events: Accumulating faster than delivery
-Buffer: Fills up (default: 1000 events)
-Response: Error sent to subscriber
-Error: E_SUB_BUFFER_OVERFLOW_603
-Retryable: YES (reconnect and replay from sequence)
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Monitoring: Buffer usage > 90%
-- Automatic: Overflow detected
-
-**Recovery:**
-
-- **Client:** Reconnect and replay from last sequence number
-- **Automatic:** Filter events (add WHERE clause) to reduce volume
-- **Manual:** Increase buffer size
-- **RTO:** < 10 seconds (reconnect)
-
-#### 2.7.3 Event Delivery Failure (Webhooks)
-
-**When:** Webhook endpoint returns error or is slow
-
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Event: Needs delivery to webhook
-Request: HTTP POST to endpoint
-Response: 500 error or timeout
-Behavior: Automatic retry with backoff
-Attempts: Up to 5 retries over 10 minutes
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Automatic: HTTP response code >= 400
-- Monitoring: Webhook delivery failures
-
-**Recovery:**
-
-- **Automatic:** Retry with exponential backoff
-  - Attempt 1: Immediately
-  - Attempt 2: After 1s
-  - Attempt 3: After 5s
-  - Attempt 4: After 30s
-  - Attempt 5: After 5 minutes
-- **Final failure:** Event logged, Webhook marked unhealthy
-- **RTO:** 10 minutes until all retries exhausted
-
----
-
-### 2.8 Authorization/Security Failures
-
-#### 2.8.1 Auth Token Invalid
-
-**When:** Malformed, expired, or tampered token
-
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Request: Includes invalid token
-Auth: Validation fails
-Response: HTTP 401 Unauthorized
-Error: E_AUTH_INVALID_TOKEN_201
-Retryable: NO (user must re-authenticate)
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Automatic: Token signature invalid
-- Automatic: Token expiration date passed
-
-**Recovery:**
-
-- **Client:** Re-authenticate to get new token
-- **RTO:** Depends on auth flow (typically < 1 minute)
-
-#### 2.8.2 Auth Context Stale
-
-**When:** User role/permissions changed after token issued
-
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Request: Token valid but permissions changed
-Authorization: Evaluated against stale role
-Result: May allow/deny incorrectly
-Probability: Low (permissions don't change frequently)
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Monitoring: Authorization denials after known permission grant
-- Manual: Security audit
-
-**Recovery:**
-
-- **Automatic:** Re-fetch auth context on periodic basis (TTL)
-- **Manual:** Revoke and re-issue tokens
-- **RTO:** 0-1 hour (depends on token refresh interval)
-
-#### 2.8.3 RLS Policy Violation
-
-**When:** Row-level security policy prevents access
-
-**Client Impact:**
-
-```text
-<!-- Code example in TEXT -->
-Query: Attempts cross-tenant access
-RLS: Policy prevents unauthorized access
-Response: Query returns empty or error
-Error: E_AUTH_ROW_LEVEL_SECURITY_DENIED_204 (if explicit)
-Retryable: NO (user doesn't have permission)
-```text
-<!-- Code example in TEXT -->
-
-**Detection:**
-
-- Automatic: RLS policy evaluation
-- Monitoring: RLS denials by policy
-
-**Recovery:**
-
-- **No automatic recovery** (intentional security boundary)
-- **Manual:** DBA grants access or user requests permission
-- **RTO:** Depends on access request process
+**Recovery:** None automatic. A privileged operator must grant access if appropriate.
 
 ---
 
 ## 3. Cascading Failures
 
-### 3.1 Database Down → Everything Down
+### 3.1 Database Down → Reads and Writes Fail
 
 ```text
-<!-- Code example in TEXT -->
-T0: Primary database becomes unavailable
-T1: All queries start failing
-T2: Cache still works (if recently populated)
-T3: Subscriptions: Events not captured
-T4: Federation: Dependent services affected
-T5-30min: RTO depends on failover setup
-```text
-<!-- Code example in TEXT -->
+PostgreSQL becomes unavailable
+→ Queries and mutations fail (no connection)
+→ A warm cache may still serve some reads until entries expire
+→ RTO is governed by your PostgreSQL recovery/failover, not FraiseQL
+```
 
-### 3.2 Cache Down → Database Load Spikes
+### 3.2 Cache Down → Database Load Increases
 
 ```text
-<!-- Code example in TEXT -->
-T0: Cache server fails
-T1: All queries bypass cache
-T2: Database CPU/memory spike
-T3: Database becomes slow
-T4: Queries timeout
-T5+: Potential database failure if resources exhausted
-```text
-<!-- Code example in TEXT -->
+Cache backend fails
+→ All reads bypass the cache and hit the database directly
+→ Database CPU and I/O rise
+→ Without statement timeouts and pool bounds, slow queries can pile up
+Mitigation: keep statement_timeout and a bounded pool so the database
+degrades gracefully rather than collapsing.
+```
 
-### 3.3 Authentication Provider Down → All Writes Blocked
+### 3.3 Auth Provider Down → New Sessions Blocked
 
 ```text
-<!-- Code example in TEXT -->
-T0: Auth provider unreachable
-T1: New token validation fails (OAuth2 tokens)
-T2: New user requests return 401
-T3: Existing queries continue (token already valid)
-T4: Eventually: All tokens expire, all users blocked
-```text
-<!-- Code example in TEXT -->
-
-### 3.4 Subscription Event Buffer Full → All Events Dropped
-
-```text
-<!-- Code example in TEXT -->
-T0: Event throughput increases
-T1: Buffer fills to capacity
-T2: New events cannot be stored
-T3: Subscribers miss events
-T4: Clients must replay from last sequence_number
-```text
-<!-- Code example in TEXT -->
+Provider becomes unreachable
+→ Self-contained JWTs continue to validate against cached keys
+→ Flows that need a live provider call (login, introspection) fail
+→ Existing valid tokens keep working until they expire
+```
 
 ---
 
 ## 4. Failure Recovery Procedures
 
-### 4.1 Single Instance Crash
+### 4.1 Process Crash
 
-**Automatic (no human intervention):**
+**Automatic (with a supervisor configured):**
 
 ```text
-<!-- Code example in TEXT -->
+1. The FraiseQL process crashes.
+2. systemd / Kubernetes detects the unhealthy process.
+3. It starts a replacement process.
+4. The replacement re-establishes its PostgreSQL pool on first use.
+5. Traffic resumes (immediately on surviving processes if you run several
+   behind a load balancer; after restart for a single-process deployment).
 
-1. Instance crashes
-2. Kubernetes detects unhealthy pod (10-30s)
-3. Spins up new pod
-4. New pod joins load balancer
-5. Existing connections fail (clients retry)
-6. New requests route to new pod
-
-Total time: 30-60 seconds
-Human intervention: None
-Data loss: None
-```text
-<!-- Code example in TEXT -->
+Data loss: none (PostgreSQL holds durable state).
+```
 
 **Manual verification:**
 
 ```bash
-<!-- Code example in BASH -->
-# Check pod logs for crash reason
-kubectl logs pod-name
+# Inspect logs for the crash cause
+kubectl logs <pod-name>      # or: journalctl -u <service>
 
-# If OOM: Increase memory limits
-# If out of disk: Clean up logs/cache
-# If panic: File bug report
-```text
-<!-- Code example in TEXT -->
+# If OOM:           raise the memory limit or bound result sizes / cache
+# If disk pressure: clear logs / temporary files
+# If a bug:         capture the traceback and file an issue
+```
 
-### 4.2 Database Connection Lost
+### 4.2 Database Connection Lost (Transient)
 
 **Automatic:**
 
 ```text
-<!-- Code example in TEXT -->
+1. A query fails with a connection error.
+2. The pool discards the broken connection.
+3. The pool opens a fresh connection on the next acquisition.
+4. The retried query succeeds.
+5. Clients see a brief latency spike.
 
-1. Query fails with connection error
-2. Runtime closes stale connection
-3. Reopens connection (exponential backoff)
-4. Retries query on new connection
-5. Client sees temporary latency spike
+Data loss: none.
+```
 
-Total time: 2-10 seconds
-Human intervention: None (check database logs)
-Data loss: None
-```text
-<!-- Code example in TEXT -->
+### 4.3 Database Unavailable (Operational Recovery)
 
-### 4.3 Database Unavailable (Recovery)
-
-**Steps:**
+This is a PostgreSQL operations procedure; FraiseQL simply reconnects once the database
+is healthy.
 
 ```text
-<!-- Code example in TEXT -->
+1. Monitoring detects PostgreSQL is not responding.
+2. Page the on-call DBA.
+3. Investigate database and network logs.
+4. Recover:
+   a. Crashed server   → restart PostgreSQL.
+   b. Network issue    → restore connectivity.
+   c. HA setup         → promote a replica (your HA tooling, not FraiseQL).
+5. Verify with test queries; watch replication lag if applicable.
+6. Ramp traffic back up and monitor.
 
-1. Monitor: Detect database not responding (< 5 seconds)
-2. Alert: Page on-call DBA
-3. Investigate: Check database logs, network connectivity
-4. Recovery:
-   a. If crashed: Restart database server
-   b. If network: Restore network connectivity
-   c. If failed: Promote replica (if HA setup)
-5. Verify: Run queries, check replication lag
-6. Monitor: Watch for issues, gradual traffic increase
+Data loss: none for committed writes (durable in PostgreSQL).
+```
 
-Total time: 5-30 minutes (depends on issue)
-Human intervention: Required
-Data loss: None (if durability persisted)
-```text
-<!-- Code example in TEXT -->
-
-### 4.4 Complete Data Center Failure
-
-**Steps (assume multi-datacenter setup):**
-
-```text
-<!-- Code example in TEXT -->
-
-1. Monitor: Detect all instances/database in region down
-2. Alert: Page incident commander
-3. Failover:
-   a. Update DNS to point to secondary region
-   b. Promote secondary database (if replication lag acceptable)
-   c. OR: Route to standby region
-4. Verify: Monitor traffic, error rates
-5. Recovery:
-   a. Restore primary region
-   b. Rebuild replication to primary
-   c. Failback (if needed)
-6. Monitor: Watch for issues
-
-Total time: 2-5 minutes (automatic DNS) + manual investigation
-Human intervention: Required
-Data loss: Depends on replication lag (typically < 1 second)
-```text
-<!-- Code example in TEXT -->
+Multi-region, replica promotion, and DNS failover are deployment topologies you build
+and operate around FraiseQL; FraiseQL does not perform them. RPO in those scenarios
+depends on your replication configuration.
 
 ---
 
 ## 5. Resilience Design Patterns
 
-### 5.1 Circuit Breaker Pattern
+These are patterns to apply in your deployment and client code. FraiseQL does not
+implement them for you unless noted.
 
-Used for subgraph/external service calls:
+### 5.1 Retry with Exponential Backoff
 
-```text
-<!-- Code example in TEXT -->
-State 1: CLOSED (normal)
-  - Requests pass through
-  - If error rate > threshold: transition to OPEN
-
-State 2: OPEN (circuit broken)
-  - Requests fail immediately (no wait)
-  - Error: E_FED_SUBGRAPH_UNAVAILABLE
-  - Duration: 30 seconds
-
-State 3: HALF_OPEN (testing recovery)
-  - Allow 1 request through
-  - If succeeds: transition to CLOSED
-  - If fails: transition back to OPEN
-
-Example:
-  Error rate: 50% failures
-  Threshold: 10% failures
-  → Transition to OPEN
-  → Requests fail immediately
-  → 30s later: Try 1 request (HALF_OPEN)
-  → Succeeds: Transition to CLOSED, resume normal
-```text
-<!-- Code example in TEXT -->
-
-### 5.2 Bulkhead Pattern
-
-Isolate resources to prevent cascading failure:
+For transient failures (connection drops, deadlocks, statement timeouts), clients
+should retry with increasing, jittered delays:
 
 ```text
-<!-- Code example in TEXT -->
-Pool 1: Queries (max 100 concurrent)
-Pool 2: Mutations (max 50 concurrent)
-Pool 3: Subscriptions (max 1000 concurrent)
+Attempt 1: immediate
+Attempt 2: ~1s  + jitter
+Attempt 3: ~2s  + jitter
+Attempt 4: ~4s  + jitter
+Attempt 5: ~8s  + jitter
 
-If Pool 1 exhausted:
-  - Queries queue or fail
-  - Mutations: Still work (own pool)
-  - Subscriptions: Still work (own pool)
+Jitter avoids a thundering herd; bound the total wait so clients fail in
+reasonable time. Only retry operations that are safe to repeat (idempotent
+reads, or mutations you can deduplicate).
+```
 
-Prevents: One type of query from starving others
-```text
-<!-- Code example in TEXT -->
+### 5.2 Bounded Pools and Timeouts
 
-### 5.3 Retry with Exponential Backoff
-
-For transient failures:
+Keep failures contained:
 
 ```text
-<!-- Code example in TEXT -->
-Attempt 1: Immediate
-Attempt 2: Wait 1s + random(0-100ms)
-Attempt 3: Wait 2s + random(0-100ms)
-Attempt 4: Wait 4s + random(0-100ms)
-Attempt 5: Wait 8s + random(0-100ms)
-Max attempts: 5 (total wait: ~15 seconds)
+- Bound the connection pool (max_size) so a spike cannot open unbounded
+  connections against PostgreSQL.
+- Set statement_timeout so a runaway query cannot hold a connection forever.
+- Set request/keep-alive timeouts so abandoned clients release resources.
+```
 
-Benefits:
-  - Avoids thundering herd
-  - Gives system time to recover
-  - Client waits reasonably (15s)
-  - Success rate increases 90% → 99%+
-```text
-<!-- Code example in TEXT -->
+### 5.3 Graceful Degradation
 
-### 5.4 Graceful Degradation
-
-Accept reduced functionality under load:
+Prefer reduced functionality over a hard outage:
 
 ```text
-<!-- Code example in TEXT -->
-Normal load:
-  - All features: queries, mutations, subscriptions
-  - Latency: < 500ms p99
-
-High load (>80% capacity):
-  - Disable: Subscriptions (keep for emergency)
-  - Keep: Queries, mutations, auth
-  - Latency: < 2s p99
-
-Critical load (>95% capacity):
-  - Disable: Mutations, subscriptions
-  - Keep: Read queries only
-  - Latency: < 5s p99
-
-Extreme load (>99% capacity):
-  - Disable: Most features
-  - Keep: Critical read queries only
-  - Return: 503 Service Unavailable for others
-
-Benefit: Service remains available, not crashed
-```text
-<!-- Code example in TEXT -->
+- When the cache is down, serve from the database (slower, still correct).
+- Under heavy load, shed expensive operations before essential reads.
+- Return clear, retryable errors rather than hanging the client.
+```
 
 ---
 
-## 6. Failure Testing (Chaos Engineering)
+## 6. Failure Testing
 
-### 6.1 Injected Failures
-
-Use to test resilience:
-
-```text
-<!-- Code example in TEXT -->
-# Kill 1 instance (of 3)
-chaos kill -pod 1
-
-Expected:
-  - Requests to pod 1: Fail (< 1s)
-  - Requests reroute to pods 2-3
-  - No cascading failure
-  - System still healthy
-
-# Increase latency on database
-chaos network-delay database +500ms
-
-Expected:
-  - Query latency increases
-  - Queries eventually timeout (after 30s)
-  - Retries backoff
-  - System recovers when latency drops
-
-# Fill cache
-chaos fill-cache 95%
-
-Expected:
-  - Cache evicts LRU entries
-  - More cache misses
-  - Database load increases
-  - Queries slower but not failing
-
-# Drop 10% of packets
-chaos drop-packets 10%
-
-Expected:
-  - Some requests fail
-  - Retry logic engages
-  - Eventually succeed (after retries)
-  - End-to-end latency increases
-```text
-<!-- Code example in TEXT -->
-
-### 6.2 Failure Acceptance Criteria
-
-After injected failure:
+Validate these failure modes against a real deployment. FraiseQL's repository includes
+chaos and regression tests under `tests/chaos/` and `tests/regression/`; complement
+them with infrastructure-level fault injection in your environment:
 
 ```text
-<!-- Code example in TEXT -->
-✅ PASS if:
-  - No data corruption
-  - No data loss (for writes)
-  - Requests eventually succeed (or fail gracefully)
-  - System recovers when failure removed
-  - Alerts triggered appropriately
-  - No cascading failures to other systems
+- Kill a FraiseQL process              → confirm the supervisor restarts it,
+                                          and (if clustered) traffic continues.
+- Restart PostgreSQL                    → confirm the pool reconnects and
+                                          queries resume; no committed-write loss.
+- Add latency to the database           → confirm statement_timeout fires and
+                                          clients receive retryable errors.
+- Take the cache offline                → confirm reads fall back to the database.
+- Saturate the connection pool          → confirm requests wait, then fail with a
+                                          retryable error rather than hanging forever.
+```
 
-❌ FAIL if:
-  - Data corrupted
-  - Data lost
-  - System deadlocked
-  - Cascading failure
-  - No alerts triggered
-  - Recovery time > RTO target
+**Acceptance criteria after an injected failure:**
+
 ```text
-<!-- Code example in TEXT -->
+PASS if:
+  - No data corruption.
+  - No loss of committed writes.
+  - Requests eventually succeed, or fail with a clear, retryable error.
+  - The system recovers once the fault is removed.
+  - Alerts fire appropriately.
+
+FAIL if:
+  - Data is corrupted or committed writes are lost.
+  - The process hangs instead of returning an error.
+  - Recovery does not happen after the fault is removed.
+```
 
 ---
 
 ## 7. SLO and Error Budgets
 
-### 7.1 Availability SLO
+Service-level objectives are properties of your deployment, not guarantees FraiseQL
+makes. Define them against the behaviour you can observe and control.
+
+### 7.1 Availability SLO (example)
 
 ```text
-<!-- Code example in TEXT -->
-Target: 99.9% availability (three nines)
-Definition: Successfully responding to queries
-Time unit: Calendar month
-Calculation: Uptime / Total time
+Target:      99.9% availability over a calendar month
+Definition:  fraction of requests answered successfully (or with a clean,
+             retryable error) within the latency SLO
+Budget:      99.9% of ~30 days ≈ 43 minutes of allowed downtime per month
+```
 
-99.9% of 30 days = 43 minutes downtime/month
-
-Within budget:
-  - 30 minutes unplanned outage ✅
-  - 13 minutes planned maintenance ✅
-
-Over budget:
-  - 50 minutes unplanned outage ❌
-  - Budget exhausted, any additional downtime violates SLO
-```text
-<!-- Code example in TEXT -->
-
-### 7.2 Error Budget Usage
+### 7.2 Error Budget (example)
 
 ```text
-<!-- Code example in TEXT -->
-Month: January (31 days, 44,640 minutes)
-Budget: 43.2 minutes (99.9% SLO)
+Monthly budget (99.9%):  ~43 minutes
+Each incident consumes part of the budget; when it is exhausted, prioritise
+reliability work over new features until the budget recovers.
+```
 
-Week 1: 5 min downtime → 38.2 min remaining
-Week 2: 10 min downtime → 28.2 min remaining
-Week 3: 8 min downtime → 20.2 min remaining
-Week 4: 12 min downtime → 8.2 min remaining
+Tie SLOs to your monitoring. See
+[Performance Characteristics](../../foundation/12-performance-characteristics.md) for
+latency expectations to base your SLOs on.
 
-If Week 4 has additional 2 min outage:
-  - Error budget exhausted (10.2 > 8.2)
-  - SLO violated for January
-  - Requires incident review, not just bug fix
-```text
-<!-- Code example in TEXT -->
+---
+
+## 8. Subscriptions and Failure
+
+FraiseQL subscriptions are delivered over a WebSocket and are scoped to a single
+connection on a single process. They are **not** backed by a distributed event system,
+and FraiseQL does not coordinate subscription state across processes.
+
+**WebSocket connection lost** — network interruption, client disconnect, or the
+process the connection lived on restarting:
+
+- That connection's active subscriptions end. Any in-flight delivery stops.
+- The client should reconnect and resubscribe. On a multi-process deployment the
+  reconnect may land on a different process; that is transparent to the client because
+  each subscription is independent and re-established from scratch.
+- Events that occur while the client is disconnected are not replayed unless your
+  underlying source captures them (for example, a change-log table the subscription
+  reads from on reconnect). FraiseQL does not buffer per-client event history on your
+  behalf.
+
+**Process restart** drops every subscription on that process; affected clients
+reconnect and resubscribe. There is no automatic migration of subscription state
+between processes.
+
+See [Subscriptions](../realtime/subscriptions.md) for the subscription model and
+[Versioning Strategy](./versioning-strategy.md) for how schema changes affect
+long-lived clients.
 
 ---
 
 ## Summary
 
-**FraiseQL failure characteristics:**
+A FraiseQL v1 deployment fails safely:
 
-✅ **Fast detection:** Failures detected < 5 seconds
-✅ **Automatic recovery:** Most failures handled automatically
-✅ **Graceful degradation:** Reduced functionality, not complete outage
-✅ **Data safety:** No data loss for committed writes
-✅ **Clear error codes:** Clients know what failed and why
-✅ **Observable:** Traceability via trace IDs and structured logs
+- **Durable writes:** committed mutations survive process and database restarts;
+  in-flight mutations are atomic — they commit or roll back.
+- **Self-healing connections:** the `psycopg_pool` connection pool discards broken
+  connections and reconnects automatically.
+- **Graceful cache fallback:** an unavailable cache costs latency, not correctness.
+- **Clear errors:** failures surface as structured, classifiable errors so clients know
+  whether to retry.
 
-**Key RTO targets:**
+What FraiseQL does **not** do for you: it does not provide automatic failover,
+read-replica routing, multi-instance coordination, or distributed subscriptions.
+Clustering, load balancing, PostgreSQL high availability, and multi-region failover are
+deployment topologies you operate around FraiseQL.
 
-- Single instance crash: 30-60 seconds
-- Database connection: < 10 seconds
-- Cache failure: < 5 seconds
-- Database unavailable: 5-30 minutes (operational)
-- Complete region failure: 2-5 minutes (DNS + failover)
-
-**Golden rule:** FraiseQL fails safely, recovers gracefully, and provides sufficient observability to debug issues.
-
----
-
-*End of Failure Modes and Recovery*
+**Golden rule:** FraiseQL fails safely, reconnects to PostgreSQL automatically, and
+surfaces enough detail to diagnose what happened — but durability, availability, and
+failover beyond a single process are properties of how you deploy it.

--- a/docs/architecture/reliability/versioning-strategy.md
+++ b/docs/architecture/reliability/versioning-strategy.md
@@ -1,17 +1,14 @@
-<!-- Skip to main content -->
 ---
-
 title: FraiseQL Versioning Strategy
-description: 1. [Executive Summary](#executive-summary)
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+description: How FraiseQL v1 versions its Python package and your runtime-generated GraphQL schema.
+keywords: ["versioning", "semver", "deprecation", "schema-evolution", "backward-compatibility"]
 tags: ["documentation", "reference"]
 ---
 
 # FraiseQL Versioning Strategy
 
-**Date:** January 2026
-**Status:** Complete System Specification
-**Audience:** Framework architects, platform engineers, enterprise operators, SDK maintainers
+**Status:** Reference
+**Audience:** Application developers, platform engineers, operators
 
 ## Table of Contents
 
@@ -20,85 +17,90 @@ tags: ["documentation", "reference"]
 3. [Breaking Change Policy](#2-breaking-change-policy)
 4. [Deprecation Policy](#3-deprecation-policy)
 5. [Schema Versioning](#4-schema-versioning)
-6. [Query API Versioning](#5-query-api-versioning)
+6. [GraphQL API Versioning](#5-graphql-api-versioning)
 7. [Error Code Versioning](#6-error-code-versioning)
-8. [Multi-Version Runtime Support](#7-multi-version-runtime-support)
-9. [MAJOR Version Upgrade Path](#8-major-version-upgrade-path)
+8. [Running Multiple Versions](#7-running-multiple-versions)
+9. [Upgrade Path](#8-upgrade-path)
 10. [Client Versioning & Compatibility](#9-client-versioning--compatibility)
-11. [Compiler Version Management](#10-compiler-version-management)
-12. [Ecosystem Versioning](#11-ecosystem-versioning)
-13. [Version Communication](#12-version-communication)
-14. [Support & Long-Term Maintenance](#13-support-long-term-maintenance)
-15. [Version Decision Tree](#14-version-decision-tree)
-16. [Versioning Best Practices](#15-versioning-best-practices)
-17. [Examples](#16-examples)
-18. [Summary & Quick Reference](#17-summary--quick-reference)
-19. [Appendix: Version Checking](#18-appendix-version-checking)
+11. [Version Communication](#10-version-communication)
+12. [Support & Long-Term Maintenance](#11-support--long-term-maintenance)
+13. [Version Decision Tree](#12-version-decision-tree)
+14. [Versioning Best Practices](#13-versioning-best-practices)
+15. [Examples](#14-examples)
+16. [Summary & Quick Reference](#15-summary--quick-reference)
+17. [Appendix: Version Checking](#16-appendix-version-checking)
 
 ---
 
 ## Executive Summary
 
-FraiseQL uses **semantic versioning (MAJOR.MINOR.PATCH)** with explicit breaking change policies to balance innovation with stability. The versioning strategy covers five distinct versioning dimensions:
+FraiseQL uses **semantic versioning (MAJOR.MINOR.PATCH)** with explicit breaking-change
+policies to balance new features with stability. Versioning applies to two distinct things:
 
-1. **Framework versioning** (FraiseQL runtime version)
-2. **Schema versioning** (user-defined schema evolution)
-3. **Compiled schema versioning** (internal IR evolution)
-4. **Query API versioning** (GraphQL schema evolution)
-5. **Error code versioning** (stable error taxonomy)
+1. **The FraiseQL Python package** — published on PyPI as `fraiseql`, versioned with SemVer.
+   The current release is `1.23.11`.
+2. **Your GraphQL schema** — generated at application startup from your `@fraiseql.type`,
+   `@fraiseql.query`, and `@fraiseql.mutation` decorators. This is *your* contract with
+   *your* clients, and you evolve it on your own cadence.
 
-**Core principle**: FraiseQL commits to **3-year stability windows** for MAJOR versions. Framework versions can change freely; user schemas are backward-compatible within a MAJOR version.
+These two are independent. Upgrading the FraiseQL package (a backward-compatible MINOR or
+PATCH release) does not change the GraphQL schema your clients see. Likewise, evolving your
+own schema does not require a new FraiseQL release.
+
+**Core principle**: FraiseQL is a *runtime* framework. There is no compiled schema, no build
+artifact, and no schema file to version. Your schema is assembled in memory at startup from
+your Python code, every time the app boots. Backward-compatibility decisions are therefore
+about API surface — package APIs on one side, GraphQL field/type shape on the other.
 
 ---
 
 ## 1. Semantic Versioning (SemVer 2.0.0)
 
-FraiseQL adheres to semantic versioning with three-component version numbers:
+The FraiseQL package follows semantic versioning with three-component version numbers.
 
 ### 1.1 Version Format
 
 ```text
-<!-- Code example in TEXT -->
 MAJOR.MINOR.PATCH
   |      |      |
   |      |      └── Bug fixes and patches (no breaking changes)
   |      └────────── Features and improvements (backward-compatible)
   └──────────────── Breaking changes (incompatible with prior MAJOR version)
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 1.2 Version Examples
 
 ```text
-<!-- Code example in TEXT -->
+1.0.0    → First stable release of the 1.x line
+1.1.0    → Add a new feature, backward-compatible with 1.0.x
+1.1.1    → Bug fix, backward-compatible with 1.1.0
+1.23.11  → Current release: many backward-compatible features and fixes since 1.0.0
+```
 
-2.0.0   → Framework v2, first release
-2.1.0   → Add new feature, backward-compatible with 2.0.x
-2.1.1   → Bug fix, backward-compatible with 2.1.0
-3.0.0   → Incompatible changes, requires migration from 2.x
-```text
-<!-- Code example in TEXT -->
+Within the entire `1.x` line, your code that imports and uses FraiseQL keeps working.
+Features are added in MINOR releases; bugs are fixed in PATCH releases; neither breaks you.
 
 ### 1.3 Pre-release Versions
 
-For beta testing and early access:
+For beta testing and early access, FraiseQL may publish pre-release versions:
 
 ```text
-<!-- Code example in TEXT -->
-
-2.0.0-beta.1    → Beta version, may have breaking changes
-2.0.0-rc.1      → Release candidate, likely stable
-2.0.0-rc.2      → Second RC before GA
-2.0.0            → General Availability (stable)
-```text
-<!-- Code example in TEXT -->
+1.24.0-beta.1    → Beta version, may still change before release
+1.24.0-rc.1      → Release candidate, likely stable
+1.24.0-rc.2      → Second RC before general availability
+1.24.0           → General availability (stable)
+```
 
 **Stability commitment:**
 
-- ❌ **Never** use pre-release versions in production
-- ✅ **Can** use for testing and feedback
-- ✅ **Will** provide migration guide before GA
-- ✅ **Will** announce breaking changes in pre-release changelog
+- Never pin a pre-release version in production.
+- Pre-releases are for testing and feedback.
+- A migration note ships before any release that changes public behavior.
+- Notable changes are announced in the changelog before they go stable.
+
+> **Note on "v2".** FraiseQL v2 is a *separate product* in a separate repository, not a future
+> major release of this package. This document covers FraiseQL v1 only. There is no
+> v1 → v2 migration path described here; the two are independent codebases.
 
 ---
 
@@ -106,206 +108,165 @@ For beta testing and early access:
 
 ### 2.1 What Constitutes a Breaking Change
 
-A breaking change is **any modification that requires code changes in user schemas or client applications**. These changes trigger a MAJOR version bump.
+A breaking change is **any modification that requires code changes from people who use
+FraiseQL or who call your GraphQL API**. For the package, breaking changes trigger a MAJOR
+version bump. For your GraphQL schema, the same principles tell you whether a schema edit
+will break your clients.
 
 #### 2.1.1 GraphQL Schema Breaking Changes
 
-**Removals** (require MAJOR bump):
+These are decisions *you* make when you edit your decorated types and resolvers. They break
+existing clients and should be treated like a major change to your API.
+
+**Removals** (break clients):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ BREAKING: Remove a field
-# 1.x
+# BREAKING: Remove a field
+# before
 type User {
   id: ID!
   name: String!
-  email: String   # Removing this field
+  email: String   # removing this field
 }
 
-# Would require 2.0.0
-```text
-<!-- Code example in TEXT -->
+# after — clients that selected `email` now fail
+type User {
+  id: ID!
+  name: String!
+}
+```
 
-**Behavioral changes** (require MAJOR bump):
+**Nullability and type changes** (break clients):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ BREAKING: Change return type
-# 1.x
+# BREAKING: Change return type / nullability
+# before
 type Query {
-  user(id: ID!): User
+  user(id: ID!): User      # may return null
 }
 
-# 2.x would return User | null → User! (non-null)
-# Clients that didn't handle null must update code
-```text
-<!-- Code example in TEXT -->
+# after returns User! (non-null)
+# Clients that handled null must change their code
+```
 
-**Argument changes** (require MAJOR bump):
+**Argument changes** (break clients):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ BREAKING: Add required argument
-# 1.x
+# BREAKING: Add a required argument
+# before
 type Query {
   posts: [Post!]!
 }
 
-# 2.x
+# after
 type Query {
-  posts(limit: Int!): [Post!]!  # New required argument
+  posts(limit: Int!): [Post!]!   # new required argument
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Input type changes** (require MAJOR bump):
+**Input type changes** (break clients):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ BREAKING: Add required field to input
-# 1.x
+# BREAKING: Add a required field to an input
+# before
 input CreateUserInput {
   name: String!
   email: String
 }
 
-# 2.x
+# after
 input CreateUserInput {
   name: String!
-  email: String!  # Now required
-  roles: [String!]!  # New required field
+  email: String!      # now required
+  roles: [String!]!   # new required field
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Enum value removal** (require MAJOR bump):
+**Enum value removal** (break clients):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ BREAKING: Remove enum value
-# 1.x
+# BREAKING: Remove an enum value
+# before
 enum Role {
   ADMIN
   USER
   GUEST
 }
 
-# 2.x removes GUEST
-```text
-<!-- Code example in TEXT -->
+# after removes GUEST — clients that send or match GUEST break
+```
 
-#### 2.1.2 Operator Changes Breaking Changes
+#### 2.1.2 Filter Operator Changes
 
-**Removing operators** (require MAJOR bump):
+FraiseQL exposes a set of filter operators on query arguments. Removing or re-defining one is
+a breaking change for clients that rely on it.
 
-```python
-<!-- Code example in Python -->
-# ❌ BREAKING: Remove an operator
-# 1.x supports: eq, ne, gt, gte, lt, lte, in, nin, contains, regex
-# 2.x removes: regex (for performance reasons)
-# Queries using 'regex' operator fail
-
-# Users must rewrite queries using contains or migrate to database functions
-```text
-<!-- Code example in TEXT -->
-
-**Changing operator semantics** (require MAJOR bump):
+**Removing an operator** (breaks clients):
 
 ```python
-<!-- Code example in Python -->
-# ❌ BREAKING: Change operator behavior
-# 1.x: in operator is case-sensitive
-# 2.x: in operator is case-insensitive (SQL ILIKE)
-# Queries that relied on case-sensitivity break
-```text
-<!-- Code example in TEXT -->
+# BREAKING: Remove a supported operator
+# Queries that use the removed operator fail. Clients must rewrite
+# those queries (for example, switch from `regex` to `contains`).
+```
 
-#### 2.1.3 Authorization Changes Breaking Changes
-
-**Removing authorization rules** (require MAJOR bump):
+**Changing operator semantics** (breaks clients):
 
 ```python
-<!-- Code example in Python -->
-# ❌ BREAKING: Remove field-level masking
-# 1.x: User.ssn field masked for non-admins
-# 2.x: Remove masking (now exposed to everyone)
-# Security expectations break; clients may violate compliance
+# BREAKING: Change operator behaviour
+# Example: an `in` operator that was case-sensitive becomes case-insensitive.
+# Queries that relied on case-sensitivity now return different results.
+```
 
-# This is a MAJOR version change with security implications
-```text
-<!-- Code example in TEXT -->
+#### 2.1.3 Authorization Changes
 
-**Adding required authorization rules** (require MAJOR bump):
+**Removing an authorization rule** (breaking, with security impact):
 
 ```python
-<!-- Code example in Python -->
-# ❌ BREAKING: Add row-level security that filters results
-# 1.x: Query returns all posts
-# 2.x: Only return posts by current user
-# Queries that expected all posts now get fewer results
-```text
-<!-- Code example in TEXT -->
+# BREAKING: Remove field-level masking
+# Before: User.ssn masked for non-admins.
+# After: masking removed (now exposed to everyone).
+# Security expectations break; this is a serious change.
+```
 
-#### 2.1.4 Error Code Changes Breaking Changes
-
-**Removing error codes** (require MAJOR bump):
+**Adding a row-level filter that changes results** (breaking):
 
 ```python
-<!-- Code example in Python -->
-# ❌ BREAKING: Error code E_VALIDATION_EMAIL_001 removed
-# 1.x: query fails with E_VALIDATION_EMAIL_001
-# 2.x: Different error code or different error format
-# Client error handling breaks
-```text
-<!-- Code example in TEXT -->
+# BREAKING: Add row-level security that filters results
+# Before: query returns all posts.
+# After: only the current user's posts are returned.
+# Clients that expected all posts now get fewer results.
+```
 
-**Changing error code semantics** (require MAJOR bump):
+#### 2.1.4 Error Code Changes
+
+**Removing an error code** (breaks clients):
 
 ```python
-<!-- Code example in Python -->
-# ❌ BREAKING: Change what E_DB_POSTGRES_DEADLOCK_303 means
-# 1.x: Means database deadlock (retry with exponential backoff)
-# 2.x: Now means connection timeout (retry with circuit breaker)
-# Client retry logic becomes ineffective
-```text
-<!-- Code example in TEXT -->
+# BREAKING: An error code your clients handle is removed.
+# Before: a request fails with E_VALIDATION_EMAIL_001.
+# After: a different code or format is returned.
+# Client error handling breaks.
+```
 
-**Note**: Error codes are part of the contract and **never** change within a MAJOR version.
+**Changing what an error code means** (breaks clients):
 
-#### 2.1.5 Compilation-Time Changes Breaking Changes
+```python
+# BREAKING: Re-define an error code.
+# Before: E_DB_DEADLOCK means "deadlock — retry with backoff".
+# After: the same code means "connection timeout".
+# Client retry logic becomes wrong.
+```
 
-**Changing compiled schema structure** (require MAJOR bump):
+**Note**: Treat your error codes as part of your API contract — they should not change
+meaning once clients depend on them.
 
-```text
-<!-- Code example in TEXT -->
-# ❌ BREAKING: Compiled schema JSON structure changes
-# 1.x CompiledSchema:
-{
-  "version": "2.0.0",
-  "types": {...},
-  "operations": {...}
-}
+#### 2.1.5 Type System Changes
 
-# 2.x CompiledSchema changes structure:
-{
-  "framework_version": "2.0.0",
-  "schema_version": 1,
-  "entities": {...},  # Renamed from "types"
-  "queries": {...}    # Renamed from "operations"
-}
-
-# Runtime cannot load 2.x schemas if built for 1.x framework
-```text
-<!-- Code example in TEXT -->
-
-#### 2.1.6 Type System Breaking Changes
-
-**Removing a custom scalar** (require MAJOR bump):
+**Removing a custom scalar** (breaks clients):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ BREAKING: Remove custom scalar
-# 1.x
+# BREAKING: Remove a custom scalar
+# before
 scalar DateTime
 scalar JSON
 type Event {
@@ -313,190 +274,152 @@ type Event {
   metadata: JSON
 }
 
-# 2.x removes DateTime scalar
-# Queries fail; schemas using DateTime cannot compile
-```text
-<!-- Code example in TEXT -->
+# after removes DateTime — clients that select `timestamp` break
+```
 
-**Changing scalar serialization** (require MAJOR bump):
+**Changing scalar serialization** (breaks clients):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ BREAKING: Change how UUID is serialized
-# 1.x: UUID serialized as "f47ac10b-58cc-4372-a567-0e02b2c3d479"
-# 2.x: UUID serialized as "f47ac10b58cc4372a5670e02b2c3d479" (no hyphens)
-# Clients parsing UUID strings break
-```text
-<!-- Code example in TEXT -->
+# BREAKING: Change how a value is serialized
+# Before: UUID serialized as "f47ac10b-58cc-4372-a567-0e02b2c3d479".
+# After: UUID serialized without hyphens.
+# Clients that parse the string representation break.
+```
 
 ### 2.2 Non-Breaking Changes
 
-These changes are safe within the same MAJOR version:
+These changes are safe and do not break existing clients.
 
-#### 2.2.1 Safe Additions (MINOR version bump)
+#### 2.2.1 Safe Additions
 
-**Adding new fields** (backward-compatible):
+**Adding new fields** (additive, safe):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ✅ SAFE: Add optional field
-# 1.x
+# SAFE: Add optional fields
+# before
 type User {
   id: ID!
   name: String!
   email: String
 }
 
-# 1.1 (MINOR bump)
+# after
 type User {
   id: ID!
   name: String!
   email: String
-  phone: String           # New optional field
-  verified_at: DateTime   # New optional field
+  phone: String           # new optional field
+  verifiedAt: DateTime    # new optional field
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Adding new types** (backward-compatible):
-
-```graphql
-<!-- Code example in GraphQL -->
-# ✅ SAFE: Add new type and query
-# 1.x types: User, Post, Comment
-
-# 1.1 adds: Product type and products query
-# Existing clients unaffected
-```text
-<!-- Code example in TEXT -->
-
-**Adding new enum values** (backward-compatible):
+**Adding new types** (additive, safe):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ✅ SAFE: Add enum value (if clients ignore unknown values)
-# 1.x
+# SAFE: Add a new type and query
+# Existing types (User, Post, Comment) are untouched.
+# A new Product type and `products` query are added.
+# Existing clients are unaffected.
+```
+
+**Adding new enum values** (safe when clients ignore unknown values):
+
+```graphql
+# SAFE: Add an enum value
+# before
 enum Role {
   ADMIN
   USER
 }
 
-# 1.1
+# after
 enum Role {
   ADMIN
   USER
-  SUPER_ADMIN  # New enum value
+  SUPER_ADMIN   # new value
 }
 
-# Clients that don't use SUPER_ADMIN are unaffected
-```text
-<!-- Code example in TEXT -->
+# Clients that do not use SUPER_ADMIN are unaffected.
+```
 
-**Adding optional arguments** (backward-compatible):
+**Adding optional arguments** (additive, safe):
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ✅ SAFE: Add optional argument
-# 1.x
+# SAFE: Add optional arguments
+# before
 type Query {
   posts: [Post!]!
 }
 
-# 1.1
+# after
 type Query {
   posts(limit: Int, offset: Int): [Post!]!
 }
 
-# Existing queries without arguments still work
-```text
-<!-- Code example in TEXT -->
+# Existing queries with no arguments still work.
+```
 
-**Adding new operators** (backward-compatible):
-
-```python
-<!-- Code example in Python -->
-# ✅ SAFE: Add new operator
-# 1.x supports: eq, ne, gt, gte, lt, lte, in, nin, contains
-
-# 1.1 adds: startsWith, endsWith, regex
-# Existing queries work unchanged
-```text
-<!-- Code example in TEXT -->
-
-**Adding field-level masking** (backward-compatible):
+**Adding a new filter operator** (additive, safe):
 
 ```python
-<!-- Code example in Python -->
-# ✅ SAFE: Add masking that previously wasn't masked (restricts data, not expands it)
-# 1.x: User.ssn visible to everyone
-# 1.1: User.ssn now masked for non-admins (returns null for regular users)
-# Admin clients still see ssn; regular clients see null (which is safe)
-```text
-<!-- Code example in TEXT -->
+# SAFE: Add a new operator.
+# Existing queries are unaffected; clients can opt into the new operator.
+```
 
-**Expanding authorization** (backward-compatible):
+**Adding field-level masking** (restricts data, safe):
 
 ```python
-<!-- Code example in Python -->
-# ✅ SAFE: Make row-level security more restrictive (fewer results is safe)
-# 1.x: Query returns posts from all users
-# 1.1: Query now only returns current user's posts
-# Results are filtered but authorization is stricter (more secure)
-```text
-<!-- Code example in TEXT -->
+# SAFE: Mask a field that was previously visible.
+# Before: User.ssn visible to everyone.
+# After: User.ssn masked for non-admins (returns null for regular users).
+# Admin clients still see it; regular clients see null, which is safe.
+```
 
-**Adding new error codes** (backward-compatible):
+**Making authorization stricter** (fewer results, safe):
 
 ```python
-<!-- Code example in Python -->
-# ✅ SAFE: Add new error codes (clients ignore codes they don't recognize)
-# 1.x error codes: E_VALIDATION_*, E_AUTH_*, E_DB_*
-# 1.1 adds: E_RATE_LIMIT_* (new category)
-# Existing error handling still works; clients can add handling for new codes
-```text
-<!-- Code example in TEXT -->
+# SAFE: Make row-level security more restrictive.
+# Before: query returns posts from all users.
+# After: query returns only the current user's posts.
+# Fewer results, stricter access — more secure, not less.
+```
 
-#### 2.2.2 Safe Modifications (PATCH version bump)
+**Adding new error codes** (safe when clients ignore unknown codes):
 
-**Performance improvements** (patch):
+```python
+# SAFE: Add a new error code category.
+# Existing handling still works; clients can add handling for new codes.
+```
 
-```text
-<!-- Code example in TEXT -->
-# ✅ SAFE: Query execution faster, same semantics
-# 1.0.0 → 1.0.1: Database query optimized from 100ms to 50ms
-# Behavior unchanged; only performance changes
-```text
-<!-- Code example in TEXT -->
+#### 2.2.2 Safe Modifications (PATCH-level)
 
-**Bug fixes** (patch):
+**Performance improvements** (safe):
 
 ```text
-<!-- Code example in TEXT -->
-# ✅ SAFE: Fix incorrect behavior to match specification
-# 1.0.0 had a bug: "in" operator case-sensitive despite spec saying case-insensitive
-# 1.0.1: Fix bug, "in" operator now case-insensitive per spec
-# Note: This is a bug fix (behavior was wrong), not a breaking change
-```text
-<!-- Code example in TEXT -->
+SAFE: A query runs faster with identical results.
+Behaviour unchanged; only performance improves.
+```
 
-**Documentation updates** (patch):
+**Bug fixes** (safe):
 
 ```text
-<!-- Code example in TEXT -->
-# ✅ SAFE: Documentation corrections, no code changes
-# 1.0.0 → 1.0.1: Update docs for clarity
-```text
-<!-- Code example in TEXT -->
+SAFE: Fix incorrect behaviour to match the documented specification.
+Example: the `in` operator was wrongly case-sensitive; it is fixed to be
+case-insensitive per spec. This is a bug fix, not a breaking change.
+```
 
-**Internal refactoring** (patch):
+**Documentation updates** (safe):
 
 ```text
-<!-- Code example in TEXT -->
-# ✅ SAFE: Rewrite internals without changing external behavior
-# 1.0.0 → 1.0.1: Rewrite Rust pipeline for performance
-# Compiled schema output identical; only internals change
+SAFE: Documentation corrections with no code changes.
+```
+
+**Internal refactoring** (safe):
+
 ```text
-<!-- Code example in TEXT -->
+SAFE: Rewrite internals (including the optional Rust hot path in
+fraiseql_rs) without changing externally observable behaviour.
+```
 
 ---
 
@@ -504,303 +427,206 @@ type Query {
 
 ### 3.1 Deprecation Lifecycle
 
-FraiseQL follows a **three-phase deprecation lifecycle** before removal:
+A clean deprecation has three phases before anything is removed:
 
 ```text
-<!-- Code example in TEXT -->
-ANNOUNCEMENT (Minor Version N)
+ANNOUNCEMENT (a MINOR release)
      ↓
-DEPRECATION (Minor Versions N to N+3)
+DEPRECATION  (kept working across subsequent MINOR releases, with warnings)
      ↓
-REMOVAL (Major Version M+1)
+REMOVAL      (the next MAJOR release)
+```
+
+Nothing that clients or users depend on is removed without first going through an
+announced deprecation period.
+
+### 3.2 Deprecation Timeline
+
+Give people enough notice. A practical pattern within the `1.x` line:
+
 ```text
-<!-- Code example in TEXT -->
-
-### 3.2 Deprecation Timeline (3-Year Stability Window)
-
-FraiseQL commits to a **3-year support window** for each MAJOR version:
-
-```text
-<!-- Code example in TEXT -->
-v2.0.0 Released (Year 0)
-       ├─ v2.1.0 (Year 0, Q2) - Add new feature, announce deprecation
-       ├─ v2.2.0 (Year 0, Q4) - Feature fully deprecated
-       ├─ v2.3.0 (Year 1, Q2) - Still deprecated, but working
-       ├─ v2.4.0 (Year 1, Q4) - Still deprecated, but working
-       ├─ v2.5.0 (Year 2, Q2) - Last MINOR version of v2.x
-       ├─ v2.6.0 (Year 2, Q4) - Still working
-       └─ v2.x.x (Year 3)      - Last day of v2 support (Dec 31, Year 2)
-
-v3.0.0 Released (Year 3)
-       └─ v2.x.x no longer supported (Jan 1, Year 3)
-```text
-<!-- Code example in TEXT -->
+1.20.0  → Announce deprecation of a feature; it still works, warnings shown
+1.21.0  → Still works, warnings continue
+1.22.0  → Still works, warnings continue
+1.23.0  → Still works, warnings continue
+2.0.0   → Feature removed (separate MAJOR release)
+```
 
 ### 3.3 Deprecation Announcement Format
 
-When a feature is deprecated, the changelog includes:
+When something is deprecated, the changelog should state:
 
 ```markdown
-<!-- Code example in MARKDOWN -->
-### v2.1.0 (Deprecation Announcement)
+### Deprecated
 
-#### Deprecated
+- **`regex` filter operator**: Use the `contains` operator instead.
+  - **Reason**: Regex carries performance overhead; most cases are better served by `contains`.
+  - **Migration**: Replace `{name: {regex: "/pattern/"}}` with `{name: {contains: "pattern"}}`.
+  - **Timeline**: Deprecated in this MINOR release; removal in the next MAJOR release.
+```
 
-- **`regex` operator**: Use `contains` operator instead. Will be removed in v2.5.0.
-  - **Reason**: Regex performance overhead; most use cases better served by `contains`
-  - **Migration**: Replace `{name: {regex: "/pattern/"}}` with `{name: {contains: "pattern"}}`
-  - **Timeline**: Deprecated v2.1, removal in v3.0 (3-year window)
-  - **Help**: See migration guide: https://docs.FraiseQL.io/migration/v2.1-regex-deprecation
+### 3.4 Deprecation Warning at Runtime
 
-- **Field-level masking via `@mask` decorator**: Use row-level security via `@authorize` instead.
-  - **Reason**: @authorize more expressive; @mask conflates field-level with row-level
-  - **Timeline**: Deprecated v2.1, removal in v3.0
-  - **Help**: See migration guide: https://docs.FraiseQL.io/migration/v2.1-mask-deprecation
-```text
-<!-- Code example in TEXT -->
-
-### 3.4 Deprecation Warning in Runtime
-
-When deprecated features are used:
+When a deprecated feature is used, the GraphQL response can carry a warning in `extensions`:
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Query uses deprecated regex operator
+# Query uses a deprecated filter operator
 query GetPosts {
   posts(where: { title: { regex: "/draft/" } }) {
     id
     title
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Response includes deprecation warning:**
+**Response includes a deprecation warning:**
 
 ```json
-<!-- Code example in JSON -->
 {
   "data": {
-    "posts": [...]
+    "posts": []
   },
   "extensions": {
     "deprecations": [
       {
-        "message": "Operator 'regex' is deprecated. Use 'contains' instead. Will be removed in v3.0.",
+        "message": "Operator 'regex' is deprecated. Use 'contains' instead.",
         "code": "W_DEPRECATED_OPERATOR_REGEX",
-        "removal_version": "3.0.0",
-        "migration_url": "https://docs.FraiseQL.io/migration/v2.1-regex-deprecation",
-        "location": {
-          "line": 2,
-          "column": 45
-        }
+        "location": { "line": 2, "column": 45 }
       }
     ]
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-### 3.5 Migration Guides
+### 3.5 Migration Guidance
 
-For each deprecation, FraiseQL provides:
+For each deprecation, communicate:
 
-1. **Why** — Business/technical reason for deprecation
-2. **Impact** — Which features/users affected
-3. **How to migrate** — Step-by-step migration instructions
-4. **Timeline** — When removed
-5. **Help** — Link to detailed guide and support
-
-**Example migration guide structure:**
-
-```text
-<!-- Code example in TEXT -->
-docs/migration/
-├── v2.1-regex-deprecation.md
-├── v2.2-field-masking.md
-├── v2.3-custom-scalars.md
-└── v3.0-breaking-changes.md
-```text
-<!-- Code example in TEXT -->
+1. **Why** — the reason for the change.
+2. **Impact** — who and what is affected.
+3. **How to migrate** — step-by-step instructions.
+4. **Timeline** — when it is removed.
+5. **Help** — where to get support.
 
 ---
 
 ## 4. Schema Versioning
 
-### 4.1 User-Defined Schema Evolution
+### 4.1 Your Schema Is Generated at Runtime
 
-Users write schemas in Python (or YAML/TypeScript). These schemas are **versioned separately** from the FraiseQL framework.
-
-#### 4.1.1 User Schema Version Format
+You define your schema in Python with decorators. At application startup FraiseQL reads those
+decorators and builds an in-memory GraphQL schema — there is no compile step and no schema
+artifact on disk. Versioning your schema therefore means versioning *your Python code* and
+managing the compatibility of the GraphQL surface it produces.
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.version("1.0.0")
-@FraiseQL.type
+import fraiseql
+from fraiseql.types import ID
+
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
-    """Version 1.0.0 of User type"""
     id: ID
     name: str
-```text
-<!-- Code example in TEXT -->
+    email: str | None = None
+```
 
-**User schema versions are independent of framework version:**
+You decide your own schema version (often the same number as your application release). It is
+**independent of the FraiseQL package version**: a backward-compatible FraiseQL upgrade does
+not change the GraphQL schema your decorators produce.
 
-```text
-<!-- Code example in TEXT -->
-Framework v2.0.0
-└─ User schema v1.0.0
-   └─ Posts schema v2.5.0
-   └─ Comments schema v1.3.0
+### 4.2 Schema Backward Compatibility
 
-Framework v2.1.0 (backward-compatible)
-└─ User schema v1.0.0 (unchanged)
-   └─ Posts schema v2.5.0 (unchanged)
-   └─ Comments schema v1.3.0 (unchanged)
+Use the breaking vs. non-breaking rules from [Section 2](#2-breaking-change-policy) to keep
+schema edits safe.
 
-Framework v3.0.0 (breaking changes)
-└─ User schema v2.0.0 (may need updates for new framework)
-   └─ Posts schema v3.0.0
-   └─ Comments schema v2.0.0
-```text
-<!-- Code example in TEXT -->
-
-#### 4.1.2 Schema Backward Compatibility
-
-**Within the same framework MAJOR version:**
-
-FraiseQL enforces backward-compatible schema changes:
+**Backward-compatible edit (additive):**
 
 ```python
-<!-- Code example in Python -->
-# v1.0.0
-@FraiseQL.type
+import fraiseql
+from datetime import datetime
+from fraiseql.types import ID
+
+# v1 of your schema
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
     id: ID
     name: str
     email: str | None = None
 
-# v1.1.0 (backward-compatible with 1.0.0)
-@FraiseQL.type
+# v1.1 of your schema — additive, no clients break
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
     id: ID
     name: str
     email: str | None = None
-    phone: str | None = None       # New optional field
-    created_at: datetime | None = None  # New optional field
-```text
-<!-- Code example in TEXT -->
+    phone: str | None = None              # new optional field
+    created_at: datetime | None = None    # new optional field
+```
 
-**Between framework MAJOR versions:**
+When you add a field, also expose it in the corresponding `v_`/`tv_` PostgreSQL view's `data`
+JSONB so the resolver can return it.
 
-Schema changes may require migration:
+**Breaking schema edit (requires planning and client coordination):**
 
 ```python
-<!-- Code example in Python -->
-# Framework v2.x
-@FraiseQL.type
+import fraiseql
+from fraiseql.types import ID
+
+# before
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
     id: ID
     name: str
     email: str | None = None
 
-# Framework v3.0 (breaking changes)
-@FraiseQL.type
+# after — `email` is now required: this breaks clients that relied on null
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
     id: ID
     name: str
-    email: str  # Now required (breaking change in User schema)
-    profile: UserProfile  # New required nested type
-```text
-<!-- Code example in TEXT -->
+    email: str        # nullability change is breaking
+```
 
-### 4.2 Compiled Schema Versioning
+### 4.3 No Schema Artifact to Version
 
-The **compiled schema** (internal IR) is versioned separately from user schemas:
-
-```json
-<!-- Code example in JSON -->
-{
-  "framework_version": "2.0.0",
-  "compiled_schema_version": 1,
-  "types": {...},
-  "operations": {...},
-  "federation": {...},
-  "subscriptions": {...}
-}
-```text
-<!-- Code example in TEXT -->
-
-#### 4.2.1 Compiled Schema Format Evolution
-
-Changes to compiled schema JSON format trigger framework MAJOR version bump:
-
-```json
-<!-- Code example in JSON -->
-# Framework 2.x compiled schema
-{
-  "version": "2.0.0",
-  "types": {...}
-}
-
-# Framework 3.0 compiled schema (different format)
-{
-  "framework_version": "3.0.0",
-  "compiled_schema_version": 2,
-  "entities": {...}  # Renamed from "types"
-}
-```text
-<!-- Code example in TEXT -->
-
-**Impact**: Compiled schemas are not portable across major framework versions.
-
-#### 4.2.2 Runtime Schema Loading
-
-The runtime includes the compiled schema **at build time**:
+Because the schema is built at startup, there is nothing to store, distribute, or load:
 
 ```text
-<!-- Code example in TEXT -->
-User defines schema.py
+Your decorated Python modules
+       ↓  (at app startup, in memory)
+build_fraiseql_schema(...) / create_fraiseql_app(...)
        ↓
-Compiler compiles to compiled-schema.json
-       ↓
-Runtime packages compiled-schema.json with code
-       ↓
-Runtime starts with built-in schema (no compilation at runtime)
-```text
-<!-- Code example in TEXT -->
+graphql-core schema served over FastAPI
+```
 
-**Schema is immutable at runtime** — no runtime recompilation.
+There is no schema file, no intermediate representation, and no recompilation. If you change
+your Python code and restart the app, the new schema is built fresh. To compare schema
+versions, snapshot the GraphQL SDL via introspection and diff those snapshots.
 
 ---
 
-## 5. Query API Versioning
+## 5. GraphQL API Versioning
 
-### 5.1 GraphQL Schema Versioning
+### 5.1 The Schema Your Clients See
 
-The **GraphQL schema** (what clients see) is version-locked with the framework:
+The GraphQL schema your clients query against is exactly what your decorators produce at
+startup. You version it together with your application code:
 
 ```graphql
-<!-- Code example in GraphQL -->
-# FraiseQL v2.0.0
 type Query {
   user(id: ID!): User
 }
+```
 
-# All queries compile against THIS schema
-# Schema is part of framework, not separately versioned
-```text
-<!-- Code example in TEXT -->
+Clients write queries against this schema. Keep it additive (see
+[Section 2.2](#22-non-breaking-changes)) and existing clients keep working.
 
 ### 5.2 Query Compatibility
 
-**Within same framework version (e.g., v2.0 to v2.4):**
-
-Queries remain compatible:
+**Across additive schema changes**, existing queries keep working:
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Query written for v2.0.0
+# Query written against your earlier schema
 query GetUser {
   user(id: "123") {
     id
@@ -809,18 +635,13 @@ query GetUser {
   }
 }
 
-# Same query works on v2.1.0, v2.2.0, v2.3.0, v2.4.0
-# New optional fields added in v2.1+, but this query unchanged
-```text
-<!-- Code example in TEXT -->
+# Still works after you add new optional fields — this query is unchanged.
+```
 
-**Across framework MAJOR versions (e.g., v2.x to v3.0):**
-
-Queries may break and require migration:
+**Across a breaking schema change**, queries may need updates:
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Query written for v2.x
+# Query written against your earlier filter shape
 query GetPosts {
   posts(filter: { author_id: "123" }) {
     id
@@ -828,981 +649,578 @@ query GetPosts {
   }
 }
 
-# v3.0 changes filter syntax
+# After you changed the filter shape, clients must update
 query GetPosts {
-  posts(where: { author: { id: "123" } }) {  # Changed syntax
+  posts(where: { author: { id: "123" } }) {
     id
     title
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 5.3 Query Validation
 
-FraiseQL validates all queries at **compile time**, not runtime:
+FraiseQL validates incoming queries against the in-memory schema at request time, using
+`graphql-core`. A query that selects a field which does not exist is rejected with a GraphQL
+validation error:
 
 ```python
-<!-- Code example in Python -->
-# Compile-time: Query validation
-schema = FraiseQL.compile(schema_definition)
-
-# Invalid queries caught during compilation, not at runtime
-query = """
-  query GetUser {
-    user(id: "123") {
-      nonexistent_field
-    }
-  }
-"""
-
-schema.validate(query)  # Raises CompilationError immediately
-```text
-<!-- Code example in TEXT -->
+# At request time, queries are validated against the running schema.
+# A selection like `nonexistent_field` produces a GraphQL validation error
+# in the response — it never reaches the database.
+```
 
 ---
 
 ## 6. Error Code Versioning
 
-### 6.1 Error Code Stability Guarantee
+### 6.1 Error Code Stability
 
-**Error codes are part of the contract and never change** within a MAJOR version.
+**Treat error codes as part of your API contract.** Once clients branch on a code, keep its
+meaning stable.
 
 #### 6.1.1 Error Code Format
 
-Error codes follow deterministic format:
+A deterministic, structured format makes codes easy to handle:
 
 ```text
-<!-- Code example in TEXT -->
 E_CATEGORY_SUBCATEGORY_NUMBER
 
-E_VALIDATION_EMAIL_001      → Category: VALIDATION, Subcategory: EMAIL, Number: 001
-E_DB_POSTGRES_DEADLOCK_303  → Category: DB, Subcategory: POSTGRES_DEADLOCK, Number: 303
-E_AUTH_PERMISSION_401       → Category: AUTH, Subcategory: PERMISSION, Number: 401
-E_FED_SUBGRAPH_TIMEOUT_502  → Category: FED, Subcategory: SUBGRAPH_TIMEOUT, Number: 502
-```text
-<!-- Code example in TEXT -->
+E_VALIDATION_EMAIL_001   → Category: VALIDATION, Subcategory: EMAIL, Number: 001
+E_DB_DEADLOCK_303        → Category: DB, Subcategory: DEADLOCK, Number: 303
+E_AUTH_PERMISSION_401    → Category: AUTH, Subcategory: PERMISSION, Number: 401
+```
 
-#### 6.1.2 Error Code Stability Rules
-
-**Within same MAJOR version:**
+#### 6.1.2 Stable Codes, Flexible Messages
 
 ```python
-<!-- Code example in Python -->
-# v2.0.0: Validation error for empty email
+# The code and its meaning stay stable across releases
 error_code = "E_VALIDATION_EMAIL_001"
 message = "Email cannot be empty"
+```
 
-# v2.1.0: Same error has same code
-error_code = "E_VALIDATION_EMAIL_001"
-message = "Email cannot be empty"
+The human-readable **message can change** (more detail, better wording), but the code and its
+semantics stay fixed.
 
-# v2.5.0: Still same error code
-error_code = "E_VALIDATION_EMAIL_001"
-message = "Email cannot be empty"
-```text
-<!-- Code example in TEXT -->
-
-**Error messages can change** (provide more details), but codes and semantics are locked.
-
-#### 6.1.3 Adding New Error Codes
-
-New error codes are safe to add in MINOR versions:
+#### 6.1.3 Adding New Error Codes (safe)
 
 ```python
-<!-- Code example in Python -->
-# v2.0.0 error codes
-E_VALIDATION_EMAIL_001    # Email cannot be empty
-E_VALIDATION_EMAIL_002    # Email format invalid
+# Existing codes
+# E_VALIDATION_EMAIL_001  → email cannot be empty
+# E_VALIDATION_EMAIL_002  → email format invalid
 
-# v2.1.0 adds new error code
-E_VALIDATION_EMAIL_003    # Email already exists (new in v2.1)
-```text
-<!-- Code example in TEXT -->
+# New, additive code
+# E_VALIDATION_EMAIL_003  → email already exists
+```
 
-**Client impact**: Clients that don't handle `E_VALIDATION_EMAIL_003` still work; they receive an error they didn't explicitly handle, which is backward-compatible.
+Clients that do not handle `E_VALIDATION_EMAIL_003` still work — they receive an error they
+did not explicitly handle, which is backward-compatible.
 
-#### 6.1.4 Removing Error Codes
-
-Removing error codes is a **BREAKING CHANGE** requiring MAJOR version bump:
+#### 6.1.4 Removing Error Codes (breaking)
 
 ```python
-<!-- Code example in Python -->
-# v2.x
-E_VALIDATION_EMAIL_002    # Email format invalid
+# Removing a code that clients handle breaks them.
+# Deprecate it first, then remove it in a MAJOR release.
+```
 
-# Cannot be removed in v2.5 (would break clients handling this code)
-# Can only be removed in v3.0 (MAJOR version)
-```text
-<!-- Code example in TEXT -->
-
-**Migration**: Deprecate error code in v2.x, remove in v3.0.
-
-#### 6.1.5 Changing Error Code Semantics
-
-Changing what an error code means is a **BREAKING CHANGE**:
+#### 6.1.5 Changing Error Code Semantics (breaking)
 
 ```python
-<!-- Code example in Python -->
-# v2.0: E_DB_POSTGRES_TIMEOUT_304 = Query execution timeout
-#       Client retries with exponential backoff
-
-# v2.5: Change E_DB_POSTGRES_TIMEOUT_304 to mean Connection timeout
-#       (different retry strategy needed)
-# This breaks client error handling
-
-# Solution: Create new error code E_DB_POSTGRES_CONN_TIMEOUT_305
-#           Keep 304 for query timeout
-```text
-<!-- Code example in TEXT -->
+# Do not re-purpose a code.
+# Instead, introduce a new code and keep the old one stable:
+#   keep   E_DB_TIMEOUT_304    → query execution timeout
+#   add    E_DB_CONN_TIMEOUT_305 → connection timeout
+```
 
 ---
 
-## 7. Multi-Version Runtime Support
+## 7. Running Multiple Versions
 
-### 7.1 Can a Runtime Load Multiple Schema Versions?
+### 7.1 One Schema per Process
 
-**Short answer**: No, not at the same time.
+A FraiseQL app builds **one** schema at startup from the decorators it imports. You cannot
+serve two different schema versions from a single process; restart with different code to
+serve a different schema.
 
-**Long answer**: The runtime is **single-schema**. You select which compiled schema to load at startup:
+```python
+from fraiseql.fastapi import create_fraiseql_app
 
-```rust
-<!-- Code example in RUST -->
-// Rust runtime initialization
-let compiled_schema = load_compiled_schema("v2.0.0");
-let runtime = FraiseQLRuntime::new(compiled_schema);
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+    production=True,
+)
+# This process serves exactly the schema these decorators produce.
+```
 
-// All queries execute against v2.0.0 schema
-// Cannot mix v2.0 and v2.1 schemas in same runtime
+### 7.2 Multiple Versions via Multiple Deployments
+
+To run two API versions at once, deploy two app instances behind a gateway:
+
 ```text
-<!-- Code example in TEXT -->
-
-### 7.2 Multiple Versions Across Multiple Instances
-
-To run multiple versions simultaneously, deploy multiple runtime instances:
-
-```text
-<!-- Code example in TEXT -->
 ┌─────────────────────────────────┐
-│ API Gateway                     │
+│ API Gateway / Reverse Proxy     │
 └──────────┬──────────────────────┘
            │
-           ├─→ Runtime Instance A (Framework v2.0.0)
-           │   └─ Schema v1.0.0
+           ├─→ App Instance A  (your schema v1)
            │
-           ├─→ Runtime Instance B (Framework v2.1.0)
-           │   └─ Schema v1.1.0
-           │
-           └─→ Runtime Instance C (Framework v2.4.0)
-               └─ Schema v1.2.0
-```text
-<!-- Code example in TEXT -->
+           └─→ App Instance B  (your schema v2)
+```
 
-**Client routing**:
+Route by path, header, or hostname:
 
-- Requests for v1.0.0 schema → Route to Instance A
-- Requests for v1.1.0 schema → Route to Instance B
-- Requests for v1.2.0 schema → Route to Instance C
+- Requests for schema v1 → Instance A
+- Requests for schema v2 → Instance B
 
-### 7.3 Schema Migration Between Versions
+### 7.3 Rolling Out a Schema Change
 
-To migrate from Framework v2.0 to v2.1:
+To move clients from one schema to the next:
 
 ```text
-<!-- Code example in TEXT -->
-
-1. Deploy new runtime instance with Framework v2.1
-2. Route new requests to v2.1 instance
-3. Keep v2.0 instance running for existing clients
-4. Gradually migrate clients to v2.1
-5. Once all clients migrated, shut down v2.0 instance
-```text
-<!-- Code example in TEXT -->
+1. Deploy a new app instance running the new schema.
+2. Route new clients to the new instance.
+3. Keep the old instance running for existing clients.
+4. Migrate clients over gradually.
+5. Once all clients have moved, decommission the old instance.
+```
 
 ---
 
-## 8. MAJOR Version Upgrade Path
+## 8. Upgrade Path
 
-### 8.1 Pre-Upgrade Checklist
+### 8.1 Upgrading the FraiseQL Package
 
-Before upgrading from v2.x to v3.0:
+Within the `1.x` line, upgrades are backward-compatible. Upgrade with `uv`:
+
+```bash
+# Upgrade to the latest 1.x release
+uv add "fraiseql>=1.23,<2"
+
+# Pin an exact version for reproducible builds
+uv add "fraiseql==1.23.11"
+```
+
+A MINOR or PATCH upgrade should require no code changes. Read the changelog, run your test
+suite, and deploy. Because the schema is rebuilt at startup, simply restarting the app picks
+up any framework improvements.
+
+### 8.2 Pre-Upgrade Checklist
 
 ```markdown
-<!-- Code example in MARKDOWN -->
-### v2.x → v3.0 Pre-Upgrade Checklist
+### Upgrade Checklist
 
-- [ ] Review v3.0 breaking changes guide
-  https://docs.FraiseQL.io/migration/v3.0-breaking-changes
+- [ ] Read the changelog for the target release.
+- [ ] Check for any deprecation warnings in your logs and address them.
+- [ ] Run your full test suite against the new FraiseQL version.
+- [ ] Verify your GraphQL schema is unchanged (diff introspection snapshots).
+- [ ] Deploy to staging and smoke-test queries and mutations.
+- [ ] Roll out to production; keep the previous version available for rollback.
+```
 
-- [ ] Check which v2.x features are deprecated in v3.0
-  [ ] No deprecated operators used
-  [ ] No deprecated decorators used
-  [ ] No deprecated error codes expected in error handling
+### 8.3 Rollback
 
-- [ ] Update schemas for v3.0 requirements
-  [ ] Update type definitions
-  [ ] Update authorization rules
-  [ ] Update error handling code
+Because there is no schema artifact and no data-format migration in the framework itself,
+rolling the FraiseQL package back to the previous version is a redeploy:
 
-- [ ] Run schema validation
-  $ FraiseQL validate schema.py --target v3.0
+```bash
+# Roll back to the previously deployed version
+uv add "fraiseql==1.22.0"
+```
 
-- [ ] Test on staging environment
-  $ FraiseQL compile schema.py --target v3.0
-  $ FraiseQL test --schema compiled-schema-v3.json
-
-- [ ] Review compiled schema changes
-  $ FraiseQL diff compiled-schema-v2.json compiled-schema-v3.json
-
-- [ ] Update client code
-  [ ] Handle new error codes
-  [ ] Adjust for removed fields/operators
-  [ ] Test error handling
-
-- [ ] Plan deployment
-  [ ] Deploy v3.0 runtime instance first (canary)
-  [ ] Route test traffic to v3.0
-  [ ] Monitor for errors
-  [ ] Gradually migrate production traffic
-  [ ] Keep v2.x instance for rollback (1-2 weeks)
-
-- [ ] Performance testing
-  [ ] Benchmark queries on v3.0
-  [ ] Check for regressions
-  [ ] Verify error handling performance
-```text
-<!-- Code example in TEXT -->
-
-### 8.2 Version Coexistence Window
-
-During migration from v2.x to v3.0:
-
-```text
-<!-- Code example in TEXT -->
-Timeline:
-  Week 0: v3.0 released
-  Week 1: Deploy v3.0 canary, route 5% traffic
-  Week 2: Increase to 25% traffic
-  Week 3: Increase to 50% traffic
-  Week 4: Increase to 75% traffic
-  Week 5: Increase to 100% traffic
-  Week 6: Keep v2.x for rollback (if needed)
-  Week 7: Decommission v2.x instance
-
-Duration: ~7 weeks for full migration
-```text
-<!-- Code example in TEXT -->
-
-### 8.3 Rollback Window
-
-If issues arise post-upgrade:
-
-```text
-<!-- Code example in TEXT -->
-If critical issue detected within 48 hours of upgrade:
-  → Can rollback to v2.x (keep v2.x instance running during migration)
-
-If critical issue detected after 7 days:
-  → Cannot safely rollback (data may have changed)
-  → Must fix forward in v3.x
-  → Will release v3.0.1 hotfix quickly
-```text
-<!-- Code example in TEXT -->
+If you also shipped a breaking change to *your own* schema, coordinate the rollback with
+your clients and your PostgreSQL views as you would any API change.
 
 ---
 
 ## 9. Client Versioning & Compatibility
 
-### 9.1 Client Version Lock
+### 9.1 Pin the Package
 
-Clients lock to a specific FraiseQL framework version:
+Applications pin the FraiseQL package version for reproducible builds:
 
 ```python
-<!-- Code example in Python -->
-# Client code targeting FraiseQL v2.x
-from FraiseQL import Client
+# pyproject.toml dependency
+# fraiseql>=1.23,<2   → any backward-compatible 1.x release
+# fraiseql==1.23.11   → an exact pin
+```
 
-client = Client(
-    endpoint="https://api.example.com",
-    framework_version="2.0.0"  # Explicit version lock
-)
+### 9.2 GraphQL Clients Track Your Schema
 
-# Query uses v2.0.0 semantics
-response = client.execute("""
-  query GetPosts {
-    posts(filter: { published: true }) {
-      id
-      title
-    }
-  }
-""")
-```text
-<!-- Code example in TEXT -->
-
-### 9.2 Client Upgrade Path
-
-When server upgrades framework:
+GraphQL clients (web apps, mobile apps, services) depend on *your* schema, not on the
+FraiseQL package version. As long as you keep schema edits additive, those clients keep
+working across your releases:
 
 ```text
-<!-- Code example in TEXT -->
-Server runs v2.0.0
-└─ Client sends queries
-   └─ Server executes against v2.0.0 schema
-   └─ Client receives responses
+You upgrade FraiseQL 1.22 → 1.23 (backward-compatible)
+└─ Your GraphQL schema is unchanged
+   └─ All GraphQL clients keep working with no changes
 
-Server upgrades to v2.1.0 (backward-compatible)
-└─ Same client queries work unchanged
-   └─ New optional fields available (client ignores if not needed)
+You add optional fields to your schema (additive)
+└─ Existing GraphQL clients keep working
+   └─ New clients can opt into the new fields
 
-Server upgrades to v3.0.0 (breaking changes)
-└─ Client queries may break
-   └─ Need to update client code
-   └─ Recompile client code for v3.0.0
+You make a breaking schema change
+└─ Affected GraphQL clients must update their queries
+```
+
+### 9.3 Advertising the Version
+
+You can expose the running version to clients however you prefer, for example via an HTTP
+header set by your app or gateway:
+
 ```text
-<!-- Code example in TEXT -->
-
-### 9.3 Version Negotiation
-
-Runtime can optionally advertise its version:
-
-```graphql
-<!-- Code example in GraphQL -->
-# GraphQL introspection
-{
-  __schema {
-    description  # "FraiseQL v2.1.0"
-  }
-}
-
-# Via HTTP header
 GET /graphql
 Host: api.example.com
-Accept: application/json
-
-Response:
 
 200 OK
-X-FraiseQL-Version: 2.1.0
+X-FraiseQL-Version: 1.23.11
 Content-Type: application/json
-```text
-<!-- Code example in TEXT -->
-
-**Client usage**:
-
-```python
-<!-- Code example in Python -->
-# Check server version before executing query
-version = response.headers.get('X-FraiseQL-Version')
-if version.startswith('2.0'):
-    # Execute v2.0 query
-    ...
-elif version.startswith('2.1'):
-    # Can use v2.1 features
-    ...
-else:
-    # Unsupported version
-    raise IncompatibleVersionError(version)
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
-## 10. Compiler Version Management
+## 10. Version Communication
 
-### 10.1 Schema Compilation
+### 10.1 Changelog Format
 
-When users compile schemas, they specify target framework version:
-
-```bash
-<!-- Code example in BASH -->
-# Compile for specific framework version
-FraiseQL compile schema.py --target 2.0.0
-
-# Compile for latest version
-FraiseQL compile schema.py --target latest
-
-# Compile with version compatibility check
-FraiseQL compile schema.py --target 2.0.0 --strict
-```text
-<!-- Code example in TEXT -->
-
-### 10.2 Compiled Schema Portability
-
-Compiled schemas are **not portable across framework versions**:
-
-```text
-<!-- Code example in TEXT -->
-Compiled schema built with FraiseQL v2.0.0
-    ↓
-Runtime v2.0.0: ✅ Works
-Runtime v2.1.0: ✅ Works (backward-compatible)
-Runtime v3.0.0: ❌ Incompatible (different format)
-```text
-<!-- Code example in TEXT -->
-
-**To upgrade**:
-
-```bash
-<!-- Code example in BASH -->
-# 1. Recompile schema with new framework version
-FraiseQL compile schema.py --target 3.0.0
-
-# 2. Deploy compiled schema and runtime v3.0 together
-docker build -t my-api:v3 --build-arg SCHEMA=compiled-schema-v3.json .
-
-# 3. Deploy new runtime instance
-docker run my-api:v3
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 11. Ecosystem Versioning
-
-### 11.1 SDK Versions
-
-Client SDKs (Python, TypeScript, Go, Rust) are versioned separately from framework:
-
-```text
-<!-- Code example in TEXT -->
-FraiseQL Framework: v2.1.0
-Python SDK:        v2.1.0  (matches framework)
-TypeScript SDK:    v2.1.1  (patch ahead for bug fixes)
-Go SDK:            v2.0.5  (behind, still testing)
-Rust SDK:          v2.1.0  (matches framework)
-```text
-<!-- Code example in TEXT -->
-
-**Compatibility matrix**:
-
-```text
-<!-- Code example in TEXT -->
-SDK v2.1.0 can connect to:
-  - Framework v2.0.x ✅ (backward-compatible)
-  - Framework v2.1.x ✅ (same version)
-  - Framework v2.2+ ✅ (forward-compatible for read)
-  - Framework v3.0 ❌ (breaking changes)
-```text
-<!-- Code example in TEXT -->
-
-### 11.2 Tool Versions
-
-Development tools have independent versions:
-
-```text
-<!-- Code example in TEXT -->
-Framework:           v2.1.0
-Compiler:            v2.1.0  (same as framework)
-Migration tool:      v1.3.2  (separate versioning)
-Schema validator:    v2.1.0  (same as framework)
-Performance profiler: v1.0.0 (separate versioning)
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 12. Version Communication
-
-### 12.1 Changelog Format
-
-Every release includes a detailed changelog:
+Every release should ship a changelog. A backward-compatible MINOR release looks like:
 
 ```markdown
-<!-- Code example in MARKDOWN -->
-# v2.1.0 Changelog
+# 1.23.0 Changelog
 
-**Release Date:** January 15, 2024
-**Framework:** FraiseQL v2.1.0
-**Compatibility:** Backward-compatible with v2.0.x
+**Compatibility:** Backward-compatible with 1.22.x
 
-## ✨ New Features
+## New Features
 
-### Keyset Pagination Support
+- Added keyset pagination support for large result sets.
+- Added `startsWith` and `endsWith` string filter operators.
 
-- Added `@cursor` directive for keyset-based pagination
-- Supports stateless pagination for large result sets
-- Example: `posts(first: 20, after: "cursor123") { id title }`
+## Bug Fixes
 
-### New Operators
+- Fixed WHERE-clause filtering on view-backed types.
+- Fixed deadlock handling in concurrent mutations.
 
-- Added `startsWith` operator for string filtering
-- Added `endsWith` operator for string filtering
-- Operators work with both `String` and `Text` types
+## Breaking Changes
 
-## 🐛 Bug Fixes
+- None — this is a backward-compatible MINOR release.
 
-- Fixed WHERE clause filtering on hybrid tables (Issue #124)
-- Fixed deadlock detection in concurrent mutations
-- Fixed error code E_VALIDATION_EMAIL_001 message formatting
+## Deprecations
 
-## 🚨 Breaking Changes
+- `regex` filter operator: use `contains` or `startsWith` instead.
+  Deprecated now; removal planned for the next MAJOR release.
 
-- **None** - This is a backward-compatible MINOR release
+## Performance
 
-## ⚠️ Deprecations
+- Query execution faster on average; reduced memory usage on the JSON hot path.
 
-- `regex` operator: Use `contains` or `startsWith` instead
-  - Deprecated in v2.1.0
-  - Will be removed in v3.0.0 (3-year window)
-  - Migration guide: https://docs.FraiseQL.io/migration/regex-deprecation
+## Security
 
-## 📊 Performance
+- Hardened LIKE-clause handling against injection.
+- Improved authorization caching.
+```
 
-- Query execution 15% faster on average
-- Memory usage reduced by 8%
-- Compiled schema size reduced by 12%
+### 10.2 Migration Guidance for Breaking Changes
 
-## 🔒 Security
-
-- Fixed potential SQL injection vector in LIKE queries
-- Enhanced rate limiting for federation queries
-- Improved authorization caching
-
-## 🛠️ For Operators
-
-- Upgraded PostgreSQL FDW support to 15.x
-- Added support for SQL Server 2022
-- Improved connection pooling (pgbouncer 1.18+)
-
-## 📚 Documentation
-
-- Added keyset pagination guide
-- Updated federation architecture guide
-- New error code reference
-```text
-<!-- Code example in TEXT -->
-
-### 12.2 Migration Guides
-
-For each MAJOR version upgrade, provide detailed guide:
-
-```text
-<!-- Code example in TEXT -->
-docs/migration/
-├── v2-to-v3.md                    # Main migration guide
-├── v3-breaking-changes.md         # What breaks
-├── v3-operator-changes.md         # Operator changes
-├── v3-error-code-mapping.md       # How error codes changed
-├── v3-schema-examples.md          # Before/after schema examples
-├── v3-performance-guide.md        # Performance characteristics
-└── v3-troubleshooting.md          # Common issues and solutions
-```text
-<!-- Code example in TEXT -->
-
-### 12.3 Deprecation Announcements
-
-Deprecations are announced prominently:
+For any breaking change to your own API, give clients a clear before/after and a timeline.
+A concise deprecation notice for a filter operator:
 
 ```markdown
-<!-- Code example in MARKDOWN -->
-# ⚠️ Deprecation Notice: `regex` Operator
+# Deprecation Notice: `regex` filter operator
 
-**Announced in:** v2.1.0
-**Removal planned:** v3.0.0
-**Timeline:** 3 years from v2.1 release
+**Announced in:** the current MINOR release
+**Removal planned:** the next MAJOR release
 
-## Why?
-The `regex` operator provides functionality better served by `contains` with superior performance (10x faster on average). We're consolidating operators to reduce API surface and improve query performance.
+## Why
+The `regex` operator carries performance overhead. `contains` and `startsWith` cover the
+common cases with better performance, so we are consolidating the operator surface.
 
-## What to do?
-
-### Before (v2.x)
-```graphql
-<!-- Code example in GraphQL -->
+## Before
+\`\`\`graphql
 query SearchPosts {
   posts(where: { title: { regex: "/^draft/" } }) {
     id
     title
   }
 }
-```text
-<!-- Code example in TEXT -->
+\`\`\`
 
-### After (v2.1+)
-
-```graphql
-<!-- Code example in GraphQL -->
+## After
+\`\`\`graphql
 query SearchPosts {
   posts(where: { title: { startsWith: "draft" } }) {
     id
     title
   }
 }
-```text
-<!-- Code example in TEXT -->
-
-## Impact
-
-- Affects ~3% of existing queries in telemetry
-- No performance impact on other queries
-- Removal affects only queries using `regex` operator
-
-## Timeline
-
-- **v2.1 (2024-01)**: Deprecation announced, `regex` still works, warnings enabled
-- **v2.2-2.5 (2024-2025)**: `regex` still works, deprecation warnings continue
-- **v3.0 (2027)**: `regex` operator removed, queries fail at compile time
-
-## Help
-
-- Migration guide: <https://docs.FraiseQL.io/migration/regex-deprecation>
-- Support: <support@FraiseQL.io>
-- Issues: <https://github.com/FraiseQL/FraiseQL/issues>
-
-```text
-<!-- Code example in TEXT -->
+\`\`\`
+```
 
 ---
 
-## 13. Support & Long-Term Maintenance
+## 11. Support & Long-Term Maintenance
 
-### 13.1 Support Window
+### 11.1 Support Window
 
-FraiseQL commits to support windows for each MAJOR version:
+FraiseQL's `1.x` line receives ongoing bug fixes and security patches in new PATCH and MINOR
+releases. Stay close to the latest `1.x` to keep receiving them. Pin a known-good version for
+production, and schedule regular, low-risk upgrades within the `1.x` line.
 
-```text
-<!-- Code example in TEXT -->
+### 11.2 Security Patches
 
-v2.x (v2.0.0 released Date X)
-  ├─ Active support: 2 years from release
-  │  └─ Full features, bug fixes, security patches
-  ├─ Maintenance support: 1 year after active support ends
-  │  └─ Security patches only, no new features
-  └─ End of life: 3 years from release
-     └─ No support, no patches
+Security fixes are released as new versions on PyPI. Upgrade promptly when a security release
+is published:
 
-v3.x (released 3 years after v2.0)
-  ├─ Active support: 2 years from release
-  └─ ...continues pattern...
+```bash
+uv add "fraiseql>=1.23.11"
+```
 
-```text
-<!-- Code example in TEXT -->
+### 11.3 End-of-Life Behaviour
 
-### 13.2 Security Patches
-
-Security vulnerabilities are backported to all supported versions:
-
-```text
-<!-- Code example in TEXT -->
-
-Security vulnerability discovered in v3.0.0
-  ├─ v3.0.1 released with patch (immediate)
-  ├─ v2.5.3 released with patch (same day)
-  ├─ v2.4.2 released with patch (same day)
-  └─ v2.3.1 released with patch (same day)
-
-```text
-<!-- Code example in TEXT -->
-
-### 13.3 End of Life (EOL) Handling
-
-When a MAJOR version reaches end of life:
-
-```markdown
-<!-- Code example in MARKDOWN -->
-# v2.x End of Life (December 31, 2026)
-
-**Support ended:** January 1, 2027
-
-Applications running v2.x will continue to function, but:
-
-- ❌ No new security patches
-- ❌ No bug fixes
-- ❌ No technical support
-- ✅ v2.x instances remain functional (no forced upgrades)
-
-To continue receiving support:
-
-1. Upgrade to v3.x or later
-2. Follow upgrade guide: https://docs.FraiseQL.io/migration/v2-to-v3
-
-We recommend upgrading before December 31, 2026.
-```text
-<!-- Code example in TEXT -->
+An application pinned to an older `1.x` version keeps running — nothing forces an upgrade —
+but it stops receiving fixes once you fall behind. To keep getting bug fixes and security
+patches, track the latest `1.x` release.
 
 ---
 
-## 14. Version Decision Tree
+## 12. Version Decision Tree
 
-Use this decision tree to determine if a change requires version bump:
+Use this to decide whether a change to the package (or to your own schema) requires a MAJOR,
+MINOR, or PATCH bump:
 
 ```text
-<!-- Code example in TEXT -->
-Does the change modify user-facing behavior?
+Does the change modify externally observable behaviour?
 │
 ├─ NO
-│  └─ Is it a code refactoring, performance improvement, or doc fix?
-│     ├─ YES → PATCH version (v2.0.0 → v2.0.1)
-│     └─ NO → No version bump (development/internal only)
+│  └─ Is it a refactor, performance improvement, or doc fix?
+│     ├─ YES → PATCH (e.g. 1.23.0 → 1.23.1)
+│     └─ NO  → No version bump (internal only)
 │
 └─ YES
    │
-   └─ Does the change break existing queries, schemas, or code?
+   └─ Does the change break existing queries, schemas, or callers?
       │
       ├─ NO (addition, improvement, deprecation)
-      │  └─ MINOR version (v2.0.0 → v2.1.0)
+      │  └─ MINOR (e.g. 1.23.0 → 1.24.0)
       │
-      └─ YES (removal, incompatibility, behavior change)
-         └─ MAJOR version (v2.0.0 → v3.0.0)
-```text
-<!-- Code example in TEXT -->
+      └─ YES (removal, incompatibility, behaviour change)
+         └─ MAJOR (e.g. 1.x → 2.0.0)
+```
 
 ---
 
-## 15. Versioning Best Practices
+## 13. Versioning Best Practices
 
-### 15.1 For Framework Maintainers
+### 13.1 For Framework Maintainers
 
-**DO:**
+**Do:**
 
-- ✅ Increment MAJOR version for breaking changes
-- ✅ Increment MINOR version for new features (backward-compatible)
-- ✅ Increment PATCH version for bug fixes
-- ✅ Test against previous versions
-- ✅ Document breaking changes prominently
-- ✅ Provide migration guides
-- ✅ Support for 3 years per MAJOR version
-- ✅ Deprecate before removing (3 versions before removal)
-- ✅ Lock error codes within MAJOR version
+- Bump MAJOR for breaking changes, MINOR for backward-compatible features, PATCH for fixes.
+- Test new releases against existing user code.
+- Document breaking changes prominently and provide migration guidance.
+- Deprecate before removing — announce in a MINOR release, remove in the next MAJOR.
+- Keep error codes stable within a MAJOR version.
 
-**DON'T:**
+**Don't:**
 
-- ❌ Remove fields/operators without deprecation period
-- ❌ Change error code semantics
-- ❌ Use 0.x versioning forever (stabilize with 1.0)
-- ❌ Break queries without MAJOR version bump
-- ❌ Change compiled schema format within MAJOR version
-- ❌ Support multiple schema versions in single runtime instance
+- Remove public APIs or operators without a deprecation period.
+- Re-purpose an error code's meaning.
+- Break callers without a MAJOR bump.
 
-### 15.2 For Application Developers
+### 13.2 For Application Developers
 
-**DO:**
+**Do:**
 
-- ✅ Lock to specific framework version in production
-- ✅ Test upgrades on staging first
-- ✅ Review changelog before upgrading
-- ✅ Plan migrations for MAJOR version upgrades
-- ✅ Handle deprecated warnings in development
-- ✅ Update error handling code for new error codes
+- Pin a specific FraiseQL version in production.
+- Test upgrades on staging first.
+- Read the changelog before upgrading.
+- Address deprecation warnings as you see them.
+- Keep your own GraphQL schema edits additive whenever possible.
 
-**DON'T:**
+**Don't:**
 
-- ❌ Use `latest` version in production
-- ❌ Upgrade MAJOR versions without planning
-- ❌ Ignore deprecation warnings
-- ❌ Assume backward compatibility between MAJOR versions
-- ❌ Run unsupported versions in production
+- Track a floating "latest" in production.
+- Make breaking schema changes without coordinating with your clients.
+- Ignore deprecation warnings.
 
 ---
 
-## 16. Examples
+## 14. Examples
 
-### 16.1 Example: Adding New Field (MINOR Version)
+### 14.1 Example: Adding a New Field (additive)
 
-**Scenario**: Add optional `phone` field to User type.
+**Scenario**: Add an optional `phone` field to the `User` type.
 
 ```python
-<!-- Code example in Python -->
-# v2.0.0
-@FraiseQL.type
+import fraiseql
+from fraiseql.types import ID
+
+# before
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
     id: ID
     name: str
     email: str | None = None
 
-# v2.1.0 (add optional field)
-@FraiseQL.type
+# after — add an optional field
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
     id: ID
     name: str
     email: str | None = None
-    phone: str | None = None  # New in v2.1
+    phone: str | None = None   # new optional field
+```
 
-# Queries written for v2.0.0 still work in v2.1.0
-# Clients can optionally request 'phone' field
-```text
-<!-- Code example in TEXT -->
+Existing GraphQL queries keep working; clients can optionally select `phone`. Expose `phone`
+in the `v_user` view's `data` JSONB so the resolver can return it.
 
-**Version bump**: `2.0.0` → `2.1.0` (MINOR)
+**Classification**: additive — safe (MINOR-style change to your schema).
 
-### 16.2 Example: Removing Operator (MAJOR Version)
+### 14.2 Example: Removing a Filter Operator (breaking)
 
-**Scenario**: Remove `regex` operator.
+**Scenario**: Remove the `regex` filter operator.
 
-```python
-<!-- Code example in Python -->
-# v2.x
-# Query with regex operator (works)
+```graphql
+# before — query using the regex operator works
 query GetPosts {
   posts(where: { title: { regex: "/draft/" } }) {
     id
   }
 }
 
-# v3.0
-# Query with regex operator (ERROR)
-query GetPosts {
-  posts(where: { title: { regex: "/draft/" } }) {
-    id
-  }
-}
-# Error: "regex operator removed in v3.0, use startsWith instead"
-
-# Require client update:
+# after — the regex operator is gone; this query errors.
+# Clients must rewrite it, e.g. using startsWith:
 query GetPosts {
   posts(where: { title: { startsWith: "draft" } }) {
     id
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Version bump**: `2.x.x` → `3.0.0` (MAJOR)
+**Classification**: breaking — requires a deprecation period, then removal in a MAJOR release.
 
-### 16.3 Example: Bug Fix (PATCH Version)
+### 14.3 Example: Bug Fix (PATCH)
 
-**Scenario**: Fix WHERE clause filtering on hybrid tables (Issue #124).
-
-```python
-<!-- Code example in Python -->
-# v2.0.0
-# WHERE clause not applied to SQL columns on hybrid tables (BUG)
-
-# v2.0.1
-# WHERE clause correctly applied to SQL columns (FIXED)
-```text
-<!-- Code example in TEXT -->
-
-**Version bump**: `2.0.0` → `2.0.1` (PATCH)
-
-### 16.4 Example: Deprecation then Removal
+**Scenario**: Fix WHERE-clause filtering on a view-backed type.
 
 ```text
-<!-- Code example in TEXT -->
-Timeline:
-  v2.1.0 (Year 0): Announce deprecation of 'regex' operator
-  v2.2.0 (Year 0): Still works, warnings shown
-  v2.3.0 (Year 1): Still works, warnings shown
-  v2.4.0 (Year 1): Still works, warnings shown
-  v2.5.0 (Year 2): Still works, warnings shown
-  v3.0.0 (Year 3): Operator removed, queries fail
+before: WHERE clause not correctly applied for some view-backed types (bug)
+after:  WHERE clause correctly applied (fixed)
+```
 
-Migration required during 3-year window (v2.1 to v3.0).
+**Classification**: bug fix — PATCH (e.g. 1.23.10 → 1.23.11).
+
+### 14.4 Example: Deprecation then Removal
+
 ```text
-<!-- Code example in TEXT -->
+1.20.0  Announce deprecation of the `regex` operator; it still works, warnings shown.
+1.21.0  Still works, warnings shown.
+1.22.0  Still works, warnings shown.
+1.23.0  Still works, warnings shown.
+2.0.0   Operator removed; queries using it fail validation.
+```
+
+Clients migrate at any point during the deprecation window.
 
 ---
 
-## 17. Summary & Quick Reference
+## 15. Summary & Quick Reference
 
-### 17.1 Versioning at a Glance
+### 15.1 Versioning at a Glance
 
-| Version Type | Use Case | Example | Support |
-|--------------|----------|---------|---------|
-| **MAJOR** | Breaking changes | 2.0.0 → 3.0.0 | 3 years |
-| **MINOR** | New features, backward-compatible | 2.0.0 → 2.1.0 | Until v3 released |
-| **PATCH** | Bug fixes, performance | 2.0.0 → 2.0.1 | Until v3 released |
+| Version Type | Use Case | Example |
+|--------------|----------|---------|
+| **MAJOR** | Breaking changes | 1.x → 2.0.0 |
+| **MINOR** | New features, backward-compatible | 1.22.0 → 1.23.0 |
+| **PATCH** | Bug fixes, performance | 1.23.10 → 1.23.11 |
 
-### 17.2 Breaking Change Examples
+### 15.2 Breaking Change Examples
 
-**Requires MAJOR version bump:**
+**Requires a MAJOR bump (package) / breaks clients (your schema):**
 
-- Remove field from type
-- Change field return type
-- Remove operator
-- Remove error code
-- Change error code semantics
-- Change compiled schema format
-- Remove custom scalar
-- Add required argument/input field
+- Remove a field from a type.
+- Change a field's type or make it non-null.
+- Remove or re-define a filter operator.
+- Remove or re-purpose an error code.
+- Remove a custom scalar or change its serialization.
+- Add a required argument or required input field.
 
-**Backward-compatible (MINOR version bump):**
+**Backward-compatible (MINOR-style):**
 
-- Add optional field
-- Add new operator
-- Add new type
-- Add new enum value
-- Add new error code
-- Add optional argument
+- Add an optional field.
+- Add a new filter operator.
+- Add a new type or query.
+- Add a new enum value.
+- Add a new error code.
+- Add an optional argument.
 
-**Bug fixes and performance (PATCH version bump):**
+**Bug fixes and performance (PATCH-style):**
 
-- Fix incorrect behavior
-- Improve performance
-- Update documentation
-- Internal refactoring
+- Fix incorrect behaviour.
+- Improve performance.
+- Update documentation.
+- Refactor internals (including the optional `fraiseql_rs` hot path).
 
-### 17.3 Deprecation & Support
+### 15.3 Deprecation & Stability
 
-- **Deprecation window**: 3 years (MAJOR version)
-- **Support window per MAJOR**: 3 years (active + maintenance)
-- **Error codes**: Locked within MAJOR version (never change)
-- **Compiled schemas**: Require recompilation for MAJOR version change
+- **Deprecate before removing** — announce in a MINOR release, remove in the next MAJOR.
+- **Error codes** — keep their meaning stable; add new codes rather than re-purposing old ones.
+- **Schema** — generated at runtime; there is no artifact to version, so diff introspection
+  snapshots to track changes.
 
 ---
 
-## 18. Appendix: Version Checking
+## 16. Appendix: Version Checking
 
-### 18.1 Programmatic Version Checks
+### 16.1 Programmatic Version Check
 
 ```python
-<!-- Code example in Python -->
-import FraiseQL
+import fraiseql
 
-# Get framework version
-version = FraiseQL.__version__
-# Returns: "2.1.0"
+# Get the installed FraiseQL package version
+print(fraiseql.__version__)
+# Example: "1.23.11"
+```
 
-# Check version compatibility
-if FraiseQL.version_matches(">=2.0.0,<3.0.0"):
-    print("Running on v2.x")
-else:
-    print("Running on different MAJOR version")
+You can also read the installed version through the standard library:
 
-# Get compiled schema version
-schema = FraiseQL.compile(...)
-print(schema.framework_version)
-# Returns: "2.1.0"
+```python
+from importlib.metadata import version
 
-print(schema.compiled_schema_version)
-# Returns: 1
-```text
-<!-- Code example in TEXT -->
+print(version("fraiseql"))
+# Example: "1.23.11"
+```
 
-### 18.2 GraphQL Introspection
+### 16.2 GraphQL Introspection
+
+Use introspection to snapshot your runtime schema (useful for diffing schema versions):
 
 ```graphql
-<!-- Code example in GraphQL -->
 {
   __schema {
     types {
       name
-      description  # May include version info
+      description
     }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-### 18.3 Runtime Endpoints
+### 16.3 Version Endpoint
+
+Expose your application's version however you like, for example a small endpoint:
 
 ```bash
-<!-- Code example in BASH -->
-# Check framework version
+# Your app returns its version
 curl https://api.example.com/version
-# Returns: {"version": "2.1.0"}
-
-# Get schema version
-curl https://api.example.com/graphql \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ __schema { description } }"}'
-```text
-<!-- Code example in TEXT -->
+# Example: {"version": "1.23.11"}
+```
 
 ---
 
-**Document Version**: 1.0.0
-**Last Updated**: January 2026
-**Status**: Complete and frozen for framework v2.x
+## Related Reading
 
-FraiseQL versioning ensures stability for users while allowing framework innovation. Three-year support windows, explicit breaking change policies, and comprehensive migration guides make upgrades predictable and manageable.
+- [Consistency Model](./consistency-model.md)
+- [Error Handling Model](./error-handling-model.md)
+- [Failure Modes and Recovery](./failure-modes-and-recovery.md)


### PR DESCRIPTION
Phase 2 of the docs cleanup (follows #418, #419, #420). Rewrites the **Architecture → Reliability** nav pages, which framed FraiseQL as a multi-database, federated, compiled system. All 4 now describe v1 reality: a **single-PostgreSQL, runtime Python/FastAPI** framework.

## Per-file summary

| File | Key v2→v1 changes |
|------|-------------------|
| `consistency-model` | remove the entire Multi-Database/Federation section (FDW, "causal consistency") + invented `@consistency` directive; keep ACID/isolation/read-after-write/subscription-ordering; read replicas reframed as a PostgreSQL deployment note (FraiseQL uses one `database_url` via `psycopg_pool`, no read routing/failover) |
| `error-handling-model` | "compile-time errors" → schema-validation at startup; drop federation + Rust-panic (`E_INTERNAL_PANIC`) codes; PostgreSQL-only SQLSTATE taxonomy; `@success`/`@error` unions |
| `failure-modes-and-recovery` | drop distributed-subscription/NATS + federation; subscriptions = per-WebSocket-connection; multi-instance/failover/replicas = optional deployment topologies (not FraiseQL features); RTO/RPO softened to guidance; keep DB/pool/deadlock/constraint/auth failure modes (1354→767 lines) |
| `versioning-strategy` | reframe around two dimensions — the FraiseQL **PyPI package** (SemVer, current **1.23.11**) and your **runtime-generated GraphQL schema** (no artifact to version); drop compiled-schema versioning + v2→v3 migration path |

Cross-cutting: `@FraiseQL.*` → `@fraiseql.*`, Rust error syntax → plain/JSON, modern typing, removed malformed fences and `<!-- Code example -->` artifacts, PostgreSQL-only.

## Verification

- `grep`: **zero** `@FraiseQL.` / federation / FDW / multi-DB / `schema.compiled` / v3 artifacts; every failover/replica/compile mention is an explicit **negation/disclaimer** (e.g. "FraiseQL does *not* provide automatic failover").
- Connection pooling grounded in the real `psycopg_pool.AsyncConnectionPool`; **no invented** FraiseQL failover/replica features; version 1.23.11 verified against `pyproject.toml`.
- All cross-links resolve; fences balanced; no Rust/NATS leftovers; `mkdocs build` no new warnings.

Net: **+1635 / −3151** lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)