### PR TITLE
docs(architecture): rewrite Decisions/Integration/Realtime for v1 (Phase 2)

### DIFF
--- a/docs/architecture/decisions/anti-patterns.md
+++ b/docs/architecture/decisions/anti-patterns.md
@@ -1,23 +1,35 @@
-<!-- Skip to main content -->
 ---
-
-title: FraiseQL Anti-Patterns: What NOT to Do
-description: This document catalogs anti-patterns—designs that seem reasonable but lead to problems in practice. Learning what NOT to do is as important as learning what TO
-keywords: ["workflow", "design", "scalability", "saas", "performance", "realtime", "patterns", "ecommerce"]
+title: "FraiseQL Anti-Patterns: What NOT to Do"
+description: This document catalogs anti-patterns—designs that seem reasonable but lead to problems in practice. Learning what NOT to do is as important as learning what TO do.
+keywords: ["anti-patterns", "design", "scalability", "performance", "n+1", "pagination", "postgresql", "views"]
 tags: ["documentation", "reference"]
 ---
 
 # FraiseQL Anti-Patterns: What NOT to Do
 
-**Date:** January 2026
-**Status:** Complete System Specification
 **Audience:** Developers, architects, technical leads
 
 ---
 
 ## Executive Summary
 
-This document catalogs anti-patterns—designs that seem reasonable but lead to problems in practice. Learning what NOT to do is as important as learning what TO do.
+This document catalogs anti-patterns—designs that seem reasonable but lead to
+problems in practice. Learning what NOT to do is as important as learning what
+TO do.
+
+FraiseQL v1 is a **Python runtime GraphQL framework for PostgreSQL**. You
+declare types and resolvers with decorators (`@fraiseql.type`,
+`@fraiseql.query`, `@fraiseql.mutation`); the schema is built in memory at app
+startup and served over FastAPI. The architecture is CQRS:
+
+- **Reads** come from PostgreSQL **read views** (`v_`) or table-backed
+  projection views (`tv_`) via `db.find` / `db.find_one`.
+- **Writes** run through PostgreSQL **functions** (`fn_`) via
+  `db.execute_function` — all write business logic lives in the database.
+
+Most of the anti-patterns below boil down to one root cause: *fighting the
+CQRS model* by pushing logic into the Python layer that belongs in your views
+and functions.
 
 Each anti-pattern includes:
 
@@ -32,20 +44,19 @@ Each anti-pattern includes:
 
 ### 1.1 Deep Nested Queries (N+1 Problem)
 
-**Anti-pattern**: Design without considering query depth
+**Anti-pattern**: Resolving nested relationships one row at a time
 
 ```graphql
-<!-- Code example in GraphQL -->
 # ❌ WRONG: Dangerous nesting depth
 query GetUserWithEverything {
   user(id: "user-1") {
     id
     name
-    posts {                    # 1 JOIN
+    posts {                    # 1 query
       id
-      comments {              # 1 JOIN per post (N+1!)
+      comments {              # 1 query per post (N+1!)
         id
-        author {              # 1 JOIN per comment (N+1+1!)
+        author {              # 1 query per comment (N+1+1!)
           id
           name
         }
@@ -53,26 +64,66 @@ query GetUserWithEverything {
     }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 **Problem:**
 
-- For 10 posts with 5 comments each = 50 database queries
-- Exponential explosion with deeper nesting
-- Can timeout or crash database
+- For 10 posts with 5 comments each = 50+ database round trips
+- Explosion gets worse with deeper nesting
+- Can time out or overload the database
 
 **Symptoms:**
 
-- Queries timeout despite small result set
-- Database CPU spikes with simple queries
-- "Query too complex" errors
+- Queries time out despite a small result set
+- Database CPU spikes on a single GraphQL request
+- Per-field resolvers each issue their own `SELECT`
 
-**Solution**: Limit query depth
+**Solution A — compose nesting inside the view.** In FraiseQL, the natural fix
+is to build the nested shape once in your `v_`/`tv_` view's `data` JSONB, so a
+single `db.find` returns the whole tree:
+
+```sql
+-- A read view that pre-composes posts (and their comment counts) as JSONB.
+CREATE VIEW v_user AS
+SELECT
+    u.id,                                      -- public UUID (the GraphQL id)
+    jsonb_build_object(
+        'id',    u.id,
+        'name',  u.name,
+        'posts', (
+            SELECT jsonb_agg(jsonb_build_object(
+                'id',           p.id,
+                'title',        p.title,
+                'commentCount', (SELECT count(*) FROM tb_comment c
+                                 WHERE c.fk_post = p.pk_post)
+            ))
+            FROM tb_post p
+            WHERE p.fk_user = u.pk_user
+        )
+    ) AS data
+FROM tb_user u;
+```
+
+**Solution B — batch the field with a dataloader.** When a field genuinely
+needs a separate resolver, use `@fraiseql.dataloader_field` so FraiseQL batches
+the lookups into one query instead of N:
+
+```python
+import fraiseql
+
+@fraiseql.dataloader_field
+async def author(info, comment: Comment) -> User:
+    # Called once per comment, but FraiseQL collects the keys and issues a
+    # single batched load — turning N+1 queries into 1.
+    db = info.context["db"]
+    return await db.find_one("v_user", id=comment.author_id)
+```
+
+**Solution C — cap depth and page nested lists.** Keep request shapes sane and
+always paginate nested collections:
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ✅ CORRECT: Controlled nesting (2-3 levels max)
+# ✅ CORRECT: Controlled nesting, paginated nested lists, aggregates not joins
 query GetUserWithPosts {
   user(id: "user-1") {
     id
@@ -80,43 +131,23 @@ query GetUserWithPosts {
     posts(limit: 20) {
       id
       title
-      commentCount  # Aggregated, not nested
+      commentCount  # Aggregated in the view, not nested + counted in app
     }
   }
 }
+```
 
-# Separate query for comments if needed
-query GetPostComments($postId: ID!) {
-  post(id: $postId) {
-    id
-    comments(limit: 50) {
-      id
-      content
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Implementation**: Set max query depth at compile time
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.schema_rule(max_query_depth=3)
-class MySchema:
-    pass
-```text
-<!-- Code example in TEXT -->
+**Cost of ignoring:** unpredictable latency, database saturation under load, and
+GraphQL requests that work in dev but melt in production.
 
 ---
 
 ### 1.2 Unbounded Result Sets
 
-**Anti-pattern**: Queries without LIMIT
+**Anti-pattern**: Queries (and views) without a `LIMIT`
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ WRONG: No limit, returns all rows
+# ❌ WRONG: No limit, returns every row in the view
 query GetAllUsers {
   users {
     id
@@ -124,26 +155,44 @@ query GetAllUsers {
     email
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
+
+```python
+# ❌ WRONG: resolver hands the whole view back, no bound
+@fraiseql.query
+async def users(info) -> list[User]:
+    db = info.context["db"]
+    return await db.find("v_user")   # could be millions of rows
+```
 
 **Problem:**
 
-- Returns millions of rows
-- Timeouts, memory exhaustion
-- Network overload (10GB+ response)
+- Returns the entire table behind the view
+- Memory exhaustion and timeouts
+- Huge response payloads saturate the network
 
 **Symptoms:**
 
 - Server runs out of memory
 - Client connection hangs
-- Database performance tanks
+- Database and app latency spike together
 
-**Solution**: Always use pagination
+**Solution**: Always paginate — accept `limit`/`offset` (or cursor args) and
+push them into the read:
+
+```python
+# ✅ CORRECT: bounded read with a sane default cap
+@fraiseql.query
+async def users(info, limit: int = 50, offset: int = 0) -> list[User]:
+    db = info.context["db"]
+    limit = min(limit, 200)   # hard ceiling regardless of client request
+    return await db.find("v_user", limit=limit, offset=offset)
+```
+
+For client-driven paging, expose a cursor connection:
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ✅ CORRECT: Paginated with cursor
+# ✅ CORRECT: paginated with a cursor connection
 query GetUsers($first: Int!, $after: String) {
   users(first: $first, after: $after) {
     edges {
@@ -156,295 +205,412 @@ query GetUsers($first: Int!, $after: String) {
     }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
+
+**Cost of ignoring:** a single innocent-looking query can OOM the process or
+stall every other request sharing the connection pool.
 
 ---
 
-### 1.3 Synchronous Side Effects in Mutations
+### 1.3 Business Logic in Python Instead of `fn_` Functions
 
-**Anti-pattern**: Block mutation completion on side effects
+**Anti-pattern**: Implementing write logic (validation, derived state,
+multi-row updates) in the Python resolver instead of a PostgreSQL function
 
 ```python
-<!-- Code example in Python -->
-# ❌ WRONG: Mutation waits for external service
-@FraiseQL.mutation
-def create_order(input: OrderInput) -> Order:
-    # Create order
-    order = db.insert("orders", input)
+# ❌ WRONG: mutation logic lives in Python, runs many round trips,
+#          and is not transactional
+@fraiseql.mutation
+async def create_order(info, input: CreateOrderInput) -> CreateOrderSuccess:
+    db = info.context["db"]
 
-    # Wait for email service (blocking)
-    email_service.send_confirmation(order.id)  # 2 seconds!
+    # Validate by hand, in the app
+    customer = await db.find_one("v_customer", id=input.customer_id)
+    if customer is None:
+        return CreateOrderError(message="unknown customer")
 
-    # Wait for analytics (blocking)
-    analytics.log_event("order_created", order)  # 1 second!
+    # Several separate writes — not atomic, racy
+    order = await db.execute_function("fn_insert_order_row", {...})
+    for line in input.lines:
+        await db.execute_function("fn_insert_order_line", {...})
+    await db.execute_function("fn_recompute_order_total", {"id": order["id"]})
 
-    # Total: 3 seconds (should be 50ms)
-    return order
-```text
-<!-- Code example in TEXT -->
+    return CreateOrderSuccess(order=Order(**order))
+```
 
 **Problem:**
 
-- Mutation latency includes side effect latency
-- External service slowness delays user feedback
-- Failed external services block entire operation
+- Multi-step writes are not atomic — a failure midway leaves partial state
+- Validation rules drift from the database's own constraints
+- Every step is a network round trip; latency stacks up
+- The same logic gets re-implemented (inconsistently) in every caller
 
 **Symptoms:**
 
-- Mutations taking 1-5 seconds
-- User sees spinning wheel
-- Dependent systems failure crashes mutations
+- Resolvers are long and full of `if`/`await db...` chains
+- Bugs where half an operation "took" and half didn't
+- Business rules enforced in Python but missing at the SQL layer
 
-**Solution**: Make side effects async
+**Solution**: Put the write logic in one `fn_` PostgreSQL function. The resolver
+just validates the shape of the input and calls it; the function does
+validation, the writes, and returns a JSONB result in a single transaction:
 
 ```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Async side effects
-@FraiseQL.mutation
-async def create_order(input: OrderInput) -> Order:
-    # Create order (synchronous, fast)
-    order = await db.insert("orders", input)
-
-    # Schedule side effects (fire and forget)
-    asyncio.create_task(
-        email_service.send_confirmation(order.id)
+# ✅ CORRECT: resolver is thin; the database owns the write
+@fraiseql.mutation
+async def create_order(
+    info, input: CreateOrderInput
+) -> CreateOrderSuccess | CreateOrderError:
+    db = info.context["db"]
+    result = await db.execute_function(
+        "fn_create_order",
+        {"customer_id": input.customer_id, "lines": input.lines},
     )
-    asyncio.create_task(
-        analytics.log_event("order_created", order)
-    )
+    if not result.get("success"):
+        return CreateOrderError(
+            message=result.get("message", "failed"),
+            code=result.get("code", "VALIDATION_ERROR"),
+        )
+    return CreateOrderSuccess(order=Order(**result["order"]))
+```
 
-    # Return immediately
-    return order
+```sql
+-- fn_create_order does the validation + all writes atomically and returns JSONB.
+CREATE FUNCTION fn_create_order(p_customer_id uuid, p_lines jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_order_id uuid;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM tb_customer WHERE id = p_customer_id) THEN
+        RETURN jsonb_build_object('success', false,
+                                  'code', 'UNKNOWN_CUSTOMER',
+                                  'message', 'unknown customer');
+    END IF;
 
-# Mutation latency: 50ms (as it should be)
-```text
-<!-- Code example in TEXT -->
+    INSERT INTO tb_order (fk_customer)
+    SELECT pk_customer FROM tb_customer WHERE id = p_customer_id
+    RETURNING id INTO v_order_id;
+
+    INSERT INTO tb_order_line (fk_order, sku, qty)
+    SELECT (SELECT pk_order FROM tb_order WHERE id = v_order_id),
+           line->>'sku', (line->>'qty')::int
+    FROM jsonb_array_elements(p_lines) AS line;
+
+    RETURN jsonb_build_object('success', true,
+                              'order', (SELECT data FROM v_order WHERE id = v_order_id));
+END;
+$$;
+```
+
+**Cost of ignoring:** non-atomic writes, duplicated and divergent business
+rules, and slow mutations that fan out into many round trips. See
+[design principles](../../foundation/04-design-principles.md) for the rationale
+behind keeping write logic in the database.
+
+---
+
+### 1.4 Synchronous Blocking Side Effects in Resolvers
+
+**Anti-pattern**: Block resolver completion on a slow external call
+
+```python
+# ❌ WRONG: mutation waits on an external service inside the request path
+@fraiseql.mutation
+async def create_order(
+    info, input: CreateOrderInput
+) -> CreateOrderSuccess | CreateOrderError:
+    db = info.context["db"]
+    result = await db.execute_function("fn_create_order", {...})
+
+    # Blocks the whole request on third-party I/O
+    email_service.send_confirmation(result["order"]["id"])   # 2 seconds!
+    analytics.log_event("order_created", result["order"])    # 1 second!
+
+    return CreateOrderSuccess(order=Order(**result["order"]))
+```
+
+**Problem:**
+
+- Request latency now includes every side-effect's latency
+- A slow or failing third party degrades or breaks the mutation
+- The user waits on work that has nothing to do with the response
+
+**Symptoms:**
+
+- Mutations taking seconds instead of tens of milliseconds
+- Outages in a notification/analytics provider taking down writes
+- Tail latency dominated by external calls
+
+**Solution**: Get the durable write done in PostgreSQL, then dispatch side
+effects out of the request path. The most robust approach keeps the dispatch
+*inside the transaction's reach* by recording intent in the database (an outbox
+row written by `fn_create_order`) and draining it with a separate worker:
+
+```sql
+-- fn_create_order also enqueues the side effect transactionally.
+INSERT INTO tb_outbox (kind, payload)
+VALUES ('order_confirmation',
+        jsonb_build_object('order_id', v_order_id));
+```
+
+A background worker (a separate process, not the GraphQL request) reads
+`tb_outbox` and performs the email/analytics calls with retries. The resolver
+returns as soon as the database commits:
+
+```python
+# ✅ CORRECT: the request path only does the durable write
+@fraiseql.mutation
+async def create_order(
+    info, input: CreateOrderInput
+) -> CreateOrderSuccess | CreateOrderError:
+    db = info.context["db"]
+    result = await db.execute_function("fn_create_order", {...})
+    if not result.get("success"):
+        return CreateOrderError(message=result.get("message", "failed"))
+    return CreateOrderSuccess(order=Order(**result["order"]))
+```
+
+If you genuinely must dispatch from the process, hand the work to your own
+worker/queue — never `await` a slow third party inside the resolver, and never
+fire untracked background tasks whose failures vanish silently.
+
+**Cost of ignoring:** user-visible latency tied to systems you don't control,
+and side effects that are either blocking *or* silently dropped on failure.
 
 ---
 
 ## 2. Authorization Anti-Patterns
 
-### 2.1 Authorization in Application Code (Not Schema)
+### 2.1 Scattered Authorization in Resolver Code
 
-**Anti-pattern**: Put authorization logic in business logic
+**Anti-pattern**: Re-checking permissions ad hoc in every resolver
 
 ```python
-<!-- Code example in Python -->
-# ❌ WRONG: Authorization scattered in code
-@FraiseQL.query
-def get_user(id: ID) -> User:
-    user = db.query_one("SELECT * FROM tb_user WHERE id = $1", [id])
+# ❌ WRONG: authorization scattered and easy to forget
+@fraiseql.query
+async def get_user(info, id: ID) -> User | None:
+    db = info.context["db"]
+    user = await db.find_one("v_user", id=id)
 
-    # Check authorization in code
-    if user.created_by_user_id != current_user_id:
-        if not current_user.is_admin:
-            raise PermissionError("Not authorized")
-
+    current = info.context["current_user"]
+    if user.created_by != current.id and not current.is_admin:
+        raise PermissionError("Not authorized")
     return user
 
-@FraiseQL.mutation
-def delete_user(id: ID) -> bool:
-    # Different check in different place
-    user = db.query_one("SELECT * FROM tb_user WHERE id = $1", [id])
-    if user.id != current_user_id and not current_user.is_admin:
+@fraiseql.mutation
+async def delete_user(info, id: ID) -> bool:
+    # A *different* check, written by hand, in a different place
+    db = info.context["db"]
+    current = info.context["current_user"]
+    target = await db.find_one("v_user", id=id)
+    if target.id != current.id and not current.is_admin:
         raise PermissionError("Not authorized")
-
-    db.delete("tb_user", id)
+    await db.execute_function("fn_delete_user", {"id": id})
     return True
-```text
-<!-- Code example in TEXT -->
+```
 
 **Problem:**
 
-- Authorization rules scattered everywhere
-- Impossible to audit (where are all checks?)
-- Easy to forget authorization (security hole)
-- Hard to maintain (change rule = find all places)
+- Rules are duplicated and drift apart between operations
+- Impossible to audit — there is no single place that says "who can do what"
+- Easy to forget a check on a new resolver (a silent security hole)
 
 **Symptoms:**
 
-- Authorization inconsistency between operations
-- Security audits find missing checks
-- Accidental exposure of sensitive data
+- Inconsistent behavior between similar operations
+- Security reviews keep finding missing checks
+- Accidental exposure of records a user shouldn't see
 
-**Solution**: Declare authorization in schema
+**Solution**: Declare authorization once via an `Authorizer` and attach it to
+the operation, instead of re-implementing checks inline:
 
 ```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Authorization in schema (compile-time checked)
-@FraiseQL.type
-@FraiseQL.authorize(rule="owner_or_admin")
-class User:
-    id: ID
-    email: str
-    created_by_user_id: UUID  # UUID v4 for GraphQL ID
+# ✅ CORRECT: one authorizer, attached declaratively
+from fraiseql import Authorizer
 
-@FraiseQL.query
-@FraiseQL.authorize(rule="owner_or_admin")
-def get_user(id: ID) -> User:
-    # Authorization already checked (compile-time)
-    # Code is clean, authorization is auditable
-    return db.query_one(..., [id])
+owner_or_admin = OwnerOrAdminAuthorizer()   # implements Authorizer
 
-@FraiseQL.mutation
-@FraiseQL.authorize(rule="owner_or_admin")
-def delete_user(id: ID) -> bool:
-    # Same rule everywhere (consistent)
-    db.delete("tb_user", id)
-    return True
-```text
-<!-- Code example in TEXT -->
+@fraiseql.query(authorizer=owner_or_admin)
+async def get_user(info, id: ID) -> User | None:
+    db = info.context["db"]
+    return await db.find_one("v_user", id=id)
+
+@fraiseql.mutation
+async def delete_user(
+    info, input: DeleteUserInput
+) -> DeleteUserSuccess | DeleteUserError:
+    # The same rule is enforced by fn_delete_user as well — see below.
+    db = info.context["db"]
+    result = await db.execute_function("fn_delete_user", {"id": input.id})
+    if not result.get("success"):
+        return DeleteUserError(message=result.get("message", "forbidden"))
+    return DeleteUserSuccess(id=input.id)
+```
+
+Defense in depth: enforce the *data* boundary in PostgreSQL too. `fn_delete_user`
+should refuse the operation (and your views should filter by tenant/owner) so a
+missed check in the app cannot leak data. Field-level authorization is available
+via `@fraiseql.type(..., authorize_fields=...)` and the
+`@fraiseql.field`/`@fraiseql.dataloader_field` resolver path.
+
+> **Resolver-bypass note:** authorization attached to a resolver only runs when
+> that resolver runs. Cached or batched paths can shortcut the per-field
+> resolver, so always enforce the authoritative boundary in the database
+> (`fn_` functions and tenant-scoped views), not in the resolver alone.
+
+**Cost of ignoring:** an unauditable patchwork of checks, one forgotten `if`
+away from a breach.
 
 ---
 
-### 2.2 Trusting Client-Provided Authorization
+### 2.2 Trusting Client-Provided Identity or Role
 
-**Anti-pattern**: Trust user role from GraphQL input
+**Anti-pattern**: Reading the caller's role from GraphQL input
 
 ```python
-<!-- Code example in Python -->
-# ❌ WRONG: Client provides their role (can be forged)
-@FraiseQL.query
-def get_admin_panel() -> AdminPanel:
-    # Check role from GraphQL input (client can lie!)
-    if input.user_role == "admin":
-        return admin_panel_data
-
+# ❌ WRONG: the client tells you their role (and can lie)
+@fraiseql.query
+async def admin_panel(info, role: str) -> AdminPanel:
+    if role == "admin":               # forgeable!
+        return build_admin_panel(info)
     raise PermissionError()
-```text
-<!-- Code example in TEXT -->
+```
 
 **Problem:**
 
-- Client can modify GraphQL to claim any role
-- Security boundary is client-side (non-existent)
-- Any user can become admin
+- Anyone can send `role: "admin"` in the variables
+- The security boundary is on the client (i.e. nonexistent)
+- Privilege escalation is trivial
 
 **Symptoms:**
 
-- Users access restricted data
-- Audit shows unauthorized access
-- Security breach
+- Users reaching data their role shouldn't allow
+- Audit logs showing unauthorized access
+- A breach waiting to happen
 
-**Solution**: Derive authorization from verified token
+**Solution**: Derive identity and role from the verified request context (a
+validated JWT or session), never from operation arguments:
 
 ```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Server derives role from verified token
-@FraiseQL.query
-@FraiseQL.authorize(rule="admin_only")
-def get_admin_panel() -> AdminPanel:
-    # Authorization derived from verified JWT
-    # Client cannot forge role
-    return admin_panel_data
-```text
-<!-- Code example in TEXT -->
+# ✅ CORRECT: identity comes from the verified context, not the input
+@fraiseql.query(authorizer=AdminOnlyAuthorizer())
+async def admin_panel(info) -> AdminPanel:
+    # info.context["current_user"] was populated from a verified token by
+    # auth middleware; the client cannot forge it.
+    return build_admin_panel(info)
+```
+
+**Cost of ignoring:** any user can impersonate any role; there is effectively no
+access control at all.
 
 ---
 
 ## 3. Caching Anti-Patterns
 
-### 3.1 Cache Without Invalidation
+FraiseQL v1 ships a real PostgreSQL-backed result cache
+(`cached_query`, `ResultCache` / `CachedRepository`, with `CascadeRule` and
+`setup_auto_cascade_rules` for invalidation). The anti-patterns are about using
+it carelessly.
 
-**Anti-pattern**: Cache but never invalidate
+### 3.1 Caching Without Invalidation
+
+**Anti-pattern**: Cache query results but never invalidate them on write
 
 ```python
-<!-- Code example in Python -->
-# ❌ WRONG: Cache set to 1 hour, never invalidated
-FraiseQL.cache.set(
-    f"product:{product_id}",
-    product_data,
-    ttl=3600  # 1 hour
-)
+# ❌ WRONG: a long TTL with no invalidation path
+from fraiseql.caching import cached_query
 
-# User updates product price
-mutation UpdateProduct {
-  updateProduct(id: "product-1", price: 150) {
-    price
-  }
-}
+@fraiseql.query
+async def product(info, id: ID) -> Product | None:
+    db = info.context["db"]
+    return await cached_query(
+        db, "v_product", id=id, ttl=3600,   # 1 hour
+    )
+```
 
-# Cache not invalidated!
-# Next query still sees old price (for up to 1 hour)
-```text
-<!-- Code example in TEXT -->
+```graphql
+# A mutation updates the price...
+mutation { updateProduct(input: {id: "p-1", price: 150}) { product { price } } }
+# ...but nothing invalidates product:p-1, so queries serve the stale price
+# for up to an hour.
+```
 
 **Problem:**
 
-- Stale data served to users
-- Data inconsistency between instances
-- User sees old data, confused
+- Stale results served after a write
+- Reads and writes disagree
+- Users see old data and lose trust in the API
 
 **Symptoms:**
 
-- Users report stale data
-- Updates not visible immediately
-- Cache hits show old values
+- "I updated it but it still shows the old value"
+- Cache hits returning superseded data
+- Inconsistency that "fixes itself" after the TTL expires
 
-**Solution**: Invalidate on write
+**Solution**: Tie invalidation to the write with cascade rules so that mutating
+a `tv_`/`v_` source invalidates the dependent cached queries automatically:
 
 ```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Invalidate on mutation
-@FraiseQL.mutation
-async def update_product(id: ID, input: UpdateInput) -> Product:
-    # Update database
-    product = await db.update("products", id, input)
+# ✅ CORRECT: register cascade rules so writes invalidate dependent reads
+from fraiseql.caching import ResultCache, CascadeRule, setup_auto_cascade_rules
 
-    # Invalidate related caches immediately
-    cache.invalidate(f"product:{id}")
-    cache.invalidate("featured_products")
-    cache.invalidate(f"products_by_category:{product.category}")
+cache = ResultCache(...)
+setup_auto_cascade_rules(cache)          # derive rules from the schema, or:
+cache.add_cascade_rule(
+    CascadeRule(source="tv_product", invalidates=["v_product", "v_featured"])
+)
+```
 
-    return product
-```text
-<!-- Code example in TEXT -->
+When `fn_update_product` writes the product, the cascade rule clears the cached
+`v_product` and `v_featured` entries. See
+[state management](./state-management.md) for the full caching/invalidation
+model.
+
+**Cost of ignoring:** the cache becomes a correctness bug, not a performance
+win.
 
 ---
 
-### 3.2 Caching Sensitive Data
+### 3.2 Caching Sensitive Data Carelessly
 
-**Anti-pattern**: Cache PII without safeguards
+**Anti-pattern**: Cache PII or per-tenant data under a guessable, unscoped key
 
 ```python
-<!-- Code example in Python -->
-# ❌ WRONG: Cache user email (PII)
-cache.set(f"user:{user_id}", user_data)  # Contains email!
-
-# In multi-tenant system, another tenant might hit same cache
-# if they guess the key (or keys are leaked in logs)
-```text
-<!-- Code example in TEXT -->
+# ❌ WRONG: caches email (PII) under a key with no tenant scope
+cache.set(f"user:{user_id}", user_with_email)
+```
 
 **Problem:**
 
-- PII leakage between users
-- Privacy violation, compliance issue
-- Cannot be forgotten (cache persists)
+- PII lingers in a shared cache outside your access controls
+- In a multi-tenant system, an unscoped key can collide or leak across tenants
+- "Right to be forgotten" is hard when copies live in cache
 
 **Symptoms:**
 
-- Audit findings of PII in cache
-- GDPR/privacy violations
-- Users see other users' emails
+- Audits finding PII in cache storage
+- Privacy/compliance violations
+- One tenant's data surfacing for another
 
-**Solution**: Don't cache PII (or cache carefully)
+**Solution**: Cache only what is safe to share, scope keys by tenant, and keep
+sensitive fields on a short or no TTL:
 
 ```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Cache public data only
-cache.set(f"user:{user_id}", {
+# ✅ CORRECT: cache public projection, tenant-scoped key, sensitive data excluded
+cache.set(f"tenant:{tenant_id}:user:{user_id}", {
     "id": user_id,
     "name": "Alice",
     "avatar_url": "https://...",
-    # NO email, no phone, no sensitive data
+    # no email, no phone, no tokens
 })
+```
 
-# Sensitive data fetched separately (not cached)
-# Or cached with very short TTL (30 seconds)
-```text
-<!-- Code example in TEXT -->
+The cleanest version is to keep sensitive columns out of the cached `v_`/`tv_`
+view's `data` JSONB entirely, and never put internal keys (`pk_`/`fk_`) anywhere
+near the cache.
+
+**Cost of ignoring:** a privacy incident and a cache you can't safely purge.
 
 ---
 
@@ -455,445 +621,429 @@ cache.set(f"user:{user_id}", {
 **Anti-pattern**: Optimize before measuring
 
 ```python
-<!-- Code example in Python -->
-# ❌ WRONG: Complex optimization before profiling
-@FraiseQL.query
-def get_users():
-    # Manual batch loading (complex)
-    batch_size = 1000
-    users = []
-    for i in range(0, total_users, batch_size):
-        users.extend(
-            db.query(f"SELECT * FROM users LIMIT {batch_size} OFFSET {i}")
-        )
-    return users
-
-# Measurements show: This is SLOWER than simple query
-# Because: Offset pagination is O(n), not O(1)
-# Real fix: Use keyset pagination (1 query, not n queries)
-```text
-<!-- Code example in TEXT -->
+# ❌ WRONG: hand-rolled offset batching, never profiled
+@fraiseql.query
+async def users(info) -> list[User]:
+    db = info.context["db"]
+    out: list[User] = []
+    for i in range(0, 100_000, 1000):
+        out.extend(await db.find("v_user", limit=1000, offset=i))
+    return out
+# Offset pagination is O(n) in the offset — this is *slower*, not faster,
+# and it still returns an unbounded result set (see 1.2).
+```
 
 **Problem:**
 
-- Wasted effort on wrong bottleneck
-- Complex code harder to maintain
-- Solution might be slower than original
+- Effort spent on the wrong bottleneck
+- More complex code, no measured benefit
+- The "optimization" can be slower than the naive version
 
 **Symptoms:**
 
-- Optimization makes things slower
-- Complexity increases without benefit
-- Time wasted on wrong problems
+- Changes that add complexity without moving the numbers
+- Optimizations made on a hunch, not a profile
 
-**Solution**: Profile first, optimize based on data
+**Solution**: Measure first. In FraiseQL the bottleneck is almost always the
+SQL behind a view, so look there — usually it's a missing index:
 
-```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Profile, identify bottleneck, optimize
-# Profile shows: Database query taking 95% of time
-# Root cause: Missing index on filter column
-# Fix: Add index (simple, high impact)
+```sql
+-- Profile (EXPLAIN ANALYZE the view query) shows a seq scan on the filter column.
+CREATE INDEX idx_user_status ON tb_user (status);
+-- One line; 500ms -> 50ms. No application change needed.
+```
 
-CREATE INDEX idx_user_status ON tb_user(status);
+See [performance characteristics](../../foundation/12-performance-characteristics.md)
+for what to measure and the expected shapes of fast vs slow queries.
 
-# Speedup: 500ms → 50ms (10x faster, 1 line of SQL)
-```text
-<!-- Code example in TEXT -->
+**Cost of ignoring:** time burned on non-bottlenecks while the real one (an
+index, or an over-fetching view) goes untouched.
 
 ---
 
-### 4.2 Over-Replication
+### 4.2 Ignoring Indexes and Over-Fetching in Views
 
-**Anti-pattern**: Replicate data everywhere
+**Anti-pattern**: Building wide views that scan whole tables and select columns
+nobody asked for
 
-```python
-<!-- Code example in Python -->
-# ❌ WRONG: Replicate same data to 10 read replicas
-Configuration:
-  ├─ Primary database (writes)
-  ├─ Read replica 1
-  ├─ Read replica 2
-  ├─ Read replica 3
-  ├─ Read replica 4
-  ├─ Read replica 5
-  ├─ Read replica 6
-  ├─ Read replica 7
-  ├─ Read replica 8
-  ├─ Read replica 9
-  └─ Read replica 10
+```sql
+-- ❌ WRONG: builds a fat data blob and filters on an unindexed column
+CREATE VIEW v_order AS
+SELECT
+    o.id,
+    jsonb_build_object(
+        'id',        o.id,
+        'status',    o.status,
+        'lines',     (SELECT jsonb_agg(...) FROM tb_order_line ...),
+        'history',   (SELECT jsonb_agg(...) FROM tb_order_event ...),  -- huge, rarely read
+        'rawAudit',  o.audit_blob                                      -- never requested
+    ) AS data
+FROM tb_order o;
 
-# Problem: Replication lag, storage bloat, complexity
-```text
-<!-- Code example in TEXT -->
+SELECT data FROM v_order WHERE data->>'status' = 'OPEN';   -- can't use an index
+```
 
 **Problem:**
 
-- Replication lag grows with replicas
-- Storage cost multiplied
-- Complexity in managing 11 instances
-- Diminishing returns (beyond 3-5 replicas)
+- The view materializes far more JSONB than any query selects
+- Filtering on a JSONB expression bypasses ordinary column indexes
+- Sequential scans on large tables for routine queries
 
 **Symptoms:**
 
-- High replication lag (>10 seconds)
-- Huge storage costs
-- Difficult operational overhead
+- Slow reads that `EXPLAIN ANALYZE` shows as seq scans
+- High memory churn building JSONB that's immediately discarded
+- A "simple" list query that's mysteriously expensive
 
-**Solution**: Right-size replica count
+**Solution**: Keep filterable columns as real, indexed columns on the view;
+build heavy sub-objects only where they're actually needed (or in a dedicated
+`tv_` projection refreshed out of band):
 
-```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Minimal replicas for needs
-Configuration:
-  ├─ Primary database (writes): Handles mutations
-  ├─ Read replica 1: Handles queries (local datacenter)
-  ├─ Read replica 2: Handles Arrow analytics (separate)
-  └─ Read replica 3: Disaster recovery (warm standby)
+```sql
+-- ✅ CORRECT: expose an indexed status column; keep the heavy bits out of the list view
+CREATE VIEW v_order AS
+SELECT
+    o.id,
+    o.status,                                  -- real column → indexable filter
+    jsonb_build_object('id', o.id, 'status', o.status, 'total', o.total) AS data
+FROM tb_order o;
 
-# Replication lag: <1 second
-# Storage: Manageable
-# Complexity: Operationally reasonable
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_order_status ON tb_order (status);
+-- Order history / audit live in a separate detail view fetched only when asked for.
+```
+
+**Cost of ignoring:** every list query pays for data it throws away, and the
+database can't use indexes for the filters that matter.
 
 ---
 
 ## 5. Data Modeling Anti-Patterns
 
-### 5.1 Storing Derived Data Without Updates
+### 5.1 Storing Derived Data Without Updating It
 
-**Anti-pattern**: Calculate once, store forever
+**Anti-pattern**: Compute a derived value once and store it as a plain column
+that nothing keeps current
 
-```python
-<!-- Code example in Python -->
-# ❌ WRONG: Calculate user score, store, never update
-user = {
-    "id": "user-1",
-    "name": "Alice",
-    "score": 100  # Calculated once, never updated
-}
-
-# User does activities
-# Score should update
-# But it's stale in database
-
-# Query assumes score is current (it's not!)
-```text
-<!-- Code example in TEXT -->
+```sql
+-- ❌ WRONG: score is computed at insert and then drifts
+CREATE TABLE tb_user (
+    pk_user bigint GENERATED ALWAYS AS IDENTITY,
+    id      uuid DEFAULT gen_random_uuid(),
+    name    text,
+    score   int      -- set once, never recomputed as activity accrues
+);
+```
 
 **Problem:**
 
-- Stale derived data
-- Inconsistency with calculated value
-- Hard to know when last updated
+- The stored value diverges from reality over time
+- Readers assume it's current; it isn't
+- No signal that it's stale
 
 **Symptoms:**
 
-- User score doesn't match their activities
-- Reports show wrong aggregates
-- Users confused by stale data
+- Aggregates and scores that don't match the underlying rows
+- "The number is wrong" reports that can't be reproduced from the data
+- Inconsistency between the column and a fresh `COUNT(*)`
 
-**Solution**: Use database view or trigger
+**Solution**: Compute on read in a view, or maintain it in the database with a
+trigger or projection table — never leave it to chance:
 
-```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Calculate on-demand (view) or auto-update (trigger)
-
-# Option 1: View (calculate on read)
-CREATE VIEW v_user_stats AS
+```sql
+-- Option A: compute on read in the view's data JSONB
+CREATE VIEW v_user AS
 SELECT
     u.id,
-    u.name,
-    COUNT(a.id) as score
-FROM tb_user u
-LEFT JOIN tb_activity a ON u.id = a.user_id
-GROUP BY u.id;
+    jsonb_build_object(
+        'id',    u.id,
+        'name',  u.name,
+        'score', (SELECT count(*) FROM tb_activity a WHERE a.fk_user = u.pk_user)
+    ) AS data
+FROM tb_user u;
 
-# Option 2: Trigger (update on write)
-CREATE TRIGGER update_user_score
-AFTER INSERT ON tb_activity
-FOR EACH ROW
+-- Option B: maintain it on write with a trigger (when reads must be cheap)
+CREATE FUNCTION fn_bump_user_score() RETURNS trigger
+LANGUAGE plpgsql AS $$
 BEGIN
     UPDATE tb_user
-    SET score = (SELECT COUNT(*) FROM tb_activity WHERE user_id = NEW.user_id)
-    WHERE id = NEW.user_id;
+       SET score = (SELECT count(*) FROM tb_activity WHERE fk_user = NEW.fk_user)
+     WHERE pk_user = NEW.fk_user;
+    RETURN NEW;
 END;
-```text
-<!-- Code example in TEXT -->
+$$;
+
+CREATE TRIGGER trg_bump_user_score
+AFTER INSERT ON tb_activity
+FOR EACH ROW EXECUTE FUNCTION fn_bump_user_score();
+```
+
+For heavy aggregates, a `tv_` projection table refreshed by a function/trigger
+is the table-backed version of the same idea. See the
+[aggregation model](../analytics/aggregation-model.md) for derived-data
+patterns and FraiseQL's runtime auto-aggregation.
+
+**Cost of ignoring:** silently wrong numbers that erode trust and are painful to
+reconcile after the fact.
 
 ---
 
 ## 6. Concurrency Anti-Patterns
 
-### 6.1 Optimistic Locking Without Version Check
+### 6.1 Updating Without a Version (or Conditional) Check
 
-**Anti-pattern**: Update without checking version
+**Anti-pattern**: Read-then-write without guarding against a concurrent update
 
-```python
-<!-- Code example in Python -->
-# ❌ WRONG: Race condition possible
-# Thread 1: Read user (version: 1)
-user = db.query_one("SELECT * FROM tb_user WHERE id = $1", [user_id])
-
-# Thread 2: Update user (version: 1 → 2)
-db.update("tb_user", user_id, {"name": "Bob", "version": 2})
-
-# Thread 1: Update without checking version
-db.update("tb_user", user_id, {"email": "alice@example.com", "version": 1})
-
-# Result: Race condition, version conflict
 ```text
-<!-- Code example in TEXT -->
+# ❌ WRONG: lost-update race
+Tx 1: read user (version 1)
+Tx 2: update user, version 1 -> 2
+Tx 1: update user using its stale copy, clobbering Tx 2's change
+```
 
 **Problem:**
 
-- Lost updates (Thread 1 overwrites Thread 2)
-- Data corruption
-- No conflict detection
+- Lost updates: the last writer silently overwrites the others
+- No conflict is detected or reported
+- Data corruption that's invisible until someone notices missing changes
 
 **Symptoms:**
 
-- Users report updates being lost
-- Data inconsistency
-- Stale data overwrites newer data
+- "My edit disappeared"
+- Fields reverting to older values
+- Non-reproducible inconsistencies under load
 
-**Solution**: Check version before update
+**Solution**: Make the write conditional inside the `fn_` function — increment a
+`version` column and update only when the version still matches, returning a
+conflict result when it doesn't:
 
-```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Optimistic locking with version check
-user = db.query_one(
-    "SELECT id, name, email, version FROM tb_user WHERE id = $1",
-    [user_id]
-)
+```sql
+-- ✅ CORRECT: optimistic concurrency enforced in the database
+CREATE FUNCTION fn_update_user_email(p_id uuid, p_email text, p_version int)
+RETURNS jsonb
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_rows int;
+BEGIN
+    UPDATE tb_user
+       SET email = p_email,
+           version = version + 1
+     WHERE id = p_id
+       AND version = p_version;      -- only if nobody else moved it
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
 
-# Update with version check
-result = db.execute(
-    "UPDATE tb_user SET email = $1, version = version + 1 "
-    "WHERE id = $2 AND version = $3",
-    ["newemail@example.com", user_id, user.version]
-)
+    IF v_rows = 0 THEN
+        RETURN jsonb_build_object('success', false, 'code', 'CONFLICT',
+                                  'message', 'version mismatch, refresh and retry');
+    END IF;
+    RETURN jsonb_build_object('success', true);
+END;
+$$;
+```
 
-if result.rowcount == 0:
-    raise ConflictError("Version mismatch, refresh and retry")
-```text
-<!-- Code example in TEXT -->
+The resolver passes the client's `version` through and surfaces the conflict as
+a typed error result. See the
+[consistency model](../reliability/consistency-model.md) for transaction and
+concurrency guarantees.
+
+**Cost of ignoring:** silent data loss under concurrency that's nearly
+impossible to debug after the fact.
 
 ---
 
 ## 7. Subscription Anti-Patterns
 
-### 7.1 Subscribing to All Events
+FraiseQL v1 subscriptions are real and WebSocket-based: `@fraiseql.subscription`
+decorates an **async generator** whose yielded values are streamed to the
+client. The event source is *your* generator — it can be backed by PostgreSQL
+`LISTEN/NOTIFY`, polling, or an external stream.
 
-**Anti-pattern**: Get all events, filter on client
+### 7.1 Subscribing to Everything and Filtering on the Client
+
+**Anti-pattern**: Stream all events and let the client throw most away
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ❌ WRONG: Subscribe to ALL events, filter on client
+# ❌ WRONG: subscribe to all events, filter in the browser
 subscription OnAllEvents {
-  events {
-    type
-    timestamp
-    data
-  }
+  events { type timestamp data }
 }
-
-# Client filters
-if (event.type === "order_created") {
-  handleOrderCreated(event);
-}
-```text
-<!-- Code example in TEXT -->
+```
 
 **Problem:**
 
-- Network bloat (receiving events you don't care about)
-- Buffer overflow (too many events)
-- Wasted bandwidth
+- The server pushes events every client doesn't care about
+- Bandwidth and client CPU wasted on filtering
+- Slow consumers fall behind and connections drop
 
 **Symptoms:**
 
-- WebSocket connection drops (buffer full)
-- Network usage very high
-- Client CPU high (filtering all events)
+- WebSocket disconnects under event volume
+- High network usage for a handful of relevant events
+- Client-side filtering logic that mirrors what the server already knows
 
-**Solution**: Filter on server
+**Solution**: Filter at the source — take arguments in the subscription
+generator and only `yield` matching events (FraiseQL also provides a
+`subscription_filter` helper):
 
-```graphql
-<!-- Code example in GraphQL -->
-# ✅ CORRECT: Subscribe to specific events (filtered on server)
-subscription OnOrderCreated {
-  orderCreated {
-    id
-    total
-    user { id name }
-  }
-}
+```python
+# ✅ CORRECT: filter server-side; only matching events leave the server
+from collections.abc import AsyncGenerator
 
-# Server only sends order created events
-# No buffer overflow
-# Network efficient
-```text
-<!-- Code example in TEXT -->
+@fraiseql.subscription
+async def order_created(info, customer_id: UUID) -> AsyncGenerator[Order, None]:
+    async for order in watch_orders():
+        if order.customer_id == customer_id:
+            yield order
+```
+
+**Cost of ignoring:** dropped connections and wasted bandwidth that gets worse
+as traffic grows.
 
 ---
 
-### 7.2 No Heartbeat Handling
+### 7.2 Ignoring Connection Liveness
 
-**Anti-pattern**: Assume subscription always connected
+**Anti-pattern**: Assume a WebSocket subscription stays healthy forever
 
 ```python
-<!-- Code example in Python -->
-# ❌ WRONG: No heartbeat, connection silently dies
+# ❌ WRONG: no liveness handling; a dead connection looks "subscribed"
 subscription = await client.subscribe(query)
-
 async for event in subscription:
-    process_event(event)  # Dies silently if disconnected
-```text
-<!-- Code example in TEXT -->
+    process_event(event)   # silently stops if the socket is half-open
+```
 
 **Problem:**
 
-- Connection dies silently
-- Client thinks still connected
-- Missed events
+- A half-open connection delivers no events but looks connected
+- The client believes it's live and misses updates
+- No recovery without a manual refresh
 
 **Symptoms:**
 
-- Subscription appears active but receives no events
-- User doesn't know they missed events
-- Must manually refresh
+- A subscription that's "active" but quietly stops updating
+- Users unaware they've missed events
+- Reconnects only after someone notices
 
-**Solution**: Implement heartbeat/ping
+**Solution**: Use the GraphQL-over-WebSocket transport's keepalive
+(`graphql-transport-ws` ping/pong) and reconnect on missed pongs. On the server,
+FraiseQL's `WebSocketConnection` / `SubscriptionManager` handle the protocol;
+on the client, enable ping and re-subscribe on disconnect:
 
 ```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Heartbeat keeps connection alive
-subscription = await client.subscribe(query)
+# ✅ CORRECT: client monitors liveness and reconnects
+subscription = await client.subscribe(query, keepalive=30)
 
-async def monitor_subscription():
+async def watch_liveness():
     while subscription.is_active:
-        if time.time() - subscription.last_message > 30:
-            # No message in 30 seconds, send ping
-            subscription.ping()
+        if time.monotonic() - subscription.last_message > 60:
+            await subscription.reconnect()
         await asyncio.sleep(10)
+```
 
-async for event in subscription:
-    subscription.last_message = time.time()
-    process_event(event)
-```text
-<!-- Code example in TEXT -->
+**Cost of ignoring:** users silently stop receiving real-time updates and don't
+find out until it matters.
 
 ---
 
 ## 8. Testing Anti-Patterns
 
-### 8.1 Testing Without Authorization
+### 8.1 Testing Behavior but Skipping Authorization
 
-**Anti-pattern**: Test queries/mutations but skip authorization
+**Anti-pattern**: Test the happy path and never test who is allowed to do it
 
 ```python
-<!-- Code example in Python -->
-# ❌ WRONG: Test query without checking authorization
-def test_get_user():
-    result = query(GetUserQuery, variables={"id": "user-1"})
-    assert result.user.name == "Alice"
-    # Missing: Authorization test!
-
-def test_delete_user():
-    result = mutation(DeleteUserMutation, variables={"id": "user-1"})
-    assert result.success == True
-    # Missing: Test that non-owner cannot delete!
-```text
-<!-- Code example in TEXT -->
+# ❌ WRONG: only asserts the result, never the access boundary
+async def test_get_user():
+    result = await run_query(GET_USER, variables={"id": "user-1"})
+    assert result.data["user"]["name"] == "Alice"
+    # No test that a different user is rejected!
+```
 
 **Problem:**
 
-- Authorization bypassed in tests
-- Security hole not caught
-- Test passes but production fails
+- Authorization regressions sail through the test suite
+- A removed or broken check is caught only in production
+- The security boundary is the least-tested part of the system
 
 **Symptoms:**
 
-- Tests pass but users report access denied
-- Security audit finds authorization not tested
-- Production bugs
+- Green tests, but real users hit (or bypass) access errors
+- Security reviews finding untested authorization paths
 
-**Solution**: Test authorization explicitly
+**Solution**: Test both the allowed and the denied case explicitly, with the
+caller identity coming from context (as it does in production):
 
 ```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Test with and without authorization
-def test_get_user_authorized():
-    # User can access their own user
-    result = query(GetUserQuery, user_id="user-1", variables={"id": "user-1"})
-    assert result.user.name == "Alice"
+# ✅ CORRECT: assert both the grant and the denial
+async def test_get_user_owner_allowed():
+    result = await run_query(GET_USER, current_user="user-1",
+                             variables={"id": "user-1"})
+    assert result.data["user"]["name"] == "Alice"
 
-def test_get_user_unauthorized():
-    # User cannot access other user
-    result = query(GetUserQuery, user_id="user-1", variables={"id": "user-2"})
-    assert result.errors[0].code == "E_AUTH_PERMISSION_401"
+async def test_get_user_other_denied():
+    result = await run_query(GET_USER, current_user="user-1",
+                             variables={"id": "user-2"})
+    assert result.errors[0].extensions["code"] == "FORBIDDEN"
 
-def test_delete_user_admin():
-    # Admin can delete any user
-    result = mutation(DeleteUserMutation, user_role="admin", variables={"id": "user-1"})
-    assert result.success == True
+async def test_delete_user_non_owner_denied():
+    result = await run_mutation(DELETE_USER, current_user="user-1",
+                                variables={"input": {"id": "user-2"}})
+    assert result.data["deleteUser"]["__typename"] == "DeleteUserError"
+```
 
-def test_delete_user_non_owner():
-    # Non-owner cannot delete
-    result = mutation(DeleteUserMutation, user_id="user-1", variables={"id": "user-2"})
-    assert result.errors[0].code == "E_AUTH_PERMISSION_401"
-```text
-<!-- Code example in TEXT -->
+Also test the database boundary: a `fn_` function or tenant-scoped view should
+refuse a forbidden operation even if the resolver check were removed.
+
+**Cost of ignoring:** the most security-critical behavior is the only behavior
+nobody verifies.
 
 ---
 
-## 9. Deployment Anti-Patterns
+## 9. Operational Anti-Patterns
 
-### 9.1 Schema Mismatch Between Instances
+### 9.1 Skipping Health Checks on Deploy
 
-**Anti-pattern**: Different instances using different schema versions
+**Anti-pattern**: Route traffic to a new instance before it can actually serve
+requests
 
 ```text
-<!-- Code example in TEXT -->
-Production deployment:
-├─ Instance 1: CompiledSchema v2.0.0
-├─ Instance 2: CompiledSchema v2.0.0
-├─ Instance 3: CompiledSchema v2.0.1 (oops!)
-└─ Load balancer: Routes to all 3
+# ❌ WRONG: traffic shifts the moment the process starts
+1. Start new app process
+2. Load balancer immediately routes to it
+3. ...but startup (schema build, DB pool warm-up) isn't done
+4. First requests fail or hang
+```
 
-Problem: Instance 3 has different behavior
-```text
-<!-- Code example in TEXT -->
+The FraiseQL schema is built **in memory at startup** from your decorators and
+the live database connection — there is no compiled artifact to ship or version.
+What can differ between instances is the *running code* and the *database it
+points at*, so an instance is only ready once it has built its schema and
+connected.
 
 **Problem:**
 
-- Different query plans per instance
-- Non-deterministic results
-- Hard to debug (works on some instances, fails on others)
+- Requests hit an instance that isn't finished starting
+- Errors during the warm-up window
+- Confusing "works on one pod, fails on another" reports
 
 **Symptoms:**
 
-- Some instances work, others fail
-- Errors are random (instance-dependent)
-- User sees different results on refresh
+- Spikes of errors right after each deploy
+- Failures correlated with newly-added instances
+- Intermittent failures behind a load balancer
 
-**Solution**: Atomic deployments
+**Solution**: Gate traffic on a readiness check, and roll instances so old ones
+keep serving until new ones are ready and pointed at a compatible database:
 
 ```text
-<!-- Code example in TEXT -->
-Correct deployment:
+# ✅ CORRECT: ready-gated rollout
+1. Start new app process (builds schema, warms the connection pool)
+2. Readiness probe passes only after startup completes
+3. Load balancer routes to it; an old instance is drained
+4. Apply DB migrations before/with the rollout so views/functions are compatible
+```
 
-1. Deploy new code version
-2. Wait for ready signal (health check)
-3. Verify schema matches
-4. Then route traffic
-
-All instances have identical schema
-All instances behave identically
-```text
-<!-- Code example in TEXT -->
+**Cost of ignoring:** every deploy produces a burst of user-facing errors and
+flaky, instance-dependent behavior.
 
 ---
 
@@ -901,22 +1051,34 @@ All instances behave identically
 
 Before shipping code, check:
 
-- ❌ Deep query nesting? (max 3 levels)
-- ❌ Unbounded result sets? (always paginate)
-- ❌ Synchronous side effects? (make async)
-- ❌ Authorization in code? (declare in schema)
-- ❌ Trusting client input? (verify server-side)
-- ❌ Cache without invalidation? (invalidate on write)
-- ❌ Caching sensitive data? (don't)
-- ❌ Optimizing before profiling? (profile first)
-- ❌ Subscription to all events? (filter server-side)
-- ❌ Tests without authorization? (test both cases)
-- ❌ Schema mismatch across instances? (atomic deployments)
+- ❌ Per-row nested resolvers? (compose in the view or use `@fraiseql.dataloader_field`)
+- ❌ Unbounded result sets? (always paginate, with a hard ceiling)
+- ❌ Write logic in Python? (put it in a `fn_` function, atomically)
+- ❌ Blocking side effects in resolvers? (use an outbox / out-of-band worker)
+- ❌ Authorization scattered in resolvers? (declare an `Authorizer`; enforce in the DB too)
+- ❌ Trusting client-provided role/identity? (derive it from the verified context)
+- ❌ Caching without invalidation? (use `CascadeRule` / `setup_auto_cascade_rules`)
+- ❌ Caching sensitive data carelessly? (scope keys, exclude PII)
+- ❌ Optimizing before profiling? (measure the SQL; usually it's an index)
+- ❌ Filterable data buried in JSONB? (keep indexed columns; trim the view)
+- ❌ Derived data stored and forgotten? (compute in a view, or maintain via trigger)
+- ❌ Writes without a version check? (conditional update in the `fn_` function)
+- ❌ Subscriptions that send everything? (filter in the async generator)
+- ❌ No connection-liveness handling? (keepalive + reconnect)
+- ❌ Tests that skip authorization? (test both grant and denial)
+- ❌ Routing traffic before readiness? (gate on a health check)
 
 ---
 
-**Document Version**: 1.0.0
-**Last Updated**: January 2026
-**Status**: Complete specification for framework v2.x
+Learn from others' mistakes. Avoid these patterns and your FraiseQL application
+will be safer, faster, and far easier to reason about.
 
-Learn from others' mistakes. Avoid these patterns and your application will be safer and faster.
+## Related Documentation
+
+- [State management](./state-management.md) — caching and invalidation model
+- [Error handling model](../reliability/error-handling-model.md)
+- [Consistency model](../reliability/consistency-model.md)
+- [View selection guide](../database/view-selection-guide.md) — `v_` vs `tv_` reads
+- [Aggregation model](../analytics/aggregation-model.md)
+- [Design principles](../../foundation/04-design-principles.md)
+- [Performance characteristics](../../foundation/12-performance-characteristics.md)

--- a/docs/architecture/decisions/state-management.md
+++ b/docs/architecture/decisions/state-management.md
@@ -1,761 +1,361 @@
-<!-- Skip to main content -->
 ---
-
-title: FraiseQL State Management: Caching, Change Data Capture, and State Model
-description: FraiseQL state management spans three concerns:
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+title: FraiseQL State Management — Source of Truth and Result Caching
+description: How FraiseQL keeps PostgreSQL as the single source of truth while caching query results with cascade invalidation.
+keywords: ["caching", "consistency", "performance", "patterns", "postgresql"]
 tags: ["documentation", "reference"]
 ---
 
-# FraiseQL State Management: Caching, Change Data Capture, and State Model
+# FraiseQL State Management — Source of Truth and Result Caching
 
-**Date:** January 2026
-**Status:** Complete System Specification
-**Audience:** System architects, cache engineers, CDC specialists, platform engineers
+**Status:** Stable
+**Audience:** Application architects, backend engineers, DBAs
 
 ---
 
 ## Executive Summary
 
-FraiseQL state management spans three concerns:
+FraiseQL state management is built on one principle:
 
-1. **Caching** — Query result caching for performance
-2. **Change Data Capture (CDC)** — Event stream from database changes
-3. **State Model** — How consistency is maintained across cache + live data
+> **PostgreSQL is the single source of truth. Everything else is an optimization layer.**
 
-**Core principle**: Database is source of truth; cache is optimization layer; CDC drives everything else.
+There is no separate state store, no event bus, and no change-data-capture pipeline in
+FraiseQL v1. Application state lives in your PostgreSQL tables (`tb_*`), is exposed through
+read views (`v_*` / `tv_*`), and is mutated through PostgreSQL functions (`fn_*`). On top of
+that, FraiseQL ships a real **result cache** (`src/fraiseql/caching/`) that caches the JSONB
+results of view queries and invalidates them when the underlying data changes.
 
----
+This document covers two concerns:
 
-## 1. Caching Architecture
-
-### 1.1 Cache Layers
-
-```text
-<!-- Code example in TEXT -->
-                Application
-                    ↓
-    ┌───────────────────────────────┐
-    │ L1 Cache (In-Memory)          │ <1ms access
-    │ • Query results               │ • Per-instance
-    │ • Size: 100MB-1GB             │ • Process-local
-    └───────────────────────────────┘
-                    ↓
-    ┌───────────────────────────────┐
-    │ L2 Cache (Redis/Memcached)    │ 1-5ms access
-    │ • Shared across instances     │ • Cluster-wide
-    │ • Size: 1GB-10GB              │ • Network latency
-    └───────────────────────────────┘
-                    ↓
-    ┌───────────────────────────────┐
-    │ L3 Cache (Database)           │ 10-50ms access
-    │ • PostgreSQL views            │ • Permanent
-    │ • Materialized views          │ • Slowest
-    └───────────────────────────────┘
-```text
-<!-- Code example in TEXT -->
-
-### 1.2 Cache Key Generation
-
-Cache keys combine operation + context:
-
-```python
-<!-- Code example in Python -->
-# Query: GetUserPosts(userId: "user-456", limit: 20)
-cache_key = {
-    "operation": "GetUserPosts",
-    "user_id": "user-456",
-    "variables": { "limit": 20 },
-    "version": "2.0.0"
-}
-
-# Hash to string
-cache_key_string = hash(cache_key)
-# "query:GetUserPosts:user-456:limit-20:v2"
-
-# Search in L1/L2 cache
-cached_result = cache.get(cache_key_string)
-```text
-<!-- Code example in TEXT -->
-
-### 1.3 Cache TTL (Time To Live)
-
-Different TTL per operation type:
-
-```text
-<!-- Code example in TEXT -->
-Static data (Product catalog):
-  ├─ TTL: 1 hour
-  ├─ Reason: Changes infrequently
-  └─ Miss cost: <1s (reload from DB)
-
-User-specific data (My posts):
-  ├─ TTL: 5 minutes
-  ├─ Reason: User changes data frequently
-  └─ Miss cost: <100ms
-
-Real-time data (Stock prices):
-  ├─ TTL: 10 seconds
-  ├─ Reason: Changes constantly
-  └─ Miss cost: <100ms
-
-Personalized (User feed):
-  ├─ TTL: 30 seconds
-  ├─ Reason: User + algorithm dependent
-  └─ Miss cost: <500ms
-```text
-<!-- Code example in TEXT -->
-
-### 1.4 Cache Invalidation
-
-Invalidation cascade on mutation:
-
-```text
-<!-- Code example in TEXT -->
-Mutation: UpdatePost (post_id=789)
-    ↓
-1. Query database (write completes)
-    ↓
-2. Invalidate related queries:
-    ├─ GetPost(id=789) → INVALIDATE
-    ├─ GetPostsByAuthor(author_id=456) → INVALIDATE
-    ├─ GetTrendingPosts() → INVALIDATE
-    └─ GetUserFeed(user_id=456) → INVALIDATE
-    ↓
-3. Next requests:
-    ├─ GetPost(id=789) → Cache miss → Query DB
-    ├─ GetPostsByAuthor(author_id=456) → Cache miss → Query DB
-    └─ Both re-cached for TTL period
-```text
-<!-- Code example in TEXT -->
-
-### 1.5 Cache Warming
-
-Pre-populate cache on startup:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.on_startup
-async def warm_cache():
-    """Pre-populate cache with frequently accessed data"""
-    await cache.preload([
-        "GetTrendingPosts",
-        "GetPopularUsers",
-        "GetProductCatalog",
-        "GetFeaturedBrands"
-    ])
-
-Result:
-  ├─ Startup takes 2 seconds longer
-  ├─ But 95%+ hit rate from moment 1
-  ├─ Smoother user experience (no initial delays)
-  └─ Reduced database load at launch
-```text
-<!-- Code example in TEXT -->
+1. **The state model** — how PostgreSQL provides consistency for reads and writes.
+2. **Result caching** — how FraiseQL caches query results and keeps them coherent with the
+   database via TTL expiry and cascade invalidation.
 
 ---
 
-## 2. Change Data Capture (CDC)
+## 1. The State Model
 
-### 2.1 CDC Architecture
+### 1.1 Source of truth
 
-```text
-<!-- Code example in TEXT -->
-Database (PostgreSQL)
-    ├─ Trigger on INSERT/UPDATE/DELETE
-    ├─ Publishes to LISTEN channel (pg_notify)
-    ├─ Event: { type, entity_id, timestamp, payload }
-    ↓
-FraiseQL Runtime
-    ├─ LISTEN on channels
-    ├─ Receives events
-    ├─ Processes authorization
-    ├─ Publishes to subscribers
-    ├─ Invalidates caches
-    ↓
-Subscribers & Caches
-    ├─ Subscriptions (WebSocket)
-    ├─ Webhooks (HTTP)
-    ├─ Message queues (Kafka)
-    ├─ Cache invalidation
-```text
-<!-- Code example in TEXT -->
+All durable state lives in PostgreSQL:
 
-### 2.2 CDC Events
+| Layer | Object | Role |
+|-------|--------|------|
+| Write side | `tb_*` tables | Normalized source of truth |
+| Write logic | `fn_*` functions | Validation + writes (called by mutations) |
+| Read side | `v_*` views | Logical views building a `data` JSONB column |
+| Read side | `tv_*` projection tables | Pre-composed JSONB for heavy nested reads |
 
-All changes generate events:
+Queries read from `v_*` / `tv_*` views via `db.find(...)` / `db.find_one(...)`. Mutations
+call `fn_*` functions via `db.execute_function(...)`. No business state is held in the Python
+process — the schema is assembled in memory at startup, but the data is always PostgreSQL's.
 
-```python
-<!-- Code example in Python -->
-# Mutation: CreatePost
-mutation CreatePost($title: String!) {
-  createPost(input: { title: $title }) {
-    id
-    title
-  }
-}
+### 1.2 Consistency for a single database
 
-# Database trigger generates:
-Event {
-    type: "post_created",
-    entity_type: "Post",
-    entity_id: "post-789",
-    timestamp: "2026-01-15T10:30:45Z",
-    payload: {
-        id: "post-789",
-        title: "New Post",
-        author_id: "user-456",
-        created_at: "2026-01-15T10:30:45Z"
-    }
-}
-
-# Event triggers:
-
-1. Subscriptions (OnPostCreated)
-   ├─ Subscribers notified
-   └─ Delta plane events sent
-2. Cache invalidation
-   ├─ GetTrendingPosts invalidated
-   ├─ GetUserPosts(user_id=456) invalidated
-3. Webhooks (if configured)
-   ├─ POST https://external.com/webhooks/post_created
-4. Event stream (Kafka, etc.)
-   ├─ Published to post_created topic
-```text
-<!-- Code example in TEXT -->
-
-### 2.3 CDC Event Ordering
-
-**Per-entity ordering guarantee:**
+Within a single PostgreSQL instance, consistency is whatever transaction isolation your
+database is configured for. A query started after a mutation commits sees that mutation's
+effects:
 
 ```text
-<!-- Code example in TEXT -->
-Post #123 events (guaranteed ordered):
-    1. post_created (T0)
-    2. post_updated (T0 + 1s)
-    3. post_updated (T0 + 2s)
-    4. post_deleted (T0 + 3s)
+T0     Query: db.find("v_user")            sees A, B, C
+T0+1ms Mutation: db.execute_function(
+         "fn_create_user", {...})          commits user D
+T0+10ms Query: db.find("v_user")           sees A, B, C, D
+```
 
-    Subscribers see in order: 1 → 2 → 3 → 4
+PostgreSQL is the arbiter. FraiseQL does not add its own consistency protocol on top of it.
 
-Different entity events (may reorder):
-    Post #123: post_created (T0)
-    User #456: user_updated (T0 + 0.5s)
-    Post #123: post_updated (T0 + 1s)
+### 1.3 Read replicas
 
-    Subscribers may see:
-    ├─ Post #123 created
-    ├─ Post #123 updated (both for #123 ordered)
-    ├─ User #456 updated (interleaved)
-
-    OR:
-
-    ├─ Post #123 created
-    ├─ User #456 updated
-    ├─ Post #123 updated (still ordered per entity)
-```text
-<!-- Code example in TEXT -->
-
-### 2.4 CDC Event Deduplication
-
-Events may be delivered multiple times (at-least-once):
-
-```text
-<!-- Code example in TEXT -->
-Event: post_created (id: post-789)
-
-Delivery 1: Client A receives
-Delivery 2: Client B receives
-Delivery 3: Retry (network error on first attempt)
-
-Client must handle idempotency:
-```python
-<!-- Code example in Python -->
-@FraiseQL.on_event("post_created")
-async def handle_post_created(event):
-    # Check if already processed
-    if await db.query("SELECT id FROM tb_posts WHERE id = $1", event.entity_id):
-        return  # Already processed
-
-    # Process event
-    await process_event(event)
-```text
-<!-- Code example in TEXT -->
+If you route reads to PostgreSQL read replicas, you inherit PostgreSQL's streaming
+replication semantics: writes go to the primary and become visible on replicas after a small
+replication lag (typically well under a second). This is standard PostgreSQL operations, not a
+FraiseQL feature; configure it through your connection routing and `DATABASE_URL`. See the
+consistency model document linked at the end for the guarantees this provides.
 
 ---
 
-## 3. State Model
+## 2. Result Caching
 
-### 3.1 CAP Theorem Trade-off
+### 2.1 What the cache stores
 
-FraiseQL chooses **consistency and partition tolerance** (CP):
+FraiseQL caches the **result of a view query** — the JSONB payload returned by
+`db.find(...)` / `db.find_one(...)` — keyed by the view name, tenant, and query parameters.
+The cache is an optimization: a cache miss simply re-runs the query against PostgreSQL, so the
+database remains the source of truth at all times.
 
-```text
-<!-- Code example in TEXT -->
-CAP: Choose 2 of 3
-├─ Consistency (all nodes same data)
-├─ Availability (always respond)
-└─ Partition tolerance (handle network failures)
+The public API lives in `fraiseql.caching`:
 
-FraiseQL:
-├─ Consistency: ✅ (SERIALIZABLE by default)
-├─ Availability: ✅ (read replicas)
-└─ Partition tolerance: ✅ (single database, but read replicas)
+| Symbol | Purpose |
+|--------|---------|
+| `PostgresCache` | PostgreSQL-backed cache backend (UNLOGGED table) |
+| `CacheBackend` | Protocol any backend implements (`get`/`set`/`delete`/`delete_pattern`) |
+| `ResultCache` | Cache-aside engine (`get_or_set`, `invalidate`, `invalidate_pattern`, stats) |
+| `CacheConfig` | TTL and behaviour configuration |
+| `CacheStats` | Hit/miss/error counters and `hit_rate` |
+| `CacheKeyBuilder` | Deterministic, tenant-isolated cache keys |
+| `CachedRepository` | Drop-in repository wrapper that caches reads and invalidates on writes |
+| `cached_query` | Decorator to cache an arbitrary async query function |
+| `CascadeRule` | One source-domain → target-domain invalidation rule |
+| `SchemaAnalyzer` | Derives cascade rules from your GraphQL schema |
+| `setup_auto_cascade_rules` | Registers all derived cascade rules at startup |
 
-In practice:
-  ├─ Same database: Full CP
-  ├─ With replicas: Eventually consistent across replicas
-  ├─ Causal consistency for federation
-```text
-<!-- Code example in TEXT -->
+### 2.2 The PostgreSQL cache backend
 
-### 3.2 Consistency Guarantees
+`PostgresCache` is the default backend. It stores cache entries in an `UNLOGGED` PostgreSQL
+table, so writes skip the WAL and run at in-memory speeds, while the entries remain shared
+across every application instance pointed at the same database. UNLOGGED tables are cleared on
+crash/restart, which is acceptable for cache data that can be regenerated.
 
-**Single database (SERIALIZABLE isolation):**
+```python
+from psycopg_pool import AsyncConnectionPool
+from fraiseql.caching import PostgresCache, ResultCache, CacheConfig
 
-```text
-<!-- Code example in TEXT -->
-Query 1: SELECT * FROM users
-  ├─ Sees: User A, User B, User C
-  └─ Time: T0
+pool = AsyncConnectionPool("postgresql://localhost/mydb")
 
-Mutation: Create User D
-  ├─ Executed: T0 + 1ms
-  └─ Committed: T0 + 5ms
+backend = PostgresCache(pool, table_name="fraiseql_cache")
+cache = ResultCache(backend, CacheConfig(default_ttl=300, max_ttl=3600))
+```
 
-Query 2: SELECT * FROM users
-  ├─ Sees: User A, User B, User C, User D
-  └─ Time: T0 + 10ms
+Because the cache lives in PostgreSQL, every instance sees the same entries and the same
+invalidations — there is no separate caching cluster to operate, and no cross-instance event
+stream to coordinate.
 
-Guarantee: Every query sees consistent, up-to-date state
-```text
-<!-- Code example in TEXT -->
+### 2.3 Cache-aside pattern
 
-**With read replicas (eventual consistency):**
+`ResultCache.get_or_set` implements the cache-aside pattern: look up the key, and on a miss,
+run the function, store the result, and return it.
 
-```text
-<!-- Code example in TEXT -->
-Primary database: Write all mutations
-Read replicas (3 copies): Read-only
+```python
+async def get_user_posts(cache: ResultCache, db, user_id):
+    key = cache.key_builder.build_key("v_post", filters={"user_id": user_id})
 
-Mutation: Create User D
-  ├─ Written to primary at T0
-  ├─ Replicated to replica 1 at T0 + 10ms
-  ├─ Replicated to replica 2 at T0 + 20ms
-  ├─ Replicated to replica 3 at T0 + 30ms
+    async def fetch():
+        return await db.find("v_post", user_id=user_id)
 
-Query from replica 1 at T0 + 15ms:
-  ├─ Sees new user ✓ (already replicated)
+    return await cache.get_or_set(key, fetch, ttl=300)
+```
 
-Query from replica 3 at T0 + 15ms:
-  ├─ Doesn't see new user ✗ (not yet replicated)
+On a hit it returns the cached JSONB; on a miss it queries the `v_post` view and caches the
+result. Hit/miss/error counters are tracked on `cache.get_stats()`.
 
-Result: Eventual consistency (typically <1 second)
-```text
-<!-- Code example in TEXT -->
+### 2.4 Cache keys and tenant isolation
 
-### 3.3 Cache + Live Data Consistency
+`CacheKeyBuilder` produces deterministic keys from the view name plus filters, ordering, and
+pagination. Crucially, it folds the `tenant_id` into the key so one tenant can never read
+another tenant's cached data:
 
-Challenge: Cache can be stale
+```python
+key = cache.key_builder.build_key(
+    query_name="v_post",
+    tenant_id=tenant_id,        # prevents cross-tenant cache poisoning
+    filters={"status": "published"},
+    limit=20,
+)
+```
 
-```text
-<!-- Code example in TEXT -->
-Timeline:
-T0:     GetPost(id=789) → Cache miss → Query DB
-        ├─ Result: { title: "Original" }
-        └─ Cached for 5 minutes
+`CachedRepository` does this automatically: it reads `tenant_id` from the repository context
+and includes it in every key. Never cache before an authorization check — caching is keyed by
+inputs, not by the caller's permissions, so authorization must run on every request.
 
-T0+1s:  UpdatePost(id=789, title="Updated")
-        ├─ Database updated immediately
-        └─ Cache invalidated
+### 2.5 TTL
 
-T0+2s:  GetPost(id=789) → Cache miss → Query DB
-        ├─ Result: { title: "Updated" }
-        └─ Cached for 5 minutes
-
-Result: Cache always consistent (invalidated on write)
-```text
-<!-- Code example in TEXT -->
-
-**Edge case: Network partition**
+`CacheConfig` controls time-to-live. `default_ttl` applies when a call does not specify one,
+and `max_ttl` caps any per-call TTL. Choose TTL by how fresh the data must be and how
+expensive the miss is:
 
 ```text
-<!-- Code example in TEXT -->
-Normal:
-  Mutation → Update database → Invalidate cache
-  Next query: Sees new data
+Slow-changing reference data    long TTL (e.g. 1 hour) — rarely re-queried
+User-scoped data                short TTL (e.g. 5 minutes)
+Frequently changing data        very short TTL (e.g. 10–30 seconds)
+```
 
-Network partition (Redis unreachable):
-  Mutation → Update database → Cache invalidation FAILS
-  Database updated: ✓
-  Cache invalidation: ✗ (Redis down)
-  Next query → Cache hit → Sees OLD data ✗
+Even without explicit invalidation, TTL guarantees the cache is never stale for longer than
+its lifetime — a hard backstop for correctness.
 
-Recovery:
-  ├─ Redis reconnected
-  ├─ Cache still has stale data
-  ├─ Run: cache.invalidate_all() (flush cache)
-  ├─ Or: Wait for TTL expiration (5 minutes)
-  ├─ Next query sees fresh data
+### 2.6 The cached repository
+
+`CachedRepository` wraps a `FraiseQLRepository` so that reads are cached and writes invalidate
+the affected entries automatically — no changes to your resolvers:
+
+```python
+from fraiseql.caching import CachedRepository, ResultCache, PostgresCache
+
+cached_db = CachedRepository(base_repository=db, cache=ResultCache(PostgresCache(pool)))
+
+# Reads go through the cache (tenant-isolated key, cache-aside)
+posts = await cached_db.find("v_post", status="published")
+
+# Per-call overrides
+fresh = await cached_db.find("v_post", skip_cache=True)          # bypass cache
+short = await cached_db.find("v_post", cache_ttl=30)             # custom TTL
+```
+
+When a mutation runs through the cached repository, it invalidates the affected entries:
+
+```python
+# Calls fn_update_post, then invalidates cached "post" (and "posts") entries
+await cached_db.execute_function("fn_update_post", {"id": post_id, "title": "Updated"})
+```
+
+`execute_function` derives the affected view name from the function name and calls
+`invalidate_pattern` for both the singular and plural forms, so reads of those views miss on
+their next request and re-read fresh data from PostgreSQL.
+
+### 2.7 Write path and invalidation
+
+The write path is always: mutation resolver → `fn_*` function → cache invalidation.
+
 ```text
-<!-- Code example in TEXT -->
+Mutation: fn_update_post(post_id=789)
+    1. db.execute_function runs fn_update_post (write commits in PostgreSQL)
+    2. Cache entries for the affected view(s) are invalidated
+    3. Next read of those views misses → re-queries PostgreSQL → re-caches
+```
+
+Because the database commit happens first and invalidation second, a reader can at worst see a
+slightly stale cache entry until invalidation completes or the TTL expires — never lost or
+corrupted data. The source of truth is always correct.
 
 ---
 
-## 4. State Consistency Patterns
+## 3. Cascade Invalidation
 
-### 4.1 Read-After-Write (RAW) Consistency
+A single mutation often affects more than one cached view. Updating a `User` should invalidate
+cached `Post` results that embed that user's data. FraiseQL models this with **cascade rules**.
 
-User sees their own writes immediately:
+### 3.1 Cascade rules
+
+A `CascadeRule` says "when the source domain changes, invalidate the target domain":
 
 ```python
-<!-- Code example in Python -->
-# Cache key includes user_id
-cache_key = f"GetUserPosts:{user_id}"
+from fraiseql.caching import CascadeRule
 
-# Mutation by User A
-@FraiseQL.mutation
-async def createPost(input):
-    # Write to database
-    post = await db.insert(...)
+# When user data changes, invalidate post caches
+rule = CascadeRule(source_domain="user", target_domain="post", rule_type="invalidate")
+```
 
-    # Invalidate ONLY User A's cache
-    cache.invalidate(f"GetUserPosts:{user_id}")
+Rules are registered on a `PostgresCache` via `register_cascade_rule`. Cascade invalidation
+requires the optional `pg_fraiseql_cache` PostgreSQL extension; if it is not installed,
+`PostgresCache` falls back to TTL-only caching and skips cascade registration.
 
-    return post
+### 3.2 Automatic cascade rules from the schema
 
-# User A's next query
-# Cache miss (just invalidated)
-# Query database (sees their new post)
-# ✓ User A sees their own writes
-```text
-<!-- Code example in TEXT -->
+You rarely write cascade rules by hand. `SchemaAnalyzer` walks your GraphQL schema and derives
+a rule for every relationship field — `Post.author -> User` produces `user → post`,
+`Comment.author -> User` produces `user → comment`, and so on. `setup_auto_cascade_rules`
+analyzes the schema and registers all derived rules in one call:
 
-### 4.2 Causal Consistency (for federation)
+```python
+from fraiseql.caching import setup_auto_cascade_rules
 
-Events propagate in order:
+# Run once at application startup (e.g. from a FastAPI lifespan handler)
+async def configure_cache_cascades():
+    count = await setup_auto_cascade_rules(cache, app.schema, verbose=True)
+    logger.info("Registered %d cascade rules", count)
+```
 
-```text
-<!-- Code example in TEXT -->
-User A: Create Post #1 (T0)
-    ├─ Primary database: Post created
-    ├─ Event published: post_created
-    ├─ Replicas start replication: T0 + 10ms
+The analyzer reports each rule as `source_domain → target_domain` and builds a domain
+dependency graph (for example `comment` depends on `{user, post}`), giving you zero-config
+cache coherence that follows your real type relationships.
 
-User B (on different subgraph): Query posts
-    ├─ At T0 + 20ms (after replication)
-    ├─ Sees Post #1 ✓
-    ├─ Causal consistency maintained
-
-User C (on different subgraph): Query posts
-    ├─ At T0 + 5ms (before replication)
-    ├─ Doesn't see Post #1 (not replicated yet)
-    ├─ Re-queries at T0 + 25ms
-    ├─ Sees Post #1 ✓
-```text
-<!-- Code example in TEXT -->
-
-### 4.3 Eventual Consistency (multi-database)
-
-Different databases eventually consistent:
+### 3.3 How a cascade fires
 
 ```text
-<!-- Code example in TEXT -->
-Database A (Primary for users): User created
-Database B (Replica): Gets replicated
-Database C (Replica): Gets replicated
-
-Timeline:
-  T0: User created in Database A
-  T0+10ms: Database B sees user
-  T0+20ms: Database C sees user
-
-Queries during replication:
-  T0+5ms  from DB C: Doesn't see user (not replicated)
-  T0+15ms from DB C: Sees user (replicated)
-
-Consistency model: Eventual (typically <1s)
-```text
-<!-- Code example in TEXT -->
+Mutation: fn_update_user(user_id=456)
+    1. fn_update_user commits in PostgreSQL
+    2. "user" domain marked changed
+    3. Cascade rules fire:
+         user → post      → invalidate cached posts that embed this user
+         user → comment   → invalidate cached comments that embed this user
+    4. Next reads of those views miss → re-query PostgreSQL → re-cache
+```
 
 ---
 
-## 5. Advanced Caching Patterns
+## 4. Layered Caching Thinking
 
-### 5.1 Cache-Aside Pattern
+The classic L1/L2 layering still applies, expressed through this API rather than a bespoke
+multi-tier cache:
 
-Check cache first, update on miss:
+- **PostgreSQL as the shared cache layer.** `PostgresCache` (an UNLOGGED table) is fast and
+  shared across all instances, filling the role a separate cache cluster would otherwise play
+  — with no extra infrastructure.
+- **Per-call read-through.** `ResultCache.get_or_set` (and `CachedRepository`) is the
+  read-through tier: every read checks the cache first and only touches the underlying view on
+  a miss.
+- **PostgreSQL views/projection tables as the durable backing store.** `v_*` views and `tv_*`
+  projection tables are the permanent state; `tv_*` tables additionally pre-compose heavy
+  JSONB so even a cache miss is cheap.
 
-```python
-<!-- Code example in Python -->
-async def get_user_posts(user_id):
-    # Check L1 cache
-    key = f"posts:{user_id}"
-    cached = cache_l1.get(key)
-    if cached:
-        return cached
-
-    # Check L2 cache
-    cached = await cache_l2.get(key)
-    if cached:
-        cache_l1.set(key, cached)  # Promote to L1
-        return cached
-
-    # Miss in both → Query database
-    result = await db.query(f"SELECT * FROM v_post WHERE user_id = {user_id}")
-
-    # Populate both caches
-    cache_l1.set(key, result, ttl=5*60)
-    await cache_l2.set(key, result, ttl=1*60*60)
-
-    return result
-```text
-<!-- Code example in TEXT -->
-
-### 5.2 Write-Through Caching
-
-Update cache on write:
-
-```python
-<!-- Code example in Python -->
-async def create_post(input):
-    # Write to database
-    post = await db.insert("tb_post", input)
-
-    # Update cache immediately
-    user_id = input.user_id
-    key = f"posts:{user_id}"
-
-    # Get current cache value
-    cached_posts = cache.get(key) or []
-
-    # Add new post
-    cached_posts.append(post)
-
-    # Write back to cache
-    cache.set(key, cached_posts, ttl=5*60)
-
-    return post
-```text
-<!-- Code example in TEXT -->
-
-### 5.3 Write-Behind Caching
-
-Update cache, then database (async):
-
-```python
-<!-- Code example in Python -->
-async def update_user_profile(user_id, data):
-    # Update cache immediately
-    cache.set(f"user:{user_id}", data)
-
-    # Update database asynchronously
-    asyncio.create_task(
-        db.update("tb_user", user_id, data)
-    )
-
-    return data
-
-# Client sees update immediately (from cache)
-# Database eventually consistent (async write)
-```text
-<!-- Code example in TEXT -->
+If you need an additional in-process or external tier, implement the `CacheBackend` protocol
+(`get` / `set` / `delete` / `delete_pattern`) and pass it to `ResultCache`. The cache-aside,
+TTL, and cascade behaviour come for free regardless of backend.
 
 ---
 
-## 6. CDC Integration Patterns
+## 5. Decorator-Based Caching
 
-### 6.1 Event-Driven Cache Invalidation
-
-Events drive cache updates:
+For caching an arbitrary async query function (outside the repository), use `cached_query`:
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.on_event("post_updated")
-async def on_post_updated(event):
-    """When post is updated, invalidate related caches"""
+from fraiseql.caching import cached_query, ResultCache, PostgresCache
 
-    # Get post details from event
-    post_id = event.entity_id
-    user_id = event.payload["user_id"]
+cache = ResultCache(PostgresCache(pool))
 
-    # Invalidate caches
-    cache.invalidate(f"post:{post_id}")
-    cache.invalidate(f"posts:{user_id}")
-    cache.invalidate("trending_posts")
-    cache.invalidate(f"user_feed:{user_id}")
+@cached_query(cache, ttl=60)
+async def trending_posts(limit: int = 20):
+    return await db.find("v_post", order_by=[("score", "desc")], limit=limit)
 
-@FraiseQL.on_event("post_deleted")
-async def on_post_deleted(event):
-    # Similar invalidation
-    ...
-```text
-<!-- Code example in TEXT -->
+# Bypass on demand
+fresh = await trending_posts(limit=20, skip_cache=True)
+```
 
-### 6.2 Event Sourcing
-
-Use events as primary store (optional):
-
-```python
-<!-- Code example in Python -->
-# Traditional: Store state
-POST v_post: { id, title, content, updated_at }
-
-# Event sourcing: Store history
-tb_post_events: [
-    { type: "created", timestamp: T0, data: {...} },
-    { type: "title_updated", timestamp: T1, data: {...} },
-    { type: "content_updated", timestamp: T2, data: {...} }
-]
-
-Current state = Apply events from T0 to Tn
-```text
-<!-- Code example in TEXT -->
+The decorator builds a key from the function name and arguments (or a `key_func` you provide)
+and runs the same cache-aside path as `ResultCache.get_or_set`.
 
 ---
 
-## 7. State Consistency Monitoring
+## 6. Monitoring
 
-### 7.1 Metrics
+`ResultCache.get_stats()` returns a `CacheStats` with `hits`, `misses`, `errors`, `total`, and
+a computed `hit_rate`. `PostgresCache.get_stats()` exposes backend-level statistics (entry
+counts, expiry). Watch:
 
-```text
-<!-- Code example in TEXT -->
-Cache metrics:
-  ├─ Hit rate: Target >80%
-  ├─ Invalidation rate: Monitor trends
-  ├─ TTL distribution: Ensure balanced
-  └─ Size: Monitor growth
-
-Replication metrics:
-  ├─ Replication lag: Target <1s
-  ├─ Bytes replicated: Monitor bandwidth
-  └─ Failed replications: Alert
-
-CDC metrics:
-  ├─ Event latency: Target <100ms
-  ├─ Event ordering: Verify per-entity
-  ├─ Delivery reliability: Target 99.99%
-```text
-<!-- Code example in TEXT -->
-
-### 7.2 Health Checks
-
-```text
-<!-- Code example in TEXT -->
-Cache health:
-  ├─ Redis connectivity: UP/DOWN
-  ├─ Memcached connectivity: UP/DOWN
-  └─ Response time: <5ms
-
-Replication health:
-  ├─ Primary-replica lag: <1s?
-  ├─ Bytes behind: <100MB?
-  └─ Replication errors: 0?
-
-CDC health:
-  ├─ LISTEN channels: Connected?
-  ├─ Event backlog: <100?
-  └─ Trigger functions: Enabled?
-```text
-<!-- Code example in TEXT -->
+- **Hit rate** — aim high; a sustained low hit rate suggests TTLs are too short or keys are too
+  granular.
+- **Invalidation activity** — a spike alongside writes is expected; a constant churn may mean
+  cascade rules are too broad.
+- **Errors** — cache errors are logged and degrade gracefully to a direct database read, so the
+  request still succeeds; investigate the trend, not individual misses.
 
 ---
 
-## 8. State Management Configuration
+## 7. Best Practices
 
-### 8.1 Caching Configuration
+**Do**
 
-```python
-<!-- Code example in Python -->
-FraiseQL.state.configure({
-    "cache": {
-        "l1": {
-            "backend": "memory",
-            "max_size_mb": 500,
-            "eviction": "lru"  # Least recently used
-        },
-        "l2": {
-            "backend": "redis",
-            "url": "redis://localhost:6379",
-            "max_size_mb": 5000
-        },
-        "default_ttl_seconds": 300,
-        "warmup_on_startup": True
-    },
+- Treat PostgreSQL as the source of truth — the cache is always optional for correctness.
+- Always include `tenant_id` in cache keys (`CacheKeyBuilder` / `CachedRepository` do this).
+- Set a TTL on every cached query as a correctness backstop, even with cascade rules.
+- Let `setup_auto_cascade_rules` derive cascade rules from your schema; add manual
+  `CascadeRule`s only for relationships the schema can't express.
+- Run authorization on every request, before serving from cache.
 
-    "invalidation": {
-        "strategy": "cascade",  # Cascade invalidation
-        "batch_size": 100,
-        "delay_ms": 10
-    }
-})
-```text
-<!-- Code example in TEXT -->
+**Don't**
 
-### 8.2 CDC Configuration
-
-```python
-<!-- Code example in Python -->
-FraiseQL.state.configure({
-    "cdc": {
-        "enabled": True,
-        "database": "postgresql",
-        "triggers": True,  # Use database triggers
-        "listen_timeout_seconds": 300,
-        "retry_policy": "exponential"
-    },
-
-    "replication": {
-        "replicas": [
-            "postgresql://replica1:5432/FraiseQL",
-            "postgresql://replica2:5432/FraiseQL"
-        ],
-        "lag_threshold_ms": 1000
-    }
-})
-```text
-<!-- Code example in TEXT -->
+- Rely on the cache for correctness — it is an optimization, not a state store.
+- Cache without a TTL.
+- Cache a value before checking the caller's permissions.
+- Invent an external event pipeline for invalidation — invalidation is driven by mutations
+  going through `fn_*` functions and the cascade rules above.
 
 ---
 
-## 9. Best Practices
+## See Also
 
-### 9.1 Caching
-
-**DO:**
-
-- ✅ Monitor cache hit rate
-- ✅ Adjust TTL based on access patterns
-- ✅ Invalidate on all related mutations
-- ✅ Use read replicas for analytics (no cache impact)
-- ✅ Test cache behavior with failures
-
-**DON'T:**
-
-- ❌ Rely on cache for correctness (optional optimization)
-- ❌ Cache without TTL expiration
-- ❌ Ignore stale data during network partition
-- ❌ Cache before authorization check (must check on every request)
-
-### 9.2 CDC
-
-**DO:**
-
-- ✅ Process events idempotently (handle duplicates)
-- ✅ Monitor event lag
-- ✅ Test failure scenarios (database down, network partition)
-- ✅ Use per-entity ordering guarantee
-
-**DON'T:**
-
-- ❌ Assume global event ordering
-- ❌ Lose events (use durable event log)
-- ❌ Block event processing (async handling)
-
----
-
-**Document Version**: 1.0.0
-**Last Updated**: January 2026
-**Status**: Complete specification for framework v2.x
-
-FraiseQL state management optimizes performance (caching) while maintaining consistency (CDC + immutable source of truth).
+- [Anti-Patterns](./anti-patterns.md) — state and caching mistakes to avoid.
+- [Consistency Model](../reliability/consistency-model.md) — the guarantees PostgreSQL provides.
+- [tv_ Table Pattern](../database/tv-table-pattern.md) — pre-composed projection tables for heavy reads.
+- [View Selection Guide](../database/view-selection-guide.md) — choosing between `v_` and `tv_` sources.
+- [Performance Characteristics](../../foundation/12-performance-characteristics.md) — latency and throughput context.
+- [Result Caching Guide](../../performance/caching.md) — full configuration and the `pg_fraiseql_cache` extension.

--- a/docs/architecture/integration/extension-points.md
+++ b/docs/architecture/integration/extension-points.md
@@ -1,842 +1,468 @@
-<!-- Skip to main content -->
 ---
-
-title: FraiseQL Extension Points: Plugins, Customization, and Integration Hooks
-description: FraiseQL provides extension points for customization without modifying core framework. Developers can extend behavior through hooks, custom validators, authoriz
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+title: "FraiseQL Extension Points: Customizing and Extending the Framework"
+description: FraiseQL v1 is extensible through custom field resolvers, dataloaders, scalars, FastAPI/ASGI middleware, operation authorizers, and PostgreSQL itself. This guide documents the real extension surfaces.
+keywords: ["extension", "customization", "resolvers", "dataloaders", "scalars", "middleware", "authorization", "postgresql"]
 tags: ["documentation", "reference"]
 ---
 
-# FraiseQL Extension Points: Plugins, Customization, and Integration Hooks
+# FraiseQL Extension Points: Customizing and Extending the Framework
 
-**Date:** January 2026
-**Status:** Complete System Specification
-**Audience:** Framework extension developers, plugin authors, integration engineers
+**Audience:** Application developers, integration engineers, framework users
 
 ---
 
 ## Executive Summary
 
-FraiseQL provides extension points for customization without modifying core framework. Developers can extend behavior through hooks, custom validators, authorization rules, and metrics.
+FraiseQL v1 is a Python runtime GraphQL framework for PostgreSQL. You define your
+schema with decorators; at application startup the schema is built in memory and
+served over FastAPI. There is no compile step and no separate plugin runtime.
 
-**Core principle**: Extensibility through composition, not modification. All extensions operate within compiled schema constraints.
+Extensibility is achieved through **composition** — you extend behavior by adding
+your own resolvers, scalars, middleware, and authorizers, and by pushing logic into
+PostgreSQL. The framework exposes the following real extension points:
+
+| Extension point | What it customizes |
+|-----------------|--------------------|
+| `@fraiseql.field` | Computed / derived fields on a type (sync or async) |
+| `@fraiseql.dataloader_field` | Batched field resolution to prevent N+1 queries |
+| Custom scalars | Domain-specific typed values |
+| FastAPI / ASGI middleware | Cross-cutting request/response behavior |
+| `Authorizer` + `authorizer=` | Per-operation and global authorization |
+| PostgreSQL | The deepest surface: `fn_` functions, triggers, custom types, extensions |
 
 ---
 
-## 1. Authorization Rule Extensions
+## 1. Custom Field Resolvers
 
-### 1.1 Custom Authorization Rules
-
-Define custom rules beyond built-in:
+Use `@fraiseql.field` to add a computed or derived field to a `@fraiseql.type`. The
+decorated method becomes a GraphQL field whose value is produced at resolution time
+rather than read directly from the view's `data` JSONB.
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.authorization_rule(name="published_or_author")
-def rule_published_or_author(
-    resource: Any,
-    user_context: UserContext
-) -> bool:
-    """Published posts or posts by current user"""
-    return (
-        resource.published == True
-        or resource.author_id == user_context.user_id
-    )
+import fraiseql
 
-@FraiseQL.authorization_rule(name="team_member")
-def rule_team_member(
-    resource: Any,
-    user_context: UserContext
-) -> bool:
-    """User is member of resource's team"""
-    return resource.team_id in user_context.team_ids
 
-# Use in schema
-@FraiseQL.type
+@fraiseql.field(resolver=None, description=None, track_n1=True)
+def field(...): ...
+```
+
+The signature is:
+
+- `resolver` — an optional custom resolver to override the default behavior
+  (defaults to `None`, in which case the decorated method body is the resolver).
+- `description` — the field description that appears in the GraphQL schema.
+- `track_n1` — whether to track N+1 query patterns for this field (default `True`).
+
+### 1.1 Synchronous computed field
+
+```python
+import fraiseql
+
+
+@fraiseql.type(sql_source="v_user")
+class User:
+    id: fraiseql.ID
+    first_name: str
+    last_name: str
+
+    @fraiseql.field(description="User's full display name")
+    def display_name(self) -> str:
+        return f"{self.first_name} {self.last_name}"
+```
+
+### 1.2 Async field with database access
+
+The resolver receives the GraphQL `info` object, so it can reach the request-scoped
+repository through `info.context["db"]` and run additional reads.
+
+```python
+import fraiseql
+from uuid import UUID
+
+
+@fraiseql.type(sql_source="v_user")
+class User:
+    id: UUID
+
+    @fraiseql.field(description="Number of posts authored by this user")
+    async def post_count(self, info) -> int:
+        db = info.context["db"]
+        return await db.fetchval(
+            "SELECT count(*) FROM v_post WHERE author_id = $1", self.id
+        )
+```
+
+Because the parent object (`self`) and `info` are both available, a custom field can
+combine already-loaded data with a targeted query. Keep these resolvers cheap: if a
+field issues one query per parent row, batch it with a dataloader instead (next
+section).
+
+---
+
+## 2. Dataloaders: Batching to Prevent N+1
+
+When a field needs to look up a related record for every parent in a list, resolving
+it one row at a time produces an N+1 query pattern. `@fraiseql.dataloader_field`
+batches those lookups into a single load.
+
+```python
+def dataloader_field(
+    loader_class: type[DataLoader],
+    *,
+    key_field: str,
+    description: str | None = None,
+) -> ...: ...
+```
+
+- `loader_class` — a `DataLoader` subclass that knows how to batch-load by key.
+- `key_field` — the attribute on the parent object holding the key to load.
+- `description` — optional field description for the GraphQL schema.
+
+The decorated method must have the signature `(self, info) -> ReturnType`; its body
+is auto-implemented by the decorator.
+
+```python
+import fraiseql
+from uuid import UUID
+from fraiseql.optimization.dataloader import DataLoader
+
+
+class UserDataLoader(DataLoader):
+    async def batch_load(self, keys: list[UUID]) -> list["User | None"]:
+        db = self.context["db"]
+        rows = await db.find("v_user", id__in=keys)
+        by_id = {row.id: row for row in rows}
+        return [by_id.get(key) for key in keys]
+
+
+@fraiseql.type(sql_source="v_post")
 class Post:
-    @FraiseQL.authorize(rule="published_or_author")
-    content: str
+    id: UUID
+    author_id: UUID
 
-@FraiseQL.type
-class Project:
-    @FraiseQL.authorize(rule="team_member")
-    budget: float
-```text
-<!-- Code example in TEXT -->
+    @fraiseql.dataloader_field(UserDataLoader, key_field="author_id")
+    async def author(self, info) -> "User | None":
+        """Load the post author. Batched across all posts in the request."""
+        ...  # implementation generated by the decorator
+```
 
-### 1.2 Complex Rule Logic
+All `author` lookups across a page of posts collapse into one batched load instead
+of one query per post.
 
-Rules can access database for context:
+See also: [type system](../../foundation/09-type-system.md).
 
-```python
-<!-- Code example in Python -->
-@FraiseQL.authorization_rule(name="department_lead_or_admin")
-async def rule_department_lead(
-    resource: Any,
-    user_context: UserContext,
-    db: Database  # Database connection provided
-) -> bool:
-    """User is department lead or admin"""
-    if user_context.is_admin:
-        return True
+---
 
-    # Query to check if user is lead of this department
-    is_lead = await db.query_one(
-        "SELECT COUNT(*) FROM tb_department_leads "
-        "WHERE user_id = $1 AND department_id = $2",
-        [user_context.user_id, resource.department_id]
-    )
-    return bool(is_lead)
-```text
-<!-- Code example in TEXT -->
+## 3. Custom Scalars
 
-### 1.3 Dynamic Rule Caching
-
-Cache authorization decisions:
+FraiseQL ships a library of domain scalars in `fraiseql.types`. Importing and
+annotating a field with one of these gives you parsing, serialization, and GraphQL
+schema typing for free.
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.authorization_rule(
-    name="expensive_rule",
-    cache_ttl_seconds=300,
-    cache_key_fields=["user_id", "resource_id"]
+import fraiseql
+from fraiseql.types import ID, DateTime, EmailAddress, JSON, LTree
+
+
+@fraiseql.type(sql_source="v_account")
+class Account:
+    id: ID
+    email: EmailAddress      # validated email scalar
+    created_at: DateTime     # ISO-8601 timestamp scalar
+    metadata: JSON           # arbitrary JSON payload
+    path: LTree              # PostgreSQL ltree hierarchical path
+```
+
+Available scalars include `ID`, `Date`, `DateTime`, `EmailAddress`, `JSON`, `LTree`,
+and many more domain types. Each scalar carries its own validation and
+serialization, so an `EmailAddress` field rejects malformed input at the GraphQL
+boundary before it ever reaches your resolver, and an `LTree` value maps cleanly onto
+PostgreSQL's `ltree` type.
+
+For the complete catalog and the rules each scalar enforces, see the
+[scalars reference](../../reference/scalars.md).
+
+---
+
+## 4. FastAPI / ASGI Middleware
+
+FraiseQL serves its GraphQL endpoint as a FastAPI application, so the entire FastAPI
+and Starlette middleware ecosystem is available to you. There are two ways to add
+cross-cutting request/response behavior.
+
+### 4.1 Add middleware to the generated app
+
+`create_fraiseql_app` returns a `FastAPI` instance. Add standard middleware to it
+with `add_middleware`:
+
+```python
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+    production=True,
 )
-async def expensive_rule(resource, user_context, db):
-    """Rule with expensive computation"""
-    # Cached automatically for 5 minutes
-    # Cache key: {user_id}:{resource_id}
 
-    result = await db.query_expensive(...)
-    return result
-```text
-<!-- Code example in TEXT -->
+app.add_middleware(GZipMiddleware, minimum_size=1024)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://app.example.com"],
+    allow_methods=["POST"],
+    allow_headers=["authorization", "content-type"],
+)
+```
+
+### 4.2 Mount FraiseQL inside a larger FastAPI app
+
+To run FraiseQL alongside your own REST routes and middleware, build your FastAPI app
+first and pass it to `create_fraiseql_app` via the `app=` parameter. FraiseQL extends
+that app with its GraphQL endpoint rather than creating a new one:
+
+```python
+from fastapi import FastAPI
+from fraiseql.fastapi import create_fraiseql_app
+
+parent = FastAPI(title="My Service")
+
+
+@parent.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+# Add your own middleware to the parent app, then hand it to FraiseQL.
+app = create_fraiseql_app(
+    app=parent,
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+)
+```
+
+Because middleware runs at the ASGI layer, it wraps every GraphQL request uniformly —
+ideal for request IDs, structured logging, compression, CORS, and security headers.
 
 ---
 
-## 2. Validation Rule Extensions
+## 5. Authorization
 
-### 2.1 Custom Validators
+FraiseQL enforces authorization at the **operation** level through the `Authorizer`
+protocol. An authorizer decides whether a top-level query, mutation, or subscription
+may run for the current request.
 
-Define validation on input fields:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.validator(name="email_validator")
-def validate_email(value: str) -> None:
-    """Validate email format and domain"""
-    if not "@" in value:
-        raise ValidationError("Invalid email format")
-
-    domain = value.split("@")[1]
-    if domain not in ["company.com", "trusted-partner.com"]:
-        raise ValidationError(f"Email domain {domain} not allowed")
-
-@FraiseQL.validator(name="password_strength")
-def validate_password(value: str) -> None:
-    """Validate password meets security requirements"""
-    if len(value) < 12:
-        raise ValidationError("Password must be at least 12 characters")
-
-    if not any(c.isupper() for c in value):
-        raise ValidationError("Password must contain uppercase letter")
-
-    if not any(c.isdigit() for c in value):
-        raise ValidationError("Password must contain digit")
-
-# Use in schema
-@FraiseQL.type
-class User:
-    @FraiseQL.validate(rule="email_validator")
-    email: str
-
-    @FraiseQL.mutation
-    @FraiseQL.validate(rule="password_strength")
-    def update_password(self, new_password: str) -> bool:
-        """Update user password"""
-        pass
-```text
-<!-- Code example in TEXT -->
-
-### 2.2 Async Validators
-
-Validators can query database:
+### 5.1 The Authorizer protocol
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.validator(name="unique_email")
-async def validate_unique_email(
-    value: str,
-    db: Database
-) -> None:
-    """Ensure email is unique in database"""
-    existing = await db.query_one(
-        "SELECT id FROM tb_user WHERE email = $1",
-        [value]
+from typing import Any
+from fraiseql.security import AuthorizationDecision
+
+
+class Authorizer:
+    async def authorize_operation(
+        self,
+        *,
+        context: dict[str, Any],
+        operation_type,        # OperationType (query / mutation / subscription)
+        operation_name: str,
+        arguments: dict[str, Any],
+    ) -> AuthorizationDecision | bool:
+        ...
+```
+
+`authorize_operation` may be sync or async and may return either a plain `bool` (sugar
+for allow/deny) or an `AuthorizationDecision` carrying a stable `code`, message, and
+optional row filters. Enforcement is **fail-closed**: if no authorizer is configured
+the operation is allowed; if a configured authorizer raises an unexpected error the
+operation is denied and the raw error is never surfaced to the client.
+
+### 5.2 Global and per-operation authorizers
+
+Pass an authorizer to `create_fraiseql_app` to apply it to every operation, and
+override it on a single operation with `@fraiseql.query(authorizer=...)` or
+`@fraiseql.subscription(authorizer=...)`. The per-operation authorizer wins over the
+global default.
+
+```python
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+
+
+class TenantAuthorizer:
+    async def authorize_operation(self, *, context, operation_type, operation_name, arguments):
+        return context.get("tenant_id") is not None
+
+
+@fraiseql.query(authorizer=AdminOnlyAuthorizer())
+async def all_tenants(info) -> list[Tenant]:
+    db = info.context["db"]
+    return await db.find("v_tenant")
+
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[Tenant],
+    queries=[all_tenants],
+    authorizer=TenantAuthorizer(),   # global default
+)
+```
+
+### 5.3 Decision caching
+
+Repeated authorization checks for the same context and operation can be served from a
+decision cache instead of re-running the authorizer. Enable it by passing an
+`AuthorizationCacheConfig` to `create_fraiseql_app`:
+
+```python
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.security import AuthorizationCacheConfig
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[Tenant],
+    queries=[all_tenants],
+    authorizer=TenantAuthorizer(),
+    authorization_cache=AuthorizationCacheConfig(),
+)
+```
+
+A fresh cache hit replays the prior decision without calling the authorizer. Clean
+returns (allow or deny) are cached; an authorizer that raises hits the fail-closed
+branch and is never cached, so a transient error can neither pin a deny nor leak an
+allow.
+
+### 5.4 Enterprise RBAC
+
+For role-based access control at scale, the optional `fraiseql.enterprise.rbac`
+module provides hierarchical roles, PostgreSQL-native permission caching with
+automatic invalidation, and supporting GraphQL directives and middleware. Initialize
+it during startup with `setup_rbac_cache(db_pool)` and layer it on top of the
+`Authorizer` surface described above.
+
+For the full authorization model, see the
+[authorization guide](../../security/authorization.md).
+
+---
+
+## 6. PostgreSQL: The Deepest Extension Surface
+
+In FraiseQL, PostgreSQL is not just storage — it is where most extension actually
+happens. Reads are served from `v_`/`tv_` views and writes run through `fn_`
+functions, so you can extend behavior end to end without touching the framework.
+
+### 6.1 Business logic in `fn_` functions
+
+Every mutation calls a PostgreSQL function that performs validation and the write,
+then returns JSONB describing success or failure. This is the primary place to put
+domain logic.
+
+```sql
+CREATE FUNCTION fn_create_user(input jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    new_id uuid;
+BEGIN
+    IF NOT (input->>'email') ~ '^[^@]+@[^@]+$' THEN
+        RETURN jsonb_build_object('success', false, 'message', 'invalid email');
+    END IF;
+
+    INSERT INTO tb_user (id, name, email)
+    VALUES (gen_random_uuid(), input->>'name', input->>'email')
+    RETURNING id INTO new_id;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'user', jsonb_build_object('id', new_id, 'name', input->>'name')
+    );
+END;
+$$;
+```
+
+```python
+import fraiseql
+
+
+@fraiseql.mutation
+async def create_user(info, input: CreateUserInput) -> CreateUserSuccess | CreateUserError:
+    db = info.context["db"]
+    result = await db.execute_function(
+        "fn_create_user", {"name": input.name, "email": input.email}
     )
+    if not result.get("success"):
+        return CreateUserError(message=result.get("message", "failed"))
+    return CreateUserSuccess(user=User(**result["user"]))
+```
 
-    if existing:
-        raise ValidationError(f"Email {value} already exists")
+### 6.2 Triggers and custom types
 
-# Use in mutation
-@FraiseQL.mutation
-def create_user(input: CreateUserInput) -> User:
-    """Create user with unique email validation"""
-    # @unique_email validator runs during input validation
-    pass
-```text
-<!-- Code example in TEXT -->
+Use triggers to keep projection views (`tv_`) in sync, maintain audit trails, or
+populate denormalized columns. Use PostgreSQL `CREATE TYPE` (composite or enum types)
+and `DOMAIN` constraints to model domain values at the database level — the shape your
+views return flows straight into the GraphQL response.
 
----
+### 6.3 PostgreSQL extensions
 
-## 3. Lifecycle Hooks
+Because views are just SQL, any installed PostgreSQL extension is available to your
+read and write paths:
 
-### 3.1 Query Hooks
+- **pgvector** — similarity search over embeddings inside a `v_` view.
+- **pg_trgm** — fuzzy text matching and trigram indexes.
+- **PostGIS** — geospatial queries and indexing.
+- **ltree** — hierarchical paths, surfaced through the `LTree` scalar.
 
-Execute code before/after queries:
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
 
-```python
-<!-- Code example in Python -->
-@FraiseQL.hook(event="query.before_execution")
-async def log_query_start(
-    query_name: str,
-    variables: dict,
-    user_context: UserContext
-) -> None:
-    """Log query execution start"""
-    logger.info(
-        f"Query {query_name} started",
-        extra={
-            "user_id": user_context.user_id,
-            "variables": variables
-        }
-    )
+CREATE VIEW v_document_search AS
+SELECT
+    d.id,
+    jsonb_build_object(
+        'id', d.id,
+        'title', d.title,
+        'similarity', 1 - (d.embedding <=> :query_embedding)
+    ) AS data
+FROM tb_document d
+ORDER BY d.embedding <=> :query_embedding;
+```
 
-@FraiseQL.hook(event="query.after_execution")
-async def log_query_end(
-    query_name: str,
-    duration_ms: float,
-    error: Exception | None,
-    user_context: UserContext
-) -> None:
-    """Log query execution end"""
-    if error:
-        logger.error(
-            f"Query {query_name} failed: {error}",
-            extra={"user_id": user_context.user_id}
-        )
-    else:
-        logger.info(
-            f"Query {query_name} completed in {duration_ms}ms",
-            extra={"user_id": user_context.user_id}
-        )
-```text
-<!-- Code example in TEXT -->
-
-### 3.2 Mutation Hooks
-
-Execute code before/after mutations:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.hook(event="mutation.before_execution")
-async def audit_mutation_intent(
-    mutation_name: str,
-    input_data: dict,
-    user_context: UserContext
-) -> None:
-    """Log intention to perform mutation"""
-    logger.info(
-        f"Mutation {mutation_name} requested",
-        extra={
-            "user_id": user_context.user_id,
-            "mutation": mutation_name,
-            "data_summary": summarize_data(input_data)
-        }
-    )
-
-@FraiseQL.hook(event="mutation.after_execution")
-async def handle_mutation_side_effects(
-    mutation_name: str,
-    result: Any,
-    user_context: UserContext
-) -> None:
-    """Handle side effects after mutation"""
-    if mutation_name == "DeleteUser":
-        # Trigger cleanup jobs
-        await trigger_user_cleanup(result.user_id)
-    elif mutation_name == "CreateOrder":
-        # Send confirmation email
-        await send_order_confirmation(result.order_id)
-```text
-<!-- Code example in TEXT -->
-
-### 3.3 Subscription Hooks
-
-Execute code on subscription lifecycle:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.hook(event="subscription.connected")
-async def on_subscription_connected(
-    subscription_id: str,
-    subscription_name: str,
-    user_context: UserContext
-) -> None:
-    """Handle new subscription connection"""
-    logger.info(
-        f"Subscription {subscription_name} connected",
-        extra={
-            "subscription_id": subscription_id,
-            "user_id": user_context.user_id
-        }
-    )
-
-    # Track active subscriptions
-    await metrics.gauge("active_subscriptions", increment=1)
-
-@FraiseQL.hook(event="subscription.disconnected")
-async def on_subscription_disconnected(
-    subscription_id: str,
-    subscription_name: str,
-    reason: str
-) -> None:
-    """Handle subscription disconnection"""
-    logger.info(
-        f"Subscription {subscription_name} disconnected: {reason}",
-        extra={"subscription_id": subscription_id}
-    )
-
-    await metrics.gauge("active_subscriptions", increment=-1)
-```text
-<!-- Code example in TEXT -->
-
-### 3.4 Error Hooks
-
-Execute code on errors:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.hook(event="error.occurred")
-async def handle_error(
-    error: Exception,
-    error_code: str,
-    operation_type: str,
-    user_context: UserContext
-) -> None:
-    """Handle any error in operation"""
-
-    # Log authorization errors separately
-    if error_code.startswith("E_AUTH_"):
-        logger.warning(
-            f"Authorization error: {error_code}",
-            extra={"user_id": user_context.user_id}
-        )
-        await notify_security(error_code, user_context.user_id)
-
-    # Alert on database errors
-    elif error_code.startswith("E_DB_"):
-        logger.error(
-            f"Database error: {error_code}",
-            extra={"error": str(error)}
-        )
-        await alert_oncall("Database error detected")
-```text
-<!-- Code example in TEXT -->
+The resolver queries this view like any other read; the extension does the heavy
+lifting inside PostgreSQL.
 
 ---
 
-## 4. Custom Metrics
-
-### 4.1 Counter Metrics
-
-Track occurrences:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.metric(name="user_created", type="counter")
-def track_user_creation():
-    """Track user creation count"""
-    # Auto-incremented on mutation
-    pass
-
-# Use in code
-@FraiseQL.hook(event="mutation.after_execution")
-async def track_mutations(mutation_name, result):
-    if mutation_name == "CreateUser":
-        metrics.increment("user_created")
-        metrics.increment("mutations_total", labels={"type": "create"})
-```text
-<!-- Code example in TEXT -->
-
-### 4.2 Gauge Metrics
-
-Track instantaneous values:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.metric(name="active_sessions", type="gauge")
-async def update_active_sessions():
-    """Track active user sessions"""
-    count = await db.query_one(
-        "SELECT COUNT(*) FROM tb_session WHERE active = true"
-    )
-    metrics.set("active_sessions", count)
-
-# Periodic update
-@FraiseQL.schedule(interval_seconds=60)
-async def refresh_gauge_metrics():
-    await update_active_sessions()
-```text
-<!-- Code example in TEXT -->
-
-### 4.3 Histogram Metrics
-
-Track distributions:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.metric(name="query_duration_ms", type="histogram")
-async def track_query_latency(duration_ms: float):
-    """Track query latency distribution"""
-    metrics.histogram("query_duration_ms", duration_ms)
-
-# Use in hook
-@FraiseQL.hook(event="query.after_execution")
-async def record_latency(duration_ms, query_name):
-    metrics.histogram(
-        "query_duration_ms",
-        duration_ms,
-        labels={"operation": query_name}
-    )
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 5. Custom Scalars
-
-### 5.1 Custom Scalar Types
-
-Define domain-specific types:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.scalar(name="Email")
-class EmailScalar:
-    """Custom Email scalar with validation"""
-
-    @staticmethod
-    def serialize(value: str) -> str:
-        """Convert to JSON"""
-        return value
-
-    @staticmethod
-    def parse_value(value: Any) -> str:
-        """Parse from JSON"""
-        if not isinstance(value, str):
-            raise ValueError("Email must be string")
-        if "@" not in value:
-            raise ValueError("Invalid email format")
-        return value
-
-    @staticmethod
-    def parse_literal(ast) -> str:
-        """Parse from GraphQL query literal"""
-        if ast.value == "null":
-            return None
-        return EmailScalar.parse_value(ast.value)
-
-@FraiseQL.scalar(name="Money")
-class MoneyScalar:
-    """Custom Money scalar (amount + currency)"""
-
-    @staticmethod
-    def serialize(value: dict) -> dict:
-        return {"amount": value.amount, "currency": value.currency}
-
-    @staticmethod
-    def parse_value(value: dict) -> dict:
-        return {
-            "amount": Decimal(str(value["amount"])),
-            "currency": value["currency"]
-        }
-
-# Use in schema
-@FraiseQL.type
-class User:
-    email: Email  # Custom scalar
-
-@FraiseQL.type
-class Order:
-    total: Money  # Custom scalar
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 6. Custom Directives
-
-### 6.1 Field Directives
-
-Apply behavior to fields:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.directive(name="uppercase")
-def uppercase_directive(value: str) -> str:
-    """Convert field value to uppercase"""
-    return value.upper() if value else value
-
-@FraiseQL.directive(name="redact")
-def redact_directive(value: str) -> str:
-    """Redact sensitive value"""
-    if len(value) > 4:
-        return value[:2] + "****" + value[-2:]
-    return "****"
-
-# Use in schema
-@FraiseQL.type
-class User:
-    @uppercase_directive
-    name: str
-
-    @redact_directive
-    ssn: str
-```text
-<!-- Code example in TEXT -->
-
-### 6.2 Query Directives
-
-Apply behavior to queries:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.directive(name="cache")
-def cache_directive(result: Any, ttl_seconds: int) -> Any:
-    """Cache query result"""
-    # Framework handles caching
-    return result
-
-@FraiseQL.directive(name="rateLimit")
-def rate_limit_directive(
-    user_context: UserContext,
-    limit: int,
-    window_seconds: int
-) -> None:
-    """Rate limit query per user"""
-    key = f"ratelimit:{user_context.user_id}"
-    current = cache.get(key) or 0
-
-    if current >= limit:
-        raise RateLimitError(f"Rate limit exceeded: {limit}/{window_seconds}s")
-
-    cache.increment(key, 1, ttl=window_seconds)
-
-# Use in query
-@FraiseQL.query
-@cache_directive(ttl_seconds=300)
-@rate_limit_directive(limit=100, window_seconds=60)
-def get_user_posts(user_id: ID) -> [Post]:
-    """Get user's posts (cached, rate-limited)"""
-    pass
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 7. Transform Hooks
-
-### 7.1 Input Transform
-
-Transform input before validation:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.transform(event="input.before_validation")
-def normalize_email(input_data: dict) -> dict:
-    """Normalize email to lowercase"""
-    if "email" in input_data:
-        input_data["email"] = input_data["email"].lower().strip()
-    return input_data
-
-@FraiseQL.transform(event="input.before_validation")
-def sanitize_text(input_data: dict) -> dict:
-    """Sanitize text inputs to prevent XSS"""
-    for field in ["title", "content", "description"]:
-        if field in input_data and isinstance(input_data[field], str):
-            input_data[field] = sanitize_html(input_data[field])
-    return input_data
-```text
-<!-- Code example in TEXT -->
-
-### 7.2 Output Transform
-
-Transform response before sending:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.transform(event="response.before_sending")
-def add_metadata(response: dict) -> dict:
-    """Add request metadata to response"""
-    response["_metadata"] = {
-        "timestamp": now_iso(),
-        "version": "2.0.0"
-    }
-    return response
-
-@FraiseQL.transform(event="response.before_sending")
-def redact_sensitive(response: dict) -> dict:
-    """Redact sensitive fields from response"""
-    if "user" in response.get("data", {}):
-        user = response["data"]["user"]
-        if "password_hash" in user:
-            del user["password_hash"]
-    return response
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 8. Middleware Extensions
-
-### 8.1 Request Middleware
-
-Process requests:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.middleware(type="request")
-async def add_request_id(request, next_handler):
-    """Add unique request ID"""
-    request.id = generate_uuid()
-    logger.info(f"Request {request.id} started")
-
-    try:
-        response = await next_handler(request)
-        logger.info(f"Request {request.id} completed")
-        return response
-    except Exception as e:
-        logger.error(f"Request {request.id} failed: {e}")
-        raise
-
-@FraiseQL.middleware(type="request")
-async def extract_user_context(request, next_handler):
-    """Extract user from token"""
-    token = extract_bearer_token(request)
-    if token:
-        request.user_context = verify_token(token)
-    return await next_handler(request)
-```text
-<!-- Code example in TEXT -->
-
-### 8.2 Response Middleware
-
-Process responses:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.middleware(type="response")
-async def add_cache_headers(request, response, next_handler):
-    """Add cache control headers"""
-    if is_cacheable_query(request):
-        response.headers["Cache-Control"] = "public, max-age=300"
-    return response
-
-@FraiseQL.middleware(type="response")
-async def compress_response(request, response, next_handler):
-    """Compress response if large"""
-    if len(response.body) > 1024:
-        response.body = gzip_compress(response.body)
-        response.headers["Content-Encoding"] = "gzip"
-    return response
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 9. Database Extensions
-
-### 9.1 Custom Database Functions
-
-Call custom database functions from queries:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.database_function(name="search_full_text")
-def search_full_text(
-    db: Database,
-    query: str,
-    table: str
-) -> list:
-    """Full-text search using database function"""
-    return db.query(
-        f"SELECT * FROM {table} WHERE search_vector @@ to_tsquery($1)",
-        [query]
-    )
-
-# Use in schema
-@FraiseQL.query
-def search_posts(query: str) -> [Post]:
-    """Search posts by full-text"""
-    return search_full_text(query, "tb_post")
-```text
-<!-- Code example in TEXT -->
-
-### 9.2 Custom Database Views
-
-Define custom materialized views:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.view(name="v_user_stats")
-def create_user_stats_view(db: Database) -> str:
-    """Create materialized view with user statistics"""
-    return """
-    CREATE MATERIALIZED VIEW IF NOT EXISTS v_user_stats AS
-    SELECT
-        u.id,
-        u.username,
-        COUNT(p.id) as post_count,
-        COUNT(DISTINCT c.id) as comment_count,
-        MAX(p.created_at) as last_post_date
-    FROM tb_user u
-    LEFT JOIN tb_post p ON u.id = p.author_id
-    LEFT JOIN tb_comment c ON u.id = c.author_id
-    GROUP BY u.id, u.username
-    WITH DATA;
-
-    CREATE INDEX idx_user_stats_id ON v_user_stats(id);
-    """
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 10. Extension Configuration
-
-### 10.1 Enable/Disable Extensions
-
-Control which extensions are active:
-
-```python
-<!-- Code example in Python -->
-FraiseQL.extensions.configure({
-    "authorization": {
-        "custom_rules": True,
-        "enable_rules": [
-            "published_or_author",
-            "team_member",
-            "department_lead"
-        ]
-    },
-    "validators": {
-        "enabled": True,
-        "enable_validators": [
-            "email_validator",
-            "password_strength",
-            "unique_email"
-        ]
-    },
-    "hooks": {
-        "enabled": True,
-        "enable_hooks": [
-            "query.before_execution",
-            "mutation.after_execution",
-            "error.occurred"
-        ]
-    },
-    "metrics": {
-        "enabled": True,
-        "custom_metrics": True
-    },
-    "middleware": {
-        "enabled": True,
-        "order": [
-            "add_request_id",
-            "extract_user_context",
-            "rate_limiting"
-        ]
-    }
-})
-```text
-<!-- Code example in TEXT -->
-
-### 10.2 Extension Namespace
-
-Organize extensions:
-
-```python
-<!-- Code example in Python -->
-# Define extension namespace
-class CustomExtensions:
-    @FraiseQL.authorization_rule(name="my_rule_1")
-    def rule_1(resource, user_context):
-        pass
-
-    @FraiseQL.validator(name="my_validator_1")
-    def validator_1(value):
-        pass
-
-    @FraiseQL.hook(event="query.before_execution")
-    async def on_query_start(query_name, variables, user_context):
-        pass
-
-# Register namespace
-FraiseQL.extensions.register(CustomExtensions)
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 11. Best Practices
-
-### 11.1 Extension Development
+## 7. Best Practices
 
 **DO:**
 
-- ✅ Keep extensions focused (single responsibility)
-- ✅ Use async/await for I/O operations
-- ✅ Cache expensive computations
-- ✅ Log extension execution (for debugging)
-- ✅ Test extensions in isolation
-- ✅ Document extension behavior
-- ✅ Use strong typing (type hints)
+- Keep custom field resolvers cheap; batch related lookups with a dataloader.
+- Use `async`/`await` for any I/O in resolvers, authorizers, and middleware.
+- Push validation and write logic into `fn_` functions where it stays transactional.
+- Use the built-in domain scalars before reaching for a custom type.
+- Make authorizers fail-closed and free of side effects.
 
 **DON'T:**
 
-- ❌ Modify user context (read-only)
-- ❌ Perform long-running operations in hooks (use async)
-- ❌ Bypass authorization checks
-- ❌ Log sensitive data (email, password, tokens)
-- ❌ Assume extension execution order
-- ❌ Create side effects in validators (should be pure)
-
-### 11.2 Performance Considerations
-
-```python
-<!-- Code example in Python -->
-# ❌ SLOW: Complex rule evaluated for every request
-@FraiseQL.authorization_rule(name="slow_rule")
-async def slow_rule(resource, user_context, db):
-    # Database query for every field access
-    result = await db.query_expensive(...)
-    return result
-
-# ✅ FAST: Rule with caching
-@FraiseQL.authorization_rule(
-    name="fast_rule",
-    cache_ttl_seconds=300
-)
-async def fast_rule(resource, user_context, db):
-    # Cached for 5 minutes
-    result = await db.query_expensive(...)
-    return result
-```text
-<!-- Code example in TEXT -->
+- Issue one query per row in a field resolver — that is the N+1 pattern dataloaders
+  exist to prevent.
+- Expose internal `pk_`/`fk_` columns through a view's `data` JSONB.
+- Bypass the authorizer by reaching past `info.context`.
+- Log sensitive data (tokens, passwords, full email lists) from middleware or hooks.
 
 ---
 
-**Document Version**: 1.0.0
-**Last Updated**: January 2026
-**Status**: Complete specification for framework v2.x
+## Related Documentation
 
-FraiseQL extensions enable powerful customization while maintaining framework constraints and consistency guarantees.
+- [Integration patterns](./integration-patterns.md)
+- [Error handling model](../reliability/error-handling-model.md)
+- [Type system](../../foundation/09-type-system.md)
+- [Scalars reference](../../reference/scalars.md)
+- [Decorators reference](../../reference/decorators.md)
+- [Authorization](../../security/authorization.md)

--- a/docs/architecture/integration/integration-patterns.md
+++ b/docs/architecture/integration/integration-patterns.md
@@ -1,801 +1,464 @@
-<!-- Skip to main content -->
 ---
-
-title: FraiseQL Integration Patterns: Federation, Webhooks, and Messaging
-description: FraiseQL integrates with external systems through three primary patterns:
-keywords: ["workflow", "design", "scalability", "saas", "performance", "realtime", "patterns", "ecommerce"]
+title: "FraiseQL Integration Patterns: FDW, FastAPI, and Clients"
+description: How FraiseQL v1 integrates with external systems through PostgreSQL FDW, FastAPI composition, and GraphQL clients.
+keywords: ["integration", "postgres-fdw", "fastapi", "graphql-client", "notify", "outbox", "patterns"]
 tags: ["documentation", "reference"]
 ---
 
-# FraiseQL Integration Patterns: Federation, Webhooks, and Messaging
+# FraiseQL Integration Patterns: FDW, FastAPI, and Clients
 
-**Date:** January 2026
-**Status:** Complete System Specification
-**Audience:** Integration architects, backend engineers, microservices specialists
+**Audience:** Integration architects, backend engineers, platform teams
 
 ---
 
 ## Executive Summary
 
-FraiseQL integrates with external systems through three primary patterns:
+FraiseQL v1 is a Python runtime GraphQL framework that serves a PostgreSQL
+database over FastAPI. It does not ship a federation gateway, a webhook engine,
+or a message-broker publisher. Instead, integration happens at three well-defined
+layers, each using technology you already control:
 
-1. **Federation** — Compose multiple GraphQL services (Apollo Federation v2)
-2. **Webhooks** — Push events to external HTTP endpoints
-3. **Messaging** — Publish events to message brokers (Kafka, RabbitMQ, etc.)
+1. **Database-level integration** — read external or remote PostgreSQL data
+   *inside your views* with PostgreSQL Foreign Data Wrappers (FDW), and reach out
+   from `fn_` functions via `LISTEN/NOTIFY` or an outbox table.
+2. **Application-level integration** — mount the FraiseQL FastAPI app inside a
+   larger FastAPI/ASGI application, add middleware, and share authentication so
+   REST and GraphQL are served together.
+3. **Client integration** — talk to FraiseQL over standard GraphQL-over-HTTP and
+   the GraphQL-over-WebSocket subscription endpoint.
 
-Each pattern provides different trade-offs between consistency, latency, and complexity.
+Each layer is composed from standard tools (PostgreSQL, FastAPI, GraphQL clients),
+not from FraiseQL-specific integration decorators.
 
 ---
 
-## 1. Federation Patterns
+## 1. Database-Level Integration
 
-### 1.1 Basic Federation (HTTP)
+The deepest integration surface in FraiseQL is PostgreSQL itself. Because every
+GraphQL query reads from a `v_`/`tv_` view and every mutation calls an `fn_`
+function, anything PostgreSQL can do becomes available to your API without a new
+FraiseQL feature.
 
-Standard Apollo Federation v2 with HTTP subgraph communication:
+### 1.1 Reading External Data with PostgreSQL FDW
 
-```text
-<!-- Code example in TEXT -->
-┌─────────────────┐
-│  Apollo Router  │
-│  (Gateway)      │
-└────────┬────────┘
-         │
-    ┌────┴────┐
-    │         │
-┌───▼──┐  ┌──▼───┐
-│Users │  │Orders│
-│Subgraph │  │Subgraph│
-└────────┘  └───────┘
-
-HTTP `_entities` calls for federation
-```text
-<!-- Code example in TEXT -->
-
-**Implementation:**
-
-```python
-<!-- Code example in Python -->
-# Users subgraph
-@FraiseQL.type
-@FraiseQL.key(fields=["id"])
-class User:
-    id: ID!
-    name: str
-    email: str
-
-# Orders subgraph (extended type)
-@FraiseQL.type(extend=True)
-@FraiseQL.key(fields=["id"])
-class User:
-    id: ID! = FraiseQL.external()
-    orders: [Order] = FraiseQL.requires(fields=["id"])
-```text
-<!-- Code example in TEXT -->
-
-**Latency characteristics:**
-
-```text
-<!-- Code example in TEXT -->
-Single entity resolution: 50-200ms (HTTP roundtrip)
-Federation 1 level deep: 50-200ms
-Federation 2 levels deep: 100-400ms (cascading calls)
-Federation 3+ levels: Unacceptable (avoid)
-```text
-<!-- Code example in TEXT -->
-
-### 1.2 Database-Linked Federation (PostgreSQL FDW)
-
-Optimization for same-database FraiseQL-to-FraiseQL federation:
-
-```text
-<!-- Code example in TEXT -->
-┌──────────────────────────────────────┐
-│ PostgreSQL (Primary Cluster)         │
-├──────────────────────────────────────┤
-│ Schema: users_schema                 │
-│ ├─ tb_user, v_user                   │
-│ └─ Foreign table: orders_schema.v_order (via FDW)
-│                                       │
-│ Schema: orders_schema                │
-│ ├─ tb_order, v_order                 │
-│ └─ Foreign table: users_schema.v_user (via FDW)
-└──────────────────────────────────────┘
-
-Both subgraphs accessible via database-level join
-```text
-<!-- Code example in TEXT -->
-
-**Setup FDW:**
+PostgreSQL Foreign Data Wrappers let a `v_`/`tv_` view read tables that live in
+*another* PostgreSQL database (or, with the right wrapper, another data source) as
+if they were local. This is a **PostgreSQL feature you compose into your views** —
+FraiseQL never sees the difference, because it only ever queries the view.
 
 ```sql
-<!-- Code example in SQL -->
--- In users database:
+-- In your application database:
 CREATE EXTENSION IF NOT EXISTS postgres_fdw;
 
-CREATE SERVER orders_fdw FOREIGN DATA WRAPPER postgres_fdw
+CREATE SERVER orders_fdw
+  FOREIGN DATA WRAPPER postgres_fdw
   OPTIONS (host 'orders-db', dbname 'orders_db', port '5432');
 
-CREATE USER MAPPING FOR current_user SERVER orders_fdw
-  OPTIONS (user 'fdw_user', password 'secret');
+CREATE USER MAPPING FOR current_user
+  SERVER orders_fdw
+  OPTIONS (user 'fdw_reader', password 'secret');
 
--- Foreign table
-CREATE FOREIGN TABLE orders_schema_v_order (
-    pk_order BIGINTEGER,
-    id UUID,
-    user_id UUID,
-    data JSONB
+-- Expose the remote read view as a local foreign table.
+-- Mirror the remote v_order shape: a public id (UUID) plus a data JSONB column.
+CREATE FOREIGN TABLE remote_v_order (
+    id      UUID,
+    fk_user UUID,
+    data    JSONB
 ) SERVER orders_fdw
-  OPTIONS (schema_name 'orders_schema', table_name 'v_order');
-```text
-<!-- Code example in TEXT -->
+  OPTIONS (schema_name 'public', table_name 'v_order');
+```
 
-**Entity resolution with FDW:**
+Now reference the foreign table from a normal FraiseQL read view. The view still
+produces the standard `id` + `data` JSONB shape that FraiseQL expects:
 
 ```sql
-<!-- Code example in SQL -->
--- Resolve User with orders (FDW join)
-CREATE FUNCTION resolve_user_with_orders(keys UUID[]) RETURNS JSONB[] AS $$
-  SELECT array_agg(
-    u.data || jsonb_build_object(
-      'orders', COALESCE(o.orders, '[]'::jsonb)
-    ) ORDER BY idx
-  )
-  FROM unnest(keys) WITH ORDINALITY AS t(key, idx)
-  JOIN users_schema.v_user u ON u.id = t.key
-  LEFT JOIN (
-    SELECT user_id, jsonb_agg(data ORDER BY created_at DESC) AS orders
-    FROM orders_schema_v_order
-    WHERE user_id = ANY(keys)
-    GROUP BY user_id
-  ) o ON o.user_id = u.id
-$$ LANGUAGE sql STABLE;
-```text
-<!-- Code example in TEXT -->
+CREATE VIEW v_user_with_orders AS
+SELECT
+    u.id,
+    u.data
+      || jsonb_build_object(
+           'orders',
+           COALESCE(
+             (SELECT jsonb_agg(o.data ORDER BY o.data->>'createdAt' DESC)
+              FROM remote_v_order o
+              WHERE o.fk_user = u.id),
+             '[]'::jsonb
+           )
+         ) AS data
+FROM v_user u;
+```
 
-**Latency characteristics:**
-
-```text
-<!-- Code example in TEXT -->
-Single entity resolution: 5-15ms (database join, no network)
-Federation 1 level deep: 5-15ms (10x faster than HTTP)
-Federation 2 levels deep: 10-30ms (same database, all FDW)
-```text
-<!-- Code example in TEXT -->
-
-### 1.3 Hybrid Federation (Mixed HTTP and FDW)
-
-Combine HTTP and database-level federation:
-
-```text
-<!-- Code example in TEXT -->
-┌────────────────────────────────────┐
-│ Users (FraiseQL on PostgreSQL)     │
-├────────────────────────────────────┤
-│ ├─ Orders via FDW (same DB): 10ms  │
-│ ├─ Products via HTTP (Apollo): 100ms
-│ └─ Inventory via FDW (same DB): 10ms
-```text
-<!-- Code example in TEXT -->
-
-**Strategy selection (auto-detect):**
+Your `@fraiseql.type` and `@fraiseql.query` stay unchanged — they target
+`v_user_with_orders` like any other view:
 
 ```python
-<!-- Code example in Python -->
-# At compile time, detect federation targets:
-if target_subgraph.is_fraiseql and target_db_type == source_db_type:
-    resolution_strategy = "database_linking"  # FDW
-else:
-    resolution_strategy = "http"  # Standard federation
-```text
-<!-- Code example in TEXT -->
+import fraiseql
+from fraiseql.types import ID
 
-**Example:**
 
-```python
-<!-- Code example in Python -->
-@FraiseQL.type
-class Product:
-    id: ID!
+@fraiseql.type(sql_source="v_user_with_orders", jsonb_column="data")
+class User:
+    id: ID
     name: str
+    orders: list["Order"]
 
-    # This comes from Orders subgraph (FraiseQL, same DB)
-    @FraiseQL.requires(fields=["id"])
-    orders: [Order]  # Will use FDW (fast)
 
-    # This comes from Inventory subgraph (Apollo Server)
-    @FraiseQL.requires(fields=["id"])
-    inventory: Inventory  # Will use HTTP (standard)
-```text
-<!-- Code example in TEXT -->
+@fraiseql.query
+async def users(info) -> list[User]:
+    db = info.context["db"]
+    return await db.find("v_user_with_orders")
+```
+
+**This is not FraiseQL federation.** There is no gateway, no entity-resolution
+protocol, and no subgraph registry. The join happens entirely inside PostgreSQL,
+so the cost profile is a database join (single-digit milliseconds when the foreign
+server is nearby and indexed) rather than an HTTP round-trip per entity.
+
+**Operational notes for FDW views:**
+
+- Foreign-table reads are only as fast as the remote query plan. Add appropriate
+  indexes on the remote side and use `IMPORT FOREIGN SCHEMA` or `ANALYZE` so the
+  planner has statistics.
+- Network and credential failures surface as query errors. Wrap heavy FDW joins in
+  a `tv_` projection table that you refresh on a schedule if you need to decouple
+  read latency from the remote system's availability.
+- Never expose internal `pk_`/`fk_` columns through the view's `data` JSONB —
+  publish only the public `id` (UUID) and the requested fields.
+
+### 1.2 Reaching Out from `fn_` Functions
+
+Mutations call `fn_` PostgreSQL functions through `db.execute_function(...)`. Those
+functions can signal other systems as part of the same transaction, so there is no
+need for a FraiseQL-side publisher.
+
+**`LISTEN/NOTIFY` for in-process / nearby listeners:**
+
+```sql
+CREATE FUNCTION fn_create_order(input JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    new_id UUID := gen_random_uuid();
+BEGIN
+    INSERT INTO tb_order (id, fk_user, data)
+    VALUES (new_id, (input->>'userId')::uuid, input);
+
+    -- Emit an event on commit; any LISTENer on this channel receives it.
+    PERFORM pg_notify(
+        'order_events',
+        jsonb_build_object('type', 'order_created', 'id', new_id)::text
+    );
+
+    RETURN jsonb_build_object('success', true, 'id', new_id);
+END;
+$$;
+```
+
+`pg_notify` payloads are limited (8 KB) and only delivered to currently-connected
+listeners — there is no replay. For durable, ordered delivery, prefer the outbox
+pattern below.
+
+**Transactional outbox for durable delivery to your own workers:**
+
+```sql
+-- Written in the SAME transaction as the business write.
+CREATE TABLE tb_outbox (
+    pk_outbox    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id           UUID NOT NULL DEFAULT gen_random_uuid(),
+    event_type   TEXT NOT NULL,
+    payload      JSONB NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at TIMESTAMPTZ
+);
+
+CREATE FUNCTION fn_create_order(input JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    new_id UUID := gen_random_uuid();
+BEGIN
+    INSERT INTO tb_order (id, fk_user, data)
+    VALUES (new_id, (input->>'userId')::uuid, input);
+
+    INSERT INTO tb_outbox (event_type, payload)
+    VALUES ('order_created', jsonb_build_object('orderId', new_id));
+
+    RETURN jsonb_build_object('success', true, 'id', new_id);
+END;
+$$;
+```
+
+A separate worker process — **your application code, not a FraiseQL component** —
+polls `tb_outbox` (or listens on a NOTIFY channel that the insert raises), delivers
+each event to Kafka/RabbitMQ/an HTTP webhook endpoint, and marks rows processed.
+Because the outbox row is written in the same transaction as the business data, you
+get a single atomic write with at-least-once downstream delivery; consumers
+deduplicate on the event `id`.
+
+> The key principle is **single write to PostgreSQL, events propagate from there.**
+> Never write to the database *and* call an external service directly from a
+> resolver — if the second call fails you get an inconsistency with no atomicity.
+> Let PostgreSQL own the write and let a worker drain the outbox.
+
+For consistency guarantees and the read/write model, see
+[../reliability/consistency-model.md](../reliability/consistency-model.md) and
+[../../foundation/03-database-centric-architecture.md](../../foundation/03-database-centric-architecture.md).
+
+### 1.3 Other PostgreSQL Integration Surfaces
+
+Because integration lives in the database, you can use the full PostgreSQL
+ecosystem inside your views and functions:
+
+- **Extensions** — `pgvector` (similarity search), `pg_trgm` (fuzzy text),
+  PostGIS (geospatial), `ltree` (hierarchies). Expose results through a view's
+  `data` JSONB.
+- **PL/Python / PL/pgSQL** — call out to compute inside `fn_` functions when the
+  logic genuinely belongs server-side.
+- **Triggers** — keep `tv_` projection tables current, or populate `tb_outbox`
+  rows automatically on write.
 
 ---
 
-## 2. Webhook Patterns
+## 2. Application-Level Integration (FastAPI)
 
-### 2.1 Webhook Delivery
+`create_fraiseql_app(...)` returns a standard FastAPI application. That makes
+FraiseQL a normal citizen of any FastAPI/ASGI deployment: you can add middleware,
+mount it under a path, run it beside REST routes, and share authentication.
 
-Push events to external HTTP endpoints:
+### 2.1 Adding Middleware
 
-```text
-<!-- Code example in TEXT -->
-FraiseQL Event
-    ↓
-Webhook Dispatcher
-    ├─ Serialize event to JSON
-    ├─ Sign with HMAC
-    ├─ POST to webhook URL
-    └─ Track delivery status
-
-External System
-    ├─ Verify HMAC signature
-    ├─ Deserialize event
-    ├─ Process event
-    └─ Return 200 OK
-
-FraiseQL marks delivered
-```text
-<!-- Code example in TEXT -->
-
-### 2.2 Webhook Configuration
-
-Configure webhooks:
+Pass standard Starlette/FastAPI middleware through `create_fraiseql_app`:
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.webhook(
-    name="order_created_webhook",
-    url="https://external.com/webhooks/order_created",
-    events=["order_created"],
-    secret="webhook_secret_key_123"
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.gzip import GZipMiddleware
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+    production=True,
+    middleware=[
+        Middleware(
+            CORSMiddleware,
+            allow_origins=["https://app.example.com"],
+            allow_methods=["POST", "GET"],
+        ),
+        Middleware(GZipMiddleware, minimum_size=1024),
+    ],
 )
-def on_order_created(event):
-    """Webhook for order creation"""
-    pass
+```
 
-# Register webhook
-FraiseQL.webhooks.register(
-    event_type="order_created",
-    webhook_url="https://external.com/webhooks/order_created",
-    secret="webhook_secret_key_123"
+Any ASGI middleware works the same way — request logging, tracing, rate limiting,
+and so on — because there is nothing FraiseQL-specific about the integration point.
+
+### 2.2 Mounting Inside a Larger Application
+
+Run FraiseQL alongside your existing REST endpoints by mounting it as a
+sub-application. GraphQL lives under one path; the rest of your API is unchanged.
+
+```python
+from fastapi import FastAPI
+
+from fraiseql.fastapi import create_fraiseql_app
+
+# Your existing REST API.
+root = FastAPI(title="Platform API")
+
+
+@root.get("/health")
+async def health() -> dict:
+    return {"status": "ok"}
+
+
+@root.get("/v1/reports/{report_id}")
+async def get_report(report_id: str) -> dict:
+    ...  # existing REST handler
+
+
+# The FraiseQL GraphQL app.
+graphql_app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+    production=True,
 )
-```text
-<!-- Code example in TEXT -->
 
-### 2.3 Webhook Payload Format
+# Serve GraphQL under /graphql, REST everywhere else.
+root.mount("/graphql", graphql_app)
+```
 
-Standard webhook format:
+Run the composed app with any ASGI server:
 
-```json
-<!-- Code example in JSON -->
-{
-  "id": "evt-abc123",
-  "type": "order_created",
-  "timestamp": "2026-01-15T10:30:45Z",
-  "data": {
-    "order_id": "order-789",
-    "user_id": "user-456",
-    "total": 150.00,
-    "items": [...]
-  },
-  "metadata": {
-    "webhook_id": "webhook-123",
-    "attempt": 1,
-    "timestamp": "2026-01-15T10:30:45Z"
-  },
-  "signature": "sha256=abcdef123..."
-}
-```text
-<!-- Code example in TEXT -->
+```bash
+uvicorn app:root --host 0.0.0.0 --port 8000
+```
 
-### 2.4 Webhook Retry Logic
+The GraphQL HTTP endpoint, the GraphQL-over-WebSocket subscription endpoint, and
+(when `production=False`) the playground are all served under the mount path.
 
-Handle delivery failures:
+### 2.3 Sharing Authentication
+
+FraiseQL resolves authentication into `info.context`, so the cleanest pattern is to
+let one auth layer populate the request and have both REST and GraphQL read from it.
+Two common approaches:
+
+- **Shared middleware** — an ASGI auth middleware (JWT/Auth0/session) validates the
+  incoming token, attaches the principal to the request scope, and both the REST
+  routes and the FraiseQL resolvers read it. Pass it through `middleware=[...]`.
+- **FraiseQL authorization** — guard individual operations with
+  `@fraiseql.query(authorizer=...)` and `@fraiseql.subscription(authorizer=...)`,
+  and field-level access with the `authorize_fields` parameter on
+  `@fraiseql.type`. These run inside FraiseQL using the same principal the shared
+  middleware established.
 
 ```python
-<!-- Code example in Python -->
-# Retry strategy
-Attempt 1: Immediate
-Attempt 2: +5 seconds (exponential backoff)
-Attempt 3: +25 seconds
-Attempt 4: +125 seconds
-Attempt 5: +625 seconds
-Max attempts: 5 (over ~20 minutes)
+import fraiseql
 
-# Final failure
-After 5 failed attempts:
-  ├─ Mark webhook delivery as failed
-  ├─ Alert operations team
-  ├─ Can manually retry via dashboard
-```text
-<!-- Code example in TEXT -->
 
-### 2.5 Webhook Signature Verification
+@fraiseql.query(authorizer=require_authenticated)
+async def me(info) -> User | None:
+    db = info.context["db"]
+    principal = info.context["user"]  # populated by shared auth middleware
+    return await db.find_one("v_user", id=principal.id)
+```
 
-Secure webhooks with HMAC:
-
-```python
-<!-- Code example in Python -->
-import hmac
-import hashlib
-
-# Webhook payload
-payload = json.dumps(event).encode()
-
-# Shared secret
-secret = "webhook_secret_key_123"
-
-# Calculate signature
-signature = hmac.new(
-    secret.encode(),
-    payload,
-    hashlib.sha256
-).hexdigest()
-
-# Include in header
-headers = {
-    "X-FraiseQL-Signature": f"sha256={signature}"
-}
-
-# Recipient verifies
-received_signature = request.headers.get("X-FraiseQL-Signature")
-expected_signature = hmac.new(
-    secret.encode(),
-    request.body,
-    hashlib.sha256
-).hexdigest()
-
-if not hmac.compare_digest(received_signature, f"sha256={expected_signature}"):
-    raise ValueError("Invalid signature")
-```text
-<!-- Code example in TEXT -->
-
-### 2.6 Webhook Idempotency
-
-Handle duplicate deliveries:
-
-```python
-<!-- Code example in Python -->
-# Webhook includes event ID
-event = {
-    "id": "evt-abc123",  # Unique event identifier
-    "type": "order_created",
-    "data": {...}
-}
-
-# Recipient deduplicates
-recipient_side_dedup:
-    if db.get_event_id("evt-abc123"):
-        return  # Already processed
-
-    # Process event
-    process_event(event)
-
-    # Mark as processed
-    db.mark_event_processed("evt-abc123")
-```text
-<!-- Code example in TEXT -->
+Because authorization is enforced per resolver, keep it consistent across every
+operation — a resolver without an authorizer is open. See
+[./extension-points.md](./extension-points.md) for the full set of authorization,
+custom-field, and dataloader extension points.
 
 ---
 
-## 3. Message Broker Patterns
+## 3. Client Integration
 
-### 3.1 Kafka Integration
+FraiseQL speaks the two standard GraphQL transports, so any conformant client works
+without special drivers.
 
-Publish events to Kafka topics:
+### 3.1 GraphQL over HTTP
 
-```python
-<!-- Code example in Python -->
-@FraiseQL.kafka_publisher(
-    topic="FraiseQL.events",
-    broker="kafka://broker1:9092,broker2:9092"
-)
-async def publish_to_kafka(event):
-    """Publish FraiseQL events to Kafka"""
-    pass
+Queries and mutations are plain `POST` requests to the GraphQL endpoint:
 
-# Configuration
-FraiseQL.messaging.configure({
-    "kafka": {
-        "enabled": True,
-        "brokers": ["kafka1:9092", "kafka2:9092"],
-        "topic": "FraiseQL.events",
-        "compression": "snappy"
-    }
-})
-```text
-<!-- Code example in TEXT -->
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query": "{ users { id name } }"}'
+```
 
-**Kafka message format:**
+Any GraphQL client (Apollo Client, urql, graphql-request, Relay, or a hand-rolled
+`fetch`) connects the same way — point it at the endpoint URL and send the standard
+`{ query, variables, operationName }` body.
 
-```json
-<!-- Code example in JSON -->
-{
-  "event_id": "evt-abc123",
-  "event_type": "order_created",
-  "timestamp": "2026-01-15T10:30:45Z",
-  "source": "FraiseQL",
-  "version": "2.0.0",
-  "data": {
-    "order_id": "order-789",
-    "user_id": "user-456"
-  }
-}
-```text
-<!-- Code example in TEXT -->
+### 3.2 GraphQL over WebSocket (Subscriptions)
 
-### 3.2 RabbitMQ Integration
-
-Publish events to RabbitMQ exchanges:
+Subscriptions are served over GraphQL-over-WebSocket. FraiseQL supports both the
+modern `graphql-transport-ws` protocol and the legacy `graphql-ws` protocol, so
+clients negotiate whichever they implement.
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.rabbitmq_publisher(
-    exchange="FraiseQL.events",
-    routing_key="FraiseQL.{event_type}"
-)
-async def publish_to_rabbitmq(event):
-    """Publish FraiseQL events to RabbitMQ"""
-    pass
+import fraiseql
+from collections.abc import AsyncGenerator
+from uuid import UUID
 
-# Configuration
-FraiseQL.messaging.configure({
-    "rabbitmq": {
-        "enabled": True,
-        "url": "amqp://user:pass@localhost:5672/",
-        "exchange": "FraiseQL.events",
-        "exchange_type": "topic",
-        "durable": True
-    }
-})
-```text
-<!-- Code example in TEXT -->
 
-### 3.3 Consumer Groups (Kafka)
+@fraiseql.subscription
+async def task_updates(info, project_id: UUID) -> AsyncGenerator[Task, None]:
+    async for task in watch_project_tasks(project_id):
+        yield task
+```
 
-Multiple consumers process events:
+The event source is **your async generator** — it can be backed by PostgreSQL
+`LISTEN/NOTIFY`, polling a `tv_` projection, or an external stream you read. FraiseQL
+streams whatever the generator yields to the connected client over WebSocket. For
+the subscription model, lifecycle, and client setup, see
+[../realtime/subscriptions.md](../realtime/subscriptions.md).
 
-```text
-<!-- Code example in TEXT -->
-Kafka topic: FraiseQL.events
-├─ Consumer Group 1 (notifications)
-│  ├─ Consumer 1A: Partition 0
-│  ├─ Consumer 1B: Partition 1
-│  └─ Consumer 1C: Partition 2
-│
-├─ Consumer Group 2 (analytics)
-│  ├─ Consumer 2A: Partition 0
-│  ├─ Consumer 2B: Partition 1
-│  └─ Consumer 2C: Partition 2
-│
-└─ Consumer Group 3 (audit)
-   ├─ Consumer 3A: Partition 0
-   ├─ Consumer 3B: Partition 1
-   └─ Consumer 3C: Partition 2
+### 3.3 Choosing What a Client Reads
 
-Each consumer group gets all events
-Multiple consumers in same group share partitions
-```text
-<!-- Code example in TEXT -->
-
-### 3.4 Event Stream Ordering
-
-Guarantee ordering with message brokers:
-
-```text
-<!-- Code example in TEXT -->
-Option 1: Topic-level (global order)
-  ├─ All events go to single topic
-  ├─ Consumers receive in order
-  └─ Performance: Limited by single partition
-
-Option 2: Event-type topics (per-entity order)
-  ├─ FraiseQL.events.orders
-  ├─ FraiseQL.events.users
-  ├─ Each topic ordered within type
-  ├─ Different types may interleave
-  └─ Performance: Parallelized
-
-FraiseQL choice: Option 2 (per-entity order)
-```text
-<!-- Code example in TEXT -->
+Whether a query is cheap depends on the view it hits. Point read-heavy or
+deeply-nested client queries at `tv_` projection tables and lighter queries at
+plain `v_` views. The trade-offs are covered in
+[../database/view-selection-guide.md](../database/view-selection-guide.md).
 
 ---
 
-## 4. Consistency Patterns
+## 4. Putting It Together: A Reference Topology
 
-### 4.1 Eventual Consistency (Webhooks/Messaging)
+A typical FraiseQL deployment that integrates with several external systems uses
+each layer for what it does best:
 
-When using webhooks or message brokers:
+```
+        GraphQL clients (HTTP + WebSocket)
+                     |
+            ┌────────▼─────────┐
+            │  FastAPI root    │  REST routes + mounted /graphql
+            │  (your app)      │  shared auth middleware
+            └────────┬─────────┘
+                     │
+            ┌────────▼─────────┐
+            │   PostgreSQL     │
+            │  v_/tv_ views    │◀── FDW ──▶ remote PostgreSQL (read)
+            │  fn_ functions   │──▶ tb_outbox ──▶ your worker ──▶ Kafka / webhook
+            └──────────────────┘
+```
 
-```text
-<!-- Code example in TEXT -->
-FraiseQL Event (T0)
-  ├─ Immediately available to queries (database updated)
-  ├─ Webhook sent (may take 100-500ms)
-  ├─ Message broker published (may take 10-100ms)
-
-External system processing:
-  ├─ Receive webhook: T0 + 500ms
-  ├─ Process event: T0 + 600ms
-  ├─ Update external database: T0 + 700ms
-
-External system query:
-  ├─ At T0 + 100ms: Doesn't see change (not yet received)
-  ├─ At T0 + 800ms: Sees change (processed)
-
-Model: Eventual consistency (typically <1 second)
-```text
-<!-- Code example in TEXT -->
-
-### 4.2 Request-Response Consistency (Federation)
-
-When using federation (HTTP or FDW):
-
-```text
-<!-- Code example in TEXT -->
-Query: Get User with Orders
-
-FraiseQL (HTTP federation):
-  ├─ Query users table
-  ├─ For each user, call orders service
-  ├─ All data from same logical point in time
-  ├─ Consistent snapshot
-
-Consistency: Strong (synchronous)
-```text
-<!-- Code example in TEXT -->
-
-### 4.3 Idempotent Event Processing
-
-Ensure external systems handle duplicate events:
-
-```python
-<!-- Code example in Python -->
-# External system receives events
-# Webhook/message could be delivered twice
-
-# Idempotent processing
-async def process_order_created(event):
-    # Check if already processed
-    existing = db.query(
-        "SELECT id FROM processed_events WHERE event_id = $1",
-        [event.id]
-    )
-
-    if existing:
-        return  # Already processed, safe to skip
-
-    # Process event
-    order = parse_order_data(event.data)
-    db.insert("orders", order)
-
-    # Mark as processed
-    db.insert("processed_events", {"event_id": event.id, "processed_at": now()})
-```text
-<!-- Code example in TEXT -->
+- **Reads** that need remote data join through FDW *inside the view*.
+- **Writes** go to PostgreSQL via `fn_` functions; an outbox row makes downstream
+  delivery durable and atomic.
+- **Your worker** (not FraiseQL) drains the outbox and talks to brokers or HTTP
+  endpoints, keeping the single-write principle intact.
+- **Clients** use standard GraphQL transports; the playground is available in
+  development only.
 
 ---
 
-## 5. Integration Topology Patterns
+## 5. Best Practices
 
-### 5.1 Star Topology (Centralized)
+**Database-level (FDW + functions):**
 
-One central FraiseQL service connects to many external systems:
+- Compose FDW reads inside views; keep `@fraiseql.type` definitions unaware of the
+  remote source.
+- Materialize expensive FDW joins into `tv_` projection tables when remote latency
+  or availability is a risk.
+- Use the transactional outbox for durable, ordered, exactly-once-effective
+  delivery; use `LISTEN/NOTIFY` only for best-effort, nearby listeners.
+- Never expose `pk_`/`fk_` columns through a view's `data` JSONB.
 
-```text
-<!-- Code example in TEXT -->
-        ┌─────────────┐
-        │ FraiseQL    │
-        │ (Central)   │
-        └──────┬──────┘
-    ┌───────┬──┴──┬────────┬──────┐
-    │       │     │        │      │
-┌───▼──┐ ┌─▼──┐ ┌▼───┐ ┌──▼──┐ ┌─▼───┐
-│Kafka │ │ELK │ │S3  │ │Email│ │Auth │
-└──────┘ └────┘ └────┘ └─────┘ └─────┘
+**Application-level (FastAPI):**
 
-Pros: Centralized control, single GraphQL API
-Cons: Single point of failure, scalability limits
-```text
-<!-- Code example in TEXT -->
+- Mount FraiseQL under a path inside your existing app rather than running two
+  servers when REST and GraphQL share a deployment.
+- Establish authentication once in shared middleware and read the principal from
+  `info.context` in resolvers.
+- Apply an authorizer to every query, mutation, and subscription that needs one — a
+  missing authorizer means open access.
 
-### 5.2 Federated Topology (Distributed)
+**Client-level:**
 
-Multiple FraiseQL services with federation:
-
-```text
-<!-- Code example in TEXT -->
-┌──────────────────┐     ┌──────────────────┐
-│ FraiseQL Users   │◄────►│ FraiseQL Orders  │
-│ (Subgraph A)     │     │ (Subgraph B)     │
-└──────────────────┘     └──────────────────┘
-         ▲                       ▲
-         │                       │
-    ┌────▼────┐             ┌────▼────┐
-    │ Auth    │             │ Kafka   │
-    └─────────┘             └─────────┘
-
-┌──────────────────┐
-│ Apollo Router    │
-│ (Gateway)        │
-└──────────────────┘
-
-Pros: Distributed, scalable, isolated
-Cons: More complex deployment, eventual consistency
-```text
-<!-- Code example in TEXT -->
-
-### 5.3 Hub-and-Spoke Topology (Hybrid)
-
-Mix of federation and direct integrations:
-
-```text
-<!-- Code example in TEXT -->
-        ┌─────────────┐
-        │ FraiseQL    │
-        │ (Hub)       │
-        └──────┬──────┘
-    ┌───────┬──┴──┬────────┐
-    │       │     │        │
-┌───▼──┐ ┌─▼───────▼───┐ ┌▼────────┐
-│Kafka │ │ Federated   │ │ External│
-│      │ │ Subgraphs   │ │ Systems │
-└──────┘ │ (Users,     │ └─────────┘
-         │  Orders)    │
-         └─────────────┘
-
-Pros: Flexible, balanced, controlled complexity
-Cons: Moderate complexity, requires good design
-```text
-<!-- Code example in TEXT -->
+- Use any standard GraphQL-over-HTTP client; no FraiseQL-specific SDK is required.
+- Negotiate `graphql-transport-ws` for subscriptions; fall back to legacy
+  `graphql-ws` only for older clients.
+- Disable the playground in production (`production=True`).
 
 ---
 
-## 6. Real-Time Synchronization Patterns
+## Related Documentation
 
-### 6.1 Dual-Write (Anti-pattern)
-
-Don't do this:
-
-```python
-<!-- Code example in Python -->
-# ❌ WRONG: Write to both database and external system
-def create_order(order):
-    db.insert("orders", order)  # Write 1
-    external_service.post("/orders", order)  # Write 2
-
-# Problem: If Write 2 fails, inconsistency
-# Order in FraiseQL but not in external system
-# If Write 1 fails but Write 2 succeeds, reverse problem
-# No atomicity across systems
-```text
-<!-- Code example in TEXT -->
-
-### 6.2 Primary Database with CDC
-
-Correct pattern:
-
-```python
-<!-- Code example in Python -->
-# ✅ CORRECT: Single write to database, events propagate
-def create_order(order):
-    db.insert("orders", order)  # Single write (atomic)
-
-# Trigger fires → Event published
-# → Webhooks called → External system updated
-# → Kafka event → Analytics updated
-
-# Inconsistency window: Order in FraiseQL, not yet in external
-# But convergence guaranteed (eventual consistency)
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 7. Integration Monitoring
-
-### 7.1 Metrics to Track
-
-```text
-<!-- Code example in TEXT -->
-Federation:
-  ├─ Subgraph latency: p50, p95, p99
-  ├─ Entity resolution success rate
-  ├─ Federation cache hit rate
-
-Webhooks:
-  ├─ Delivery success rate (target: >99%)
-  ├─ Retry count distribution
-  ├─ Latency from event to delivery
-  └─ Failed webhook count (alert >0)
-
-Messaging:
-  ├─ Events published per second
-  ├─ Consumer lag (target: <1 minute)
-  ├─ Message loss (target: 0)
-  └─ Throughput (MB/sec)
-```text
-<!-- Code example in TEXT -->
-
-### 7.2 Alert Rules
-
-```text
-<!-- Code example in TEXT -->
-Alert: Subgraph down
-  ├─ Condition: Federation call fails 5+ times in 1 minute
-  ├─ Action: Page on-call
-  └─ Impact: Federation queries fail
-
-Alert: Webhook delivery failing
-  ├─ Condition: >5 consecutive failed deliveries
-  ├─ Action: Alert operations team
-  └─ Impact: External systems not notified
-
-Alert: Consumer lag increasing
-  ├─ Condition: Kafka lag >10 minutes
-  ├─ Action: Scale consumers or investigate slowness
-  └─ Impact: Analytics delayed
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 8. Best Practices
-
-### 8.1 Federation
-
-**DO:**
-
-- ✅ Use federation for loosely-coupled services
-- ✅ Use FDW for same-database services (10x faster)
-- ✅ Design shallow federation (max 2 levels)
-- ✅ Cache federation results
-- ✅ Monitor subgraph latency
-
-**DON'T:**
-
-- ❌ Chain more than 2 levels of federation
-- ❌ Use federation for internal services (too slow)
-- ❌ Assume federation latency <100ms (plan for 100-200ms)
-
-### 8.2 Webhooks
-
-**DO:**
-
-- ✅ Verify webhook signatures
-- ✅ Implement idempotent processing
-- ✅ Handle delivery failures gracefully
-- ✅ Track webhook delivery status
-- ✅ Provide webhook dashboard for debugging
-
-**DON'T:**
-
-- ❌ Trust webhook source without signature verification
-- ❌ Process duplicate events twice
-- ❌ Block webhook processing (use async)
-- ❌ Ignore delivery failures
-
-### 8.3 Messaging
-
-**DO:**
-
-- ✅ Use message brokers for high-throughput events
-- ✅ Partition by entity for ordering
-- ✅ Monitor consumer lag
-- ✅ Implement dead-letter queues for failures
-- ✅ Version message format
-
-**DON'T:**
-
-- ❌ Expect global event ordering (not possible)
-- ❌ Use message broker for real-time (latency too high)
-- ❌ Ignore message loss
-- ❌ Deploy without monitoring consumer health
-
----
-
-**Document Version**: 1.0.0
-**Last Updated**: January 2026
-**Status**: Complete specification for framework v2.x
-
-FraiseQL integrations balance consistency, latency, and complexity through chosen patterns.
+- [./extension-points.md](./extension-points.md) — custom fields, dataloaders,
+  authorization, and middleware extension points.
+- [../realtime/subscriptions.md](../realtime/subscriptions.md) — WebSocket
+  subscriptions and the async-generator event model.
+- [../reliability/consistency-model.md](../reliability/consistency-model.md) — the
+  read/write consistency model behind the single-write principle.
+- [../database/view-selection-guide.md](../database/view-selection-guide.md) —
+  choosing `v_` vs `tv_` for client query shapes.
+- [../../foundation/03-database-centric-architecture.md](../../foundation/03-database-centric-architecture.md)
+  — why business logic and integration live in PostgreSQL.

--- a/docs/architecture/realtime/subscriptions.md
+++ b/docs/architecture/realtime/subscriptions.md
@@ -1,2045 +1,392 @@
-<!-- Skip to main content -->
 ---
-
-title: Subscriptions: Event Projections from the Database
-description: 1. [Overview](#1-overview)
-keywords: ["design", "scalability", "performance", "patterns", "security"]
+title: Subscriptions
+description: Real-time GraphQL subscriptions in FraiseQL v1, served over WebSocket from async-generator resolvers.
+keywords: ["subscriptions", "websocket", "graphql-ws", "realtime", "listen-notify"]
 tags: ["documentation", "reference"]
 ---
 
-# Subscriptions: Event Projections from the Database
-
-**Version:** 2.0
-**Date:** February 5, 2026
-**Status:** ✅ Implemented in v2.0.0-alpha.1
-**Audience:** Runtime Developers, Integration Engineers, Database Architects
+# Subscriptions
 
 ## Table of Contents
 
 1. [Overview](#1-overview)
-2. [Architecture](#2-architecture)
-3. [Subscription Schema Authoring](#3-subscription-schema-authoring)
-4. [Transport Protocols](#4-transport-protocols)
-5. [Filtering & Variables](#5-filtering--variables)
-6. [Event Format & Transformation](#6-event-format--transformation)
-7. [Multi-Database Support](#7-multi-database-support)
-8. [System Architecture](#8-system-architecture)
-9. [Performance Characteristics](#9-performance-characteristics)
-10. [Limitations & Trade-Offs](#10-limitations--trade-offs)
-11. [Security & Authorization](#11-security--authorization)
-12. [Examples](#12-examples)
-13. [Appendix](#13-appendix)
+2. [Defining a subscription](#2-defining-a-subscription)
+3. [Driving updates](#3-driving-updates)
+4. [Filtering, complexity, and lifecycle](#4-filtering-complexity-and-lifecycle)
+5. [Authorization](#5-authorization)
+6. [Client usage](#6-client-usage)
+7. [Operational notes](#7-operational-notes)
 
 ---
 
 ## 1. Overview
 
-### What Are FraiseQL Subscriptions?
+FraiseQL v1 implements **standard GraphQL subscriptions** delivered over a
+WebSocket connection. A subscription is an ordinary GraphQL operation whose
+resolver is an **async generator**: every value it `yield`s becomes one
+subscription payload sent to the client.
 
-FraiseQL subscriptions are **compiled projections of database events** delivered through multiple transport adapters. Unlike traditional GraphQL subscriptions that execute resolvers on-demand, FraiseQL subscriptions:
+The model is intentionally simple:
 
-- **Originate from database transactions** — Events are sourced from committed database changes
-- **Compiled, not interpreted** — Subscription schemas are static, known at build time
-- **Transport-agnostic** — Same event stream delivers to graphql-ws clients, webhooks, Kafka, etc.
-- **Deterministic** — No user code execution, no dynamic logic
-- **Buffered and replayed** — Events persisted in `tb_entity_change_log` for durability
+- You write an `async def` resolver that `yield`s values (an *async generator*).
+- FraiseQL streams whatever you yield to the subscribing client over WebSocket.
+- The **event source is your generator**. It can be backed by PostgreSQL
+  `LISTEN/NOTIFY`, by polling a view, or by any external stream — FraiseQL does
+  not mandate one.
 
-### Why Subscriptions Work Differently in FraiseQL
+**Transport.** FraiseQL speaks GraphQL-over-WebSocket and supports both
+protocols:
 
-**Traditional GraphQL Subscriptions:**
+- `graphql-transport-ws` — the modern protocol (uses `next` / `complete`
+  message types).
+- `graphql-ws` — the legacy Apollo protocol (uses `data` message types).
 
-```text
-<!-- Code example in TEXT -->
-Client subscribes to User.nameChanged
-    ↓
-Server executes resolver function
-    ↓
-Resolver polls database or listens to app events
-    ↓
-Resolver emits value to client
-```text
-<!-- Code example in TEXT -->
+The WebSocket handshake, sub-protocol negotiation, keep-alive, and per-operation
+lifecycle are handled internally by `WebSocketConnection` and
+`SubscriptionManager`; you do not implement protocol framing yourself.
 
-**FraiseQL Subscriptions:**
-
-```text
-<!-- Code example in TEXT -->
-Database commits transaction (user.name updated)
-    ↓
-Application inserts event into tb_entity_change_log
-    ↓
-ChangeLogListener polls tb_entity_change_log (every 100ms)
-    ↓
-ObserverRuntime processes event
-    ↓
-Event matching filters from CompiledSchema
-    ↓
-Delivered via transport adapter (graphql-ws, webhook, Kafka)
-```text
-<!-- Code example in TEXT -->
-
-### Use Cases
-
-**1. Real-Time UI Updates**
-
-- Client subscribes to OrderCreated events
-- Receives updates within typical target envelope of <10ms (local network, reference deployment)
-- No polling, deterministic delivery
-
-**2. Event Streaming to External Systems**
-
-- Backend service consumes events via Kafka adapter
-- Replicates data to data warehouse
-- Replays events from any point in time
-
-**3. Multi-Tenant Change Notification**
-
-- Organization receives updates for their entities only
-- Row-level filtering enforced at compile time
-- No cross-tenant data leakage
-
-**4. Audit Trail Emission**
-
-- All mutations automatically create subscription events
-- Events sent to logging/analytics system
-- Immutable record of all changes
+There is **no event-log table, no change-data-capture polling runtime, and no
+server-side event replay or buffering** in v1. A subscription lives entirely
+inside its WebSocket connection. If the connection drops, the client reconnects
+and resubscribes (see [Operational notes](#7-operational-notes)).
 
 ---
 
-## 2. Architecture
-
-### 2.1 High-Level Event Flow (CORRECT)
-
-```text
-<!-- Code example in TEXT -->
-┌─────────────────────────────────────────────────────────────┐
-│ Application (GraphQL Mutation / Direct SQL)                │
-│ Executes: mutation CreateOrder($user_id, $amount)          │
-└──────────────────────────┬──────────────────────────────────┘
-                           │
-                           ↓
-        ┌──────────────────────────────────────┐
-        │ PostgreSQL Database Transaction      │
-        │ ├─ INSERT into tb_order              │
-        │ ├─ INSERT into tb_entity_change_log  │  ← Manual (for now)
-        │ └─ COMMIT                            │
-        └──────────────────────────┬───────────┘
-                                   │
-                    ┌──────────────┴──────────────────┐
-                    ↓                                 ↓
-        ┌──────────────────────┐      ┌──────────────────────┐
-        │ tb_entity_change_log │      │ tb_entity_change_log │
-        │ (Single Source of    │      │ (Debezium envelope)  │
-        │  Truth)              │      │                      │
-        │ - object_type        │      │ Polling every 100ms  │
-        │ - object_id          │      │ (effectively real-   │
-        │ - modification_type  │      │  time)               │
-        │ - object_data (JSONB)│      │                      │
-        │ - created_at         │      │                      │
-        └──────────┬────────────┘      └──────────────────────┘
-                   │
-                   ↓
-        ┌──────────────────────────────────────┐
-        │ ChangeLogListener                     │
-        │ (polls tb_entity_change_log)          │
-        │ - Poll interval: 100ms                │
-        │ - Batch size: 100 events              │
-        │ - Checkpoint tracking                 │
-        └──────────────────┬────────────────────┘
-                           │
-                           ↓
-        ┌──────────────────────────────────────┐
-        │ ObserverRuntime (background task)     │
-        │ Processes ChangeLogEntry → EntityEvent│
-        └──────────┬───────────────────┬─────────┘
-                   │                   │
-        ┌──────────┴────────┐    ┌────┴───────────────────┐
-        ↓                   ↓    ↓                        ↓
-┌───────────────────┐  ┌──────────────────┐  ┌──────────────────┐
-│ ObserverExecutor  │  │ Subscription     │  │ (Future: Other   │
-│                   │  │ Manager          │  │  Consumers)      │
-│ Actions:          │  │                  │  │                  │
-│ ├─ Webhooks       │  │ Transports:      │  │                  │
-│ ├─ Email          │  │ ├─ WebSocket     │  │                  │
-│ ├─ SMS            │  │ │  (graphql-ws)  │  │                  │
-│ ├─ Push           │  │ ├─ Kafka         │  │                  │
-│ ├─ Slack          │  │ └─ Webhooks      │  │                  │
-│ └─ Search Index   │  │                  │  │                  │
-└───────────────────┘  └──────────────────┘  └──────────────────┘
-     (automation)        (real-time UI)        (event streaming)
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 2.2 Components
-
-**tb_entity_change_log** ✅ *Table exists, manual population*
-
-- Single source of truth for ALL database change events
-- Debezium-compatible envelope format (op, before, after, source, ts_ms)
-- Durable storage with sequence numbers for ordering
-- Enables event replay from any checkpoint
-- **Populated manually** (application code must INSERT after mutations)
-- Schema:
-
-  ```sql
-<!-- Code example in SQL -->
-  CREATE TABLE tb_entity_change_log (
-      pk_entity_change_log BIGSERIAL PRIMARY KEY,
-      id UUID NOT NULL,
-      fk_customer_org UUID,
-      object_type VARCHAR(255) NOT NULL,
-      object_id VARCHAR(255) NOT NULL,
-      modification_type VARCHAR(10) NOT NULL,  -- INSERT, UPDATE, DELETE
-      change_status VARCHAR(50),
-      object_data JSONB NOT NULL,              -- Debezium "after" data
-      extra_metadata JSONB,
-      created_at TIMESTAMP NOT NULL DEFAULT NOW()
-  );
-  CREATE INDEX idx_entity_change_log_created ON tb_entity_change_log(created_at);
-  CREATE INDEX idx_entity_change_log_type ON tb_entity_change_log(object_type);
-  ```text
-<!-- Code example in TEXT -->
-
-**ChangeLogListener** ✅ *Fully implemented*
-
-- Polls `tb_entity_change_log` at configurable interval (default: 100ms)
-- Maintains checkpoint for recovery (no duplicate processing)
-- Fetches entries in batches (default: 100 events)
-- Parses Debezium envelope format (before/after/op)
-- Location: `crates/FraiseQL-observers/src/listener/change_log.rs`
-- **Key insight:** 100ms polling IS real-time for UI updates
-
-**ObserverRuntime** ✅ *Fully implemented*
-
-- Background tokio task started in server initialization
-- Calls `ChangeLogListener.next_batch()` in loop
-- Converts `ChangeLogEntry` → `EntityEvent`
-- Routes events to registered consumers:
-  - ObserverExecutor (actions like webhooks, email)
-  - SubscriptionManager (transports like WebSocket, Kafka) ← **To be added**
-- Location: `crates/FraiseQL-server/src/observers/runtime.rs`
-
-**SubscriptionManager** ✅ *Fully implemented*
-
-- Manages active GraphQL subscriptions
-- Matches events against subscription filters
-- Projects data to subscription's field selection
-- Broadcasts via `tokio::sync::broadcast` channels
-- Delivers to transport adapters (WebSocket, Kafka, Webhooks)
-- Location: `crates/FraiseQL-core/src/runtime/subscription.rs`
-
-**Transport Adapters** ✅ *All fully implemented*
-
-- **graphql-ws (WebSocket)**: Real-time UI updates, complete protocol implementation
-- **Webhooks**: HTTP POST with HMAC signatures, exponential backoff retry
-- **Kafka**: Event streaming with compression, keyed by entity_id for partitioning
-
----
-
-### 2.3 Event Format
-
-Events flow through the system in Debezium envelope format:
-
-```json
-<!-- Code example in JSON -->
-{
-  "pk_entity_change_log": 1234,
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "object_type": "Order",
-  "object_id": "ord_123",
-  "modification_type": "INSERT",
-  "object_data": {
-    "id": "ord_123",
-    "user_id": "usr_456",
-    "amount": 99.99,
-    "created_at": "2026-01-30T10:00:00Z"
-  },
-  "extra_metadata": {},
-  "created_at": "2026-01-30T10:00:00.123456Z"
-}
-```text
-<!-- Code example in TEXT -->
-
-**Conversion to SubscriptionEvent:**
-
-```rust
-<!-- Code example in RUST -->
-// In ObserverRuntime background task
-for entry in entries {
-    let entity_event = EntityEvent::from_change_log_entry(entry);
-
-    // Route to observers (existing)
-    observer_executor.process_event(&entity_event).await;
-
-    // Route to subscriptions (TO BE ADDED)
-    if let Some(ref sub_manager) = subscription_manager {
-        let subscription_event = SubscriptionEvent {
-            event_id: entity_event.id,
-            entity_type: entity_event.object_type,
-            entity_id: entity_event.object_id,
-            operation: entity_event.modification_type,  // INSERT/UPDATE/DELETE
-            data: entity_event.object_data,
-            old_data: None,  // Could extract from "before" field
-            timestamp: entity_event.created_at,
-            sequence_number: entity_event.pk,
-        };
-        sub_manager.publish_event(subscription_event).await?;
-    }
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 2.4 Architectural Insights
-
-#### Why Polling, Not LISTEN/NOTIFY?
-
-FraiseQL subscriptions use database-centric polling architecture rather than PostgreSQL LISTEN/NOTIFY:
-
-1. **Database-Centric Design** - FraiseQL's core philosophy is "database as source of truth"
-2. **Single Event Log** - `tb_entity_change_log` is THE event log, shared by observers and subscriptions
-3. **Durability** - Events in database table can be replayed, checkpointed, and audited
-4. **100ms Is Real-Time** - For UI updates, 100ms latency is imperceptible to users
-5. **Simplicity** - One polling mechanism (ChangeLogListener), not two (LISTEN + polling)
-6. **Existing Infrastructure** - ObserverRuntime already processes events; extend it
-
-#### What Would Be Wrong With LISTEN/NOTIFY?
-
-A LISTEN/NOTIFY based architecture would create:
-
-```text
-<!-- Code example in TEXT -->
-Database → PostgreSQL NOTIFY → PostgresListener → SubscriptionManager
-```text
-<!-- Code example in TEXT -->
-
-**Problems:**
-
-- ❌ Duplicate event capture mechanism (ChangeLogListener already polls)
-- ❌ No durability (NOTIFY messages are fire-and-forget)
-- ❌ No replay capability (can't reprocess old events)
-- ❌ Violates database-centric principle (message channel, not table)
-- ❌ Creates two parallel event systems fighting for same purpose
-
-#### Current Limitations (Temporary)
-
-1. **Manual Event Population** - Application code must explicitly INSERT into `tb_entity_change_log`
-   - Example:
-
-     ```rust
-<!-- Code example in RUST -->
-     sqlx::query!(
-         "INSERT INTO tb_entity_change_log (object_type, object_id, modification_type, object_data)
-          VALUES ($1, $2, $3, $4)",
-         "Order",
-         order_id,
-         "INSERT",
-         serde_json::to_value(&order)?
-     ).execute(&pool).await?;
-     ```text
-<!-- Code example in TEXT -->
-
-2. **SubscriptionManager Not Wired to ObserverRuntime** - Integration pending (see migration path below)
-
-3. **No Multi-Tenant Authorization Enforcement** - Filter evaluation exists but user context not passed
-
-#### Performance Characteristics
-
-| Aspect | Value | Notes |
-|--------|-------|-------|
-| **Event Latency** | 100ms (P50), 200ms (P99) | Polling interval + processing |
-| **Throughput** | ~1000 events/sec | Batch size 100, 100ms polling |
-| **Subscription Delivery** | 100-150ms total | Polling + matching + transport |
-| **Durability** | ✅ Full | Events persisted in database table |
-| **Replay** | ✅ Supported | Checkpoint-based from any point |
-| **Scalability** | Limited by PostgreSQL | Single table bottleneck |
-
-**Comparison:**
-
-| Architecture | Latency | Durability | Replay | Complexity |
-|--------------|---------|------------|--------|------------|
-| **Polling (FraiseQL)** | 100ms | ✅ | ✅ | Low |
-| **LISTEN/NOTIFY** | <10ms | ❌ | ❌ | Medium |
-| **Kafka** | 10-50ms | ✅ | ✅ | High |
-| **Redis Streams** | 5-20ms | ⚠️ | ⚠️ | Medium |
-
-#### Implementation Notes
-
-**Current Status in v2.0.0-alpha.1:**
-
-The subscription architecture is fully designed and tested. The implementation integrates `SubscriptionManager` with `ObserverRuntime` to emit events from database changes, supporting automatic event population through executor hooks.
-
-For enhancement requests or implementation details, see the roadmap in the project repository.
-
----
-
-### 2.5 Relationship to Observer System
-
-FraiseQL has **two separate event consumer systems** sharing the same event source:
-
-#### Subscriptions vs Observers
-
-| Aspect | Subscriptions | Observers |
-|--------|--------------|-----------|
-| **Purpose** | Real-time client notifications | Automation actions |
-| **Consumers** | Browser/mobile clients | Webhooks, email, SMS, search indexing |
-| **Transports** | graphql-ws, Kafka, HTTP webhooks | EventTransport trait (PostgresNotify, **NATS**, InMemory) |
-| **Latency** | 100-150ms (polling) | Variable (action-dependent) |
-| **Use Case** | Live dashboards, real-time UI | Background jobs, integrations |
-
-#### Architecture: Two Branches from Same Source
-
-```text
-<!-- Code example in TEXT -->
-tb_entity_change_log (single source of truth)
-    ↓
-ChangeLogListener (polls every 100ms)
-    ↓
-ObserverRuntime (in-process routing)
-    ├─ ObserverExecutor → Actions (can use NATS transport)
-    │   ├─ Webhooks
-    │   ├─ Email/SMS
-    │   ├─ Slack notifications
-    │   └─ Search indexing
-    │
-    └─ SubscriptionManager → Client transports
-        ├─ graphql-ws (WebSocket)
-        ├─ Kafka
-        └─ HTTP webhooks
-```text
-<!-- Code example in TEXT -->
-
-#### Why Subscriptions Don't Use NATS Directly
-
-**Subscriptions** use their own transport adapters (graphql-ws, Kafka) because:
-
-- Clients connect directly to FraiseQL server (WebSocket)
-- No intermediate message bus needed for latency-sensitive UI
-- GraphQL protocol expectations (graphql-ws spec)
-
-**Observers** can optionally use NATS because:
-
-- Actions are asynchronous (latency tolerance)
-- May need polyglot consumers (Python, Go, etc.)
-- Benefits from distributed event streaming
-- Horizontal scaling of action processors
-
-#### Configuration: Composition by Default, NATS Optional
-
-**Default (Composition):**
-
-```toml
-<!-- Code example in TOML -->
-# FraiseQL.toml
-[observer_runtime]
-transport = "in_process"  # Direct routing, no NATS required
-
-# Both observers and subscriptions get events from same ObserverRuntime
-```text
-<!-- Code example in TEXT -->
-
-**Optional (NATS Everywhere):**
-
-```toml
-<!-- Code example in TOML -->
-[observer_runtime]
-transport = "nats"
-nats_url = "nats://localhost:4222"
-stream_name = "FraiseQL.events"
-
-# All events published to NATS once
-# ObserverExecutor and SubscriptionManager both consume from NATS
-```text
-<!-- Code example in TEXT -->
-
-**Key Insight:** FraiseQL defaults to **database-centric composition** (no NATS required), but makes **NATS everywhere** easy to enable for distributed deployments.
-
----
-
-## 3. Subscription Schema Authoring
-
-### 3.1 Declaring Subscriptions
-
-Subscriptions are declared using the same schema authoring languages as types and queries.
-
-**Python Example:**
+## 2. Defining a subscription
+
+Decorate an async generator with `@fraiseql.subscription`. The resolver receives
+`info` first (the GraphQL resolve info, with `info.context["db"]` available),
+followed by your declared arguments. Annotate the return type as
+`AsyncGenerator[T, None]`, where `T` is the GraphQL type you stream.
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class OrderCreated:
-    """Events for new orders created by the authenticated user."""
-
-    # Compile-time filter: Only current user's orders
-    where: WhereOrder = FraiseQL.where(user_id=FraiseQL.context.user_id)
-
-    # Fields to project from the Order entity
-    id: ID
-    user_id: ID
-    created_at: DateTime
-    amount: Decimal
-
-    @FraiseQL.variable(name="since_date")
-    class Filter:
-        """Optional runtime filter for timestamp range."""
-        created_at: DateTimeRange
+import fraiseql
+from collections.abc import AsyncGenerator
+from uuid import UUID
 
 
-@FraiseQL.subscription
-class UserDeleted:
-    """Events for users deleted (admin only)."""
+@fraiseql.subscription
+async def task_updates(info, project_id: UUID) -> AsyncGenerator[Task, None]:
+    """Stream task changes for a single project."""
+    async for task in watch_project_tasks(info, project_id):
+        yield task
+```
 
-    # Authorization: Admin context required
-    where: WhereUser = FraiseQL.where(
-        FraiseQL.context.role.contains("admin")
-    )
+Key points:
 
-    # Soft delete: Only fire if deleted_at is set
-    id: ID
-    email: Email
-    deleted_at: DateTime
+- The function **must** be an async generator (`async def` + `yield`).
+  Decorating a plain coroutine raises a `TypeError`.
+- The yielded type is taken from the `AsyncGenerator[T, None]` annotation and
+  becomes the subscription's GraphQL field type.
+- Arguments are regular typed parameters (`project_id: UUID` above) and appear
+  as GraphQL subscription arguments.
+- The resolver runs once per subscribing client, with that client's arguments.
 
-
-@FraiseQL.subscription
-class OrderStatusChanged:
-    """Events for status changes on organization's orders."""
-
-    # Multi-tenant filtering
-    where: WhereOrder = FraiseQL.where(
-        fk_org=FraiseQL.context.org_id
-    )
-
-    # Nested projection (Order → OrderStatus entity)
-    id: ID
-    status: OrderStatus
-    updated_at: DateTime
-    updated_by_user: User
-```text
-<!-- Code example in TEXT -->
-
-### 3.2 Compile-Time Validation
-
-When the schema is compiled, the compiler:
-
-1. **Identifies all subscription types**
-   - Validates `@FraiseQL.subscription` decorators
-   - Ensures each subscription is based on a valid entity type
-
-2. **Validates WHERE filters**
-   - `user_id=context.user_id` → Must exist in Order type
-   - `role.contains("admin")` → Must be valid operator for role field
-   - Context variables must be available (authentication required)
-
-3. **Validates field projections**
-   - All fields requested must exist in entity type
-   - Nested fields checked recursively (Order → User)
-   - Soft-delete logic applied automatically (WHERE deleted_at IS NULL)
-
-4. **Generates subscription dispatch table**
-
-   ```json
-<!-- Code example in JSON -->
-   {
-     "subscriptions": {
-       "OrderCreated": {
-         "entity_type": "Order",
-         "filter_sql": "WHERE user_id = $1 AND deleted_at IS NULL",
-         "filter_params": ["user_id"],
-         "fields": ["id", "user_id", "created_at", "amount"],
-         "auth_required": true,
-         "operation": "CREATE"
-       }
-     }
-   }
-   ```text
-<!-- Code example in TEXT -->
-
-### 3.3 Multiple Key Subscriptions
-
-Subscriptions can filter on multiple fields:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class OrderUpdated:
-    """Subscription for specific order updates."""
-
-    # Both compile-time constraints
-    where: WhereOrder = FraiseQL.where(
-        fk_org=FraiseQL.context.org_id,
-        status=FraiseQL.context.allowed_statuses  # Must be in auth context
-    )
-
-    id: ID
-    status: str
-    updated_at: DateTime
-```text
-<!-- Code example in TEXT -->
+`watch_project_tasks` is *your* code — the next section shows two ways to
+implement it.
 
 ---
 
-## 4. Transport Protocols
+## 3. Driving updates
 
-### 4.1 GraphQL WebSocket (graphql-ws)
+FraiseQL streams whatever your generator yields. The two common ways to produce
+those values from PostgreSQL are `LISTEN/NOTIFY` and polling.
 
-The primary transport for real-time UI updates using the standard `graphql-ws` protocol.
+### 3.1 PostgreSQL `LISTEN/NOTIFY`
 
-#### Connection Lifecycle
+This is the push-based approach with the lowest latency. A trigger on your write
+table (`tb_*`) calls `NOTIFY` on a channel whenever a row changes, and the
+generator wakes up on each notification, fetches the current row from the read
+view (`v_*`), and yields it.
 
-```text
-<!-- Code example in TEXT -->
-Client                              Server
-  │                                   │
-  ├──────── Connection Request ──────→│
-  │                                   │
-  │◄─── Connection Acknowledgement ──│
-  │                                   │
-  ├──────── Subscribe Message ────────→│
-  │ {                                 │
-  │   "type": "subscribe",            │
-  │   "id": "1",                      │
-  │   "payload": {                    │
-  │     "operationName": null,        │
-  │     "query": "subscription {...}" │
-  │     "variables": {                │
-  │       "since_date": "2026-01-01"  │
-  │     }                             │
-  │   }                               │
-  │ }                                 │
-  │                                   │
-  │◄── Subscribe Acknowledgement ────│
-  │                                   │
-  │◄─ Next (Event Payload) ──────────│
-  │ {                                 │
-  │   "type": "next",                 │
-  │   "id": "1",                      │
-  │   "payload": {                    │
-  │     "data": {                     │
-  │       "orderCreated": {           │
-  │         "id": "ord_123",          │
-  │         "amount": 99.99           │
-  │       }                           │
-  │     }                             │
-  │   }                               │
-  │ }                                 │
-  │                                   │
-  │◄─ Next (Event Payload) ──────────│
-  │ ...                               │
-  │                                   │
-  ├──────── Unsubscribe Message ─────→│
-  │ {                                 │
-  │   "type": "complete",             │
-  │   "id": "1"                       │
-  │ }                                 │
-  │                                   │
-  │◄───── Complete Acknowledgement ──│
-  │                                   │
-  ├───────── Close Connection ───────→│
-  │                                   │
-```text
-<!-- Code example in TEXT -->
+Database side — a trigger that announces changes:
 
-#### Example: Browser Client
+```sql
+CREATE OR REPLACE FUNCTION fn_notify_task_change()
+RETURNS trigger AS $$
+BEGIN
+    -- Announce the affected task's public id on a per-project channel.
+    PERFORM pg_notify(
+        'task_changes',
+        json_build_object(
+            'project_id', NEW.fk_project,
+            'task_id', NEW.id
+        )::text
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_notify_task_change
+    AFTER INSERT OR UPDATE ON tb_task
+    FOR EACH ROW
+    EXECUTE FUNCTION fn_notify_task_change();
+```
+
+Resolver side — listen on the channel and yield matching tasks:
+
+```python
+import json
+import fraiseql
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+
+@fraiseql.subscription
+async def task_updates(info, project_id: UUID) -> AsyncGenerator[Task, None]:
+    """Stream task changes for one project via LISTEN/NOTIFY."""
+    db = info.context["db"]
+
+    async for payload in db.listen("task_changes"):
+        event = json.loads(payload)
+        if event["project_id"] != str(project_id):
+            continue  # not our project — skip
+
+        task = await db.find_one("v_task", id=event["task_id"])
+        if task is not None:
+            yield task
+```
+
+The exact API for consuming notifications depends on how your connection/pool is
+wired (for example, a `LISTEN` on a dedicated connection that exposes an async
+iterator of notification payloads). The important pattern is: subscribe to a
+channel, and on each notification re-read the affected row from your `v_`/`tv_`
+view and `yield` it.
+
+### 3.2 Polling a view
+
+When you cannot add triggers, or the source is a periodically refreshed
+projection (`tv_*`), poll a read view on an interval and yield only what changed.
+
+```python
+import asyncio
+import fraiseql
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+
+@fraiseql.subscription
+async def task_updates(info, project_id: UUID) -> AsyncGenerator[Task, None]:
+    """Stream task changes for one project by polling a view."""
+    db = info.context["db"]
+    seen: dict[str, str] = {}  # task id -> last-seen updated_at
+
+    while True:
+        tasks = await db.find("v_task", fk_project=project_id)
+        for task in tasks:
+            if seen.get(task.id) != task.updated_at:
+                seen[task.id] = task.updated_at
+                yield task
+        await asyncio.sleep(1.0)
+```
+
+Polling trades latency and database load for simplicity. Prefer `LISTEN/NOTIFY`
+when you control the schema and need low latency.
+
+---
+
+## 4. Filtering, complexity, and lifecycle
+
+FraiseQL ships a few helper decorators that compose with `@fraiseql.subscription`.
+Stack the helper **below** `@fraiseql.subscription`.
+
+### 4.1 `subscription_filter` — gate a subscription
+
+`subscription_filter(expression)` evaluates a small, sandboxed boolean
+expression before the stream runs and refuses the subscription if it is false.
+The expression can reference the connecting `user`, the subscription arguments,
+and (when applicable) a loaded `project`/`resource`.
+
+```python
+import fraiseql
+from fraiseql.subscriptions import subscription_filter
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+
+@fraiseql.subscription
+@subscription_filter("project.is_public or user.has_access")
+async def project_updates(info, project_id: UUID) -> AsyncGenerator[Task, None]:
+    async for task in watch_project_tasks(info, project_id):
+        yield task
+```
+
+Only a restricted set of names and attributes is allowed in the expression
+(boolean operators, comparisons, and attributes such as `is_public`,
+`has_access`, `is_owner`, `role`, `permissions`, `id`, `status`). Anything else
+is rejected, so the filter cannot run arbitrary code.
+
+### 4.2 `complexity` — bound cost and depth
+
+`complexity(score=..., max_depth=...)` rejects subscriptions whose computed cost
+or selection-set depth exceeds the configured limits, protecting the server from
+expensive live queries.
+
+```python
+import fraiseql
+from fraiseql.subscriptions import complexity
+from collections.abc import AsyncGenerator
+
+
+@fraiseql.subscription
+@complexity(score=100, max_depth=5)
+async def expensive_feed(info) -> AsyncGenerator[Event, None]:
+    async for event in watch_events(info):
+        yield event
+```
+
+### 4.3 `with_lifecycle` — setup / teardown hooks
+
+`with_lifecycle(on_start=..., on_event=..., on_complete=...)` runs hooks around
+the stream: `on_start` when the client subscribes, `on_event` for each yielded
+value (it can transform the value), and `on_complete` when the subscription
+ends — including on disconnect — making it the right place to release resources.
+
+```python
+import fraiseql
+from fraiseql.subscriptions import with_lifecycle
+from collections.abc import AsyncGenerator
+
+
+@fraiseql.subscription
+@with_lifecycle(
+    on_start=open_resources,
+    on_event=annotate_event,
+    on_complete=close_resources,
+)
+async def audited_feed(info) -> AsyncGenerator[Event, None]:
+    async for event in watch_events(info):
+        yield event
+```
+
+### 4.4 `cache` — reuse recent results
+
+`cache(ttl=...)` memoizes the most recent yielded value for a short window
+(default 5 seconds), so identical subscriptions sharing a cache do not all
+recompute the same result.
+
+```python
+import fraiseql
+from fraiseql.subscriptions import cache
+from collections.abc import AsyncGenerator
+
+
+@fraiseql.subscription
+@cache(ttl=10)  # reuse results for 10 seconds
+async def live_stats(info) -> AsyncGenerator[Stats, None]:
+    async for stats in compute_stats(info):
+        yield stats
+```
+
+---
+
+## 5. Authorization
+
+Pass a per-operation `authorizer` to the decorator to control who may open a
+subscription:
+
+```python
+import fraiseql
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+
+@fraiseql.subscription(authorizer=project_member_authorizer)
+async def task_updates(info, project_id: UUID) -> AsyncGenerator[Task, None]:
+    async for task in watch_project_tasks(info, project_id):
+        yield task
+```
+
+- The `authorizer` mirrors `@fraiseql.query` / `@fraiseql.mutation`: it takes
+  precedence over the global default authorizer **for this subscription only**.
+- Authorization is evaluated **once, at subscribe time** (when the client sends
+  the `subscribe` message), not on every yielded value. If it fails, the
+  subscription is rejected and no stream is opened.
+- When no `authorizer` is supplied, the registry's default authorizer applies.
+
+`subscription_filter` (see above) is complementary: use the `authorizer` for the
+authentication/authorization decision, and `subscription_filter` for declarative
+access gates expressed inline.
+
+---
+
+## 6. Client usage
+
+Connect over WebSocket with a `graphql-transport-ws` client (the
+[`graphql-ws`](https://github.com/enisdenjo/graphql-ws) library is the common
+choice; the legacy `graphql-ws` Apollo protocol is also accepted).
 
 ```javascript
-<!-- Code example in JAVASCRIPT -->
-// React component using graphql-ws
-import { useSubscription } from '@apollo/client';
+import { createClient } from 'graphql-ws';
 
-const OrdersSubscription = gql`
-  subscription OrderCreated($since_date: DateTime) {
-    orderCreated(since_date: $since_date) {
+const client = createClient({
+  url: 'ws://localhost:8000/graphql',
+  connectionParams: {
+    Authorization: `Bearer ${token}`,
+  },
+});
+
+const subscription = `
+  subscription TaskUpdates($projectId: UUID!) {
+    taskUpdates(projectId: $projectId) {
       id
-      amount
-      created_at
+      title
+      status
+      updatedAt
     }
   }
 `;
 
-export function LiveOrders() {
-  const { data, loading, error } = useSubscription(
-    OrdersSubscription,
-    {
-      variables: {
-        since_date: new Date('2026-01-01').toISOString()
-      }
-    }
-  );
-
-  if (loading) return <p>Listening for orders...</p>;
-  if (error) return <p>Subscription error: {error.message}</p>;
-
-  return (
-    <div>
-      {data?.orderCreated && (
-        <Order order={data.orderCreated} />
-      )}
-    </div>
-  );
-}
-```text
-<!-- Code example in TEXT -->
-
-#### Error Handling
-
-```json
-<!-- Code example in JSON -->
-{
-  "type": "error",
-  "id": "1",
-  "payload": [
-    {
-      "message": "Subscription not found",
-      "extensions": {
-        "code": "SUBSCRIPTION_NOT_FOUND"
-      }
-    }
-  ]
-}
-```text
-<!-- Code example in TEXT -->
-
-**Common errors:**
-
-- `AUTHENTICATION_REQUIRED` — User not authenticated
-- `FORBIDDEN` — User lacks authorization for subscription
-- `SUBSCRIPTION_NOT_FOUND` — Subscription type not defined in schema
-- `INVALID_VARIABLES` — Runtime variable types incorrect
-
-### 4.2 HTTP Webhooks
-
-For push-based delivery to external systems.
-
-#### Webhook Event
-
-```json
-<!-- Code example in JSON -->
-POST https://external-service.example.com/webhooks/FraiseQL
-
-{
-  "event_id": "evt_550e8400-e29b-41d4-a716-446655440000",
-  "event_name": "OrderCreated",
-  "entity_name": "Order",
-  "entity_id": "ord_123",
-  "operation": "CREATE",
-  "timestamp": "2026-01-11T15:35:00.123456Z",
-  "sequence_number": 4521,
-  "data": {
-    "id": "ord_123",
-    "user_id": "usr_456",
-    "amount": 99.99,
-    "created_at": "2026-01-11T15:35:00.123456Z"
+const unsubscribe = client.subscribe(
+  { query: subscription, variables: { projectId: '...' } },
+  {
+    next: (payload) => console.log('task changed', payload.data.taskUpdates),
+    error: (err) => console.error('subscription error', err),
+    complete: () => console.log('subscription complete'),
   },
-  "signature": "sha256=<hmac_signature>"
-}
-```text
-<!-- Code example in TEXT -->
-
-#### Webhook Configuration
-
-```python
-<!-- Code example in Python -->
-config = FraiseQLConfig(
-    webhooks={
-        "OrderCreated": {
-            "url": "https://analytics.example.com/events",
-            "auth": {"token": "secret_key"},
-            "retry_max_attempts": 3,
-            "retry_backoff_seconds": [1, 5, 30]
-        }
-    }
-)
-```text
-<!-- Code example in TEXT -->
-
-#### Delivery Semantics
-
-- **At-least-once:** Event may be delivered multiple times
-- **Ordered per entity:** Events for same entity arrive in order
-- **Retried on failure:** 3 retries with exponential backoff
-- **Signature verification:** HMAC-SHA256 for security
-
-### 4.3 Kafka / Event Streaming
-
-For high-throughput consumption by backend systems.
-
-#### Kafka Topic
-
-Topic name: `FraiseQL.{entity_type}.{operation}`
-
-Examples:
-
-- `FraiseQL.order.created`
-- `FraiseQL.user.updated`
-- `FraiseQL.order.deleted`
-
-#### Kafka Message
-
-```json
-<!-- Code example in JSON -->
-Key: "ord_123" (entity_id)
-
-Value:
-{
-  "event_id": "evt_550e8400-e29b-41d4-a716-446655440000",
-  "event_name": "OrderCreated",
-  "entity_name": "Order",
-  "entity_id": "ord_123",
-  "operation": "CREATE",
-  "timestamp": "2026-01-11T15:35:00.123456Z",
-  "sequence_number": 4521,
-  "data": {...}
-}
-```text
-<!-- Code example in TEXT -->
-
-#### Kafka Configuration
-
-```python
-<!-- Code example in Python -->
-config = FraiseQLConfig(
-    kafka={
-        "enabled": True,
-        "bootstrap_servers": ["kafka:9092"],
-        "subscriptions": {
-            "OrderCreated": {
-                "topic": "FraiseQL.order.created",
-                "partition_by": "entity_id"  # Orders with same ID → same partition
-            }
-        }
-    }
-)
-```text
-<!-- Code example in TEXT -->
-
-#### Delivery Semantics
-
-- **At-least-once:** Messages may duplicate (use idempotent processing)
-- **Ordered per partition:** Events for same entity arrive in order
-- **Offset management:** Consumer tracks processed events
-- **Replay capable:** Seek to any offset to replay events
-
-### 4.4 gRPC (Future)
-
-For low-latency service-to-service streaming.
-
-```protobuf
-<!-- Code example in PROTOBUF -->
-service FraiseQLSubscriptions {
-  rpc StreamEvents (StreamRequest) returns (stream Event);
-}
-
-message StreamRequest {
-  string subscription_name = 1;
-  google.protobuf.Struct variables = 2;
-  string auth_token = 3;
-}
-
-message Event {
-  string event_id = 1;
-  string entity_name = 2;
-  string entity_id = 3;
-  string operation = 4;
-  google.protobuf.Timestamp timestamp = 5;
-  google.protobuf.Struct data = 6;
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 5. Filtering & Variables
-
-### 5.1 Compile-Time WHERE Clauses
-
-Subscriptions filter events using WHERE clauses evaluated at compile time and rendered as SQL predicates.
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class OrderCreated:
-    # Filter: Only orders for authenticated user
-    where: WhereOrder = FraiseQL.where(
-        user_id=FraiseQL.context.user_id
-    )
-
-# Compiled to:
-# WHERE user_id = $1 (with $1 bound to context.user_id at runtime)
-```text
-<!-- Code example in TEXT -->
-
-**Available context variables:**
-
-```python
-<!-- Code example in Python -->
-FraiseQL.context.user_id         # Authenticated user ID
-FraiseQL.context.org_id          # Organization/tenant ID
-FraiseQL.context.role            # User role (string or list)
-FraiseQL.context.permissions     # User permissions
-FraiseQL.context.custom_claim    # Custom auth claim
-```text
-<!-- Code example in TEXT -->
-
-**Example: Multi-tenant filtering**
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class OrderUpdated:
-    where: WhereOrder = FraiseQL.where(
-        fk_org=FraiseQL.context.org_id,
-        # Only notify on changes to orders in allowed statuses
-        status=FraiseQL.context.allowed_statuses
-    )
-
-    id: ID
-    status: OrderStatus
-    updated_at: DateTime
-```text
-<!-- Code example in TEXT -->
-
-### 5.2 Runtime Variables
-
-Subscriptions accept typed runtime variables for additional filtering.
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class OrderCreated:
-    where: WhereOrder = FraiseQL.where(
-        user_id=FraiseQL.context.user_id
-    )
-
-    @FraiseQL.variable(name="since_date", type=DateTime)
-    @FraiseQL.variable(name="min_amount", type=Decimal)
-    class Filter:
-        """Optional runtime filtering on timestamp and amount."""
-        created_at: DateTimeRange
-        amount: DecimalRange
-
-    id: ID
-    amount: Decimal
-    created_at: DateTime
-
-# Client-side usage
-subscription OrderCreated(
-  $since_date: DateTime
-  $min_amount: Decimal
-) {
-  orderCreated(since_date: $since_date, min_amount: $min_amount) {
-    id
-    amount
-    created_at
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**At runtime:**
-
-1. Client provides variables: `{ "since_date": "2026-01-01", "min_amount": 50.00 }`
-2. Compiler validates variable types match WHERE operator expectations
-3. SQL predicate: `WHERE user_id = $1 AND created_at > $2 AND amount >= $3`
-4. Only matching events delivered to client
-
-### 5.3 Authorization Enforcement
-
-Subscriptions enforce authorization rules at compile time with runtime-safe parameter binding:
-
-**How it works:**
-
-- Authorization rules are **defined and validated** at schema compile time (schema defines who can access what)
-- Authorization values are **bound safely** at runtime (context.user_id, context.role, etc. resolved when subscription is established)
-- No dynamic authorization logic—filters are deterministic SQL predicates evaluated by database
-
-**Example:**
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class SensitiveDataAccessed:
-    # Only admins receive this subscription
-    where: WhereAuditLog = FraiseQL.where(
-        FraiseQL.context.role == "admin"
-    )
-
-    # If context.role != "admin", subscription unavailable
-    # Compile-time error or runtime 403 FORBIDDEN
-```text
-<!-- Code example in TEXT -->
-
-**Row-level authorization example:**
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class UserProfileUpdated:
-    # User only sees updates to their own profile
-    where: WhereUser = FraiseQL.where(
-        id=FraiseQL.context.user_id
-    )
-
-    id: ID
-    email: Email
-    name: str
-    updated_at: DateTime
-
-# If User ID = 123 subscribes, only receives updates where id = 123
-# No cross-user data leakage possible (enforced at compile time)
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 6. Event Format & Transformation
-
-### 6.1 Relationship to CDC Format
-
-Subscription events are derived from CDC events in `tb_entity_change_log`.
-
-**CDC Event (raw, in database):**
-
-```json
-<!-- Code example in JSON -->
-{
-  "event_id": "evt_550e8400-e29b-41d4-a716-446655440000",
-  "event_type": "entity:created",
-  "entity_type": "Order",
-  "entity_id": "ord_123",
-  "timestamp": "2026-01-11T15:35:00.123456Z",
-  "sequence_number": 4521,
-  "operation": {
-    "before": null,
-    "after": {
-      "id": "ord_123",
-      "user_id": "usr_456",
-      "status": "pending",
-      "amount": 99.99,
-      "created_at": "2026-01-11T15:35:00.123456Z",
-      "updated_at": "2026-01-11T15:35:00.123456Z"
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Subscription Event (projected, sent to client):**
-
-```json
-<!-- Code example in JSON -->
-{
-  "event_id": "evt_550e8400-e29b-41d4-a716-446655440000",
-  "event_name": "OrderCreated",
-  "entity_name": "Order",
-  "entity_id": "ord_123",
-  "operation": "CREATE",
-  "timestamp": "2026-01-11T15:35:00.123456Z",
-  "sequence_number": 4521,
-  "data": {
-    "id": "ord_123",
-    "amount": 99.99,
-    "created_at": "2026-01-11T15:35:00.123456Z"
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Transformation logic:**
-
-1. **Extract fields requested:** Only `id`, `amount`, `created_at` included (as per subscription definition)
-2. **Apply WHERE filter:** Event matches `user_id = $1` (context user)
-3. **Format for transport:** Remove internal CDC fields, structure for GraphQL/webhook response
-4. **Add event metadata:** `event_id`, `event_name`, `operation`, `sequence_number`
-
-### 6.2 Field Projection
-
-Subscription selection sets determine which fields are included in the event.
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class UserUpdated:
-    # All user fields available for projection
-    id: ID
-    email: Email
-    name: str
-    phone: str
-    role: str
-    created_at: DateTime
-    updated_at: DateTime
-
-# Client requests only specific fields
-subscription UserUpdated {
-  userUpdated {
-    id
-    email
-    name
-    # phone, role, created_at, updated_at NOT requested, not included
-  }
-}
-
-# Event delivered with only requested fields:
-{
-  "data": {
-    "id": "usr_456",
-    "email": "alice@example.com",
-    "name": "Alice Smith"
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-### 6.3 Nested Projections
-
-Subscriptions can project nested entities.
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class OrderCreated:
-    id: ID
-    amount: Decimal
-    user: User  # Nested: include User entity
-    created_at: DateTime
-
-# Client requests nested fields
-subscription OrderCreated {
-  orderCreated {
-    id
-    amount
-    user {
-      id
-      email
-      name
-    }
-    created_at
-  }
-}
-
-# Event includes nested data:
-{
-  "data": {
-    "id": "ord_123",
-    "amount": 99.99,
-    "user": {
-      "id": "usr_456",
-      "email": "alice@example.com",
-      "name": "Alice Smith"
-    },
-    "created_at": "2026-01-11T15:35:00.123456Z"
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 7. Multi-Database Support
-
-**PostgreSQL is the reference implementation for subscriptions.** Other databases follow the same architectural contract but may vary in maturity, feature completeness, and performance characteristics.
-
-### 7.1 PostgreSQL
-
-**Event capture mechanism:** Database table polling (`tb_entity_change_log`)
-
-```sql
-<!-- Code example in SQL -->
--- Event log table (already exists)
-CREATE TABLE tb_entity_change_log (
-    pk_entity_change_log BIGSERIAL PRIMARY KEY,
-    id UUID NOT NULL,
-    fk_customer_org UUID,
-    object_type VARCHAR(255) NOT NULL,
-    object_id VARCHAR(255) NOT NULL,
-    modification_type VARCHAR(10) NOT NULL,  -- INSERT, UPDATE, DELETE
-    change_status VARCHAR(50),
-    object_data JSONB NOT NULL,
-    extra_metadata JSONB,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
--- Indexes for efficient polling
-CREATE INDEX idx_entity_change_log_created ON tb_entity_change_log(created_at);
-CREATE INDEX idx_entity_change_log_type ON tb_entity_change_log(object_type);
+// Later, to stop receiving updates:
+// unsubscribe();
+```
 
--- Application code inserts events after mutations
-INSERT INTO tb_entity_change_log (object_type, object_id, modification_type, object_data)
-VALUES ('Order', 'ord_123', 'INSERT', '{"id": "ord_123", "user_id": "usr_456", ...}'::jsonb);
-```text
-<!-- Code example in TEXT -->
-
-**Advantages (Reference Implementation):**
-
-- Database-centric (table as event log, not message channel)
-- Full durability (events persisted in table)
-- Replay capability (query any historical event)
-- No additional infrastructure required
-- Simple and predictable (100ms polling = real-time for UIs)
-- Production-tested in FraiseQL observer system
-
-**Limitations:**
-
-- Manual event population required (no automatic triggers yet)
-- 100-200ms latency (polling interval)
-- Limited by PostgreSQL write throughput (single table)
-
-### 7.2 MySQL
-
-**Event capture mechanism:** Database table polling (`tb_entity_change_log`)
-
-**Architecture:** Same as PostgreSQL - application code inserts events into `tb_entity_change_log`, ChangeLogListener polls.
-
-**MySQL-specific considerations:**
-
-```sql
-<!-- Code example in SQL -->
--- Same table schema as PostgreSQL
-CREATE TABLE tb_entity_change_log (
-    pk_entity_change_log BIGINT AUTO_INCREMENT PRIMARY KEY,
-    id CHAR(36) NOT NULL,
-    fk_customer_org CHAR(36),
-    object_type VARCHAR(255) NOT NULL,
-    object_id VARCHAR(255) NOT NULL,
-    modification_type VARCHAR(10) NOT NULL,
-    change_status VARCHAR(50),
-    object_data JSON NOT NULL,  -- MySQL uses JSON type
-    extra_metadata JSON,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE INDEX idx_entity_change_log_created ON tb_entity_change_log(created_at);
-CREATE INDEX idx_entity_change_log_type ON tb_entity_change_log(object_type);
-```text
-<!-- Code example in TEXT -->
-
-**Advantages:**
-
-- Same architecture as PostgreSQL (consistency)
-- No additional infrastructure required
-- Works with managed MySQL services (AWS RDS, Cloud SQL)
-
-**Limitations:**
-
-- Manual event population (like PostgreSQL)
-- 100-200ms latency (polling interval)
-- JSON type instead of JSONB (slightly less efficient)
-
-### 7.3 SQL Server
-
-**Event capture mechanism:** Database table polling (`tb_entity_change_log`)
-
-**Architecture:** Same as PostgreSQL - application code inserts events into `tb_entity_change_log`, ChangeLogListener polls.
-
-**SQL Server-specific considerations:**
-
-```sql
-<!-- Code example in SQL -->
--- Same table schema as PostgreSQL
-CREATE TABLE tb_entity_change_log (
-    pk_entity_change_log BIGINT IDENTITY(1,1) PRIMARY KEY,
-    id UNIQUEIDENTIFIER NOT NULL,
-    fk_customer_org UNIQUEIDENTIFIER,
-    object_type NVARCHAR(255) NOT NULL,
-    object_id NVARCHAR(255) NOT NULL,
-    modification_type NVARCHAR(10) NOT NULL,
-    change_status NVARCHAR(50),
-    object_data NVARCHAR(MAX) NOT NULL,  -- JSON stored as NVARCHAR(MAX)
-    extra_metadata NVARCHAR(MAX),
-    created_at DATETIME2 NOT NULL DEFAULT GETUTCDATE()
-);
-
-CREATE INDEX idx_entity_change_log_created ON tb_entity_change_log(created_at);
-CREATE INDEX idx_entity_change_log_type ON tb_entity_change_log(object_type);
-```text
-<!-- Code example in TEXT -->
-
-**Advantages:**
-
-- Same architecture as PostgreSQL (consistency)
-- No additional infrastructure required
-- Works with all SQL Server editions (including Express)
-
-**Limitations:**
-
-- Manual event population (like PostgreSQL)
-- 100-200ms latency (polling interval)
-- JSON stored as NVARCHAR(MAX) (less efficient than native JSON)
-
-### 7.4 SQLite
-
-**Event capture mechanism:** Triggers on temporary in-memory event log
-
-```sql
-<!-- Code example in SQL -->
--- Triggers capture changes to temp table
-CREATE TEMP TABLE fraiseql_events (
-    id INTEGER PRIMARY KEY,
-    entity_type TEXT,
-    entity_id TEXT,
-    operation TEXT,
-    data JSON,
-    created_at TIMESTAMP
-);
-
-CREATE TRIGGER order_insert AFTER INSERT ON tb_order
-FOR EACH ROW
-INSERT INTO fraiseql_events (entity_type, entity_id, operation, data)
-VALUES ('Order', NEW.id, 'INSERT', json(...));
-
--- Subscribers poll events from temp table
--- (No push capability; pull-based)
-```text
-<!-- Code example in TEXT -->
-
-**Advantages:**
-
-- No additional infrastructure
-- Suitable for development/testing
-
-**Limitations:**
-
-- Pull-based only (clients must poll)
-- In-memory (events lost on disconnect)
-- Single process only (no network clients)
-- Not suitable for production subscriptions
-
-### 7.5 Database Abstraction
-
-FraiseQL abstracts database-specific CDC via a plugin interface:
-
-```rust
-<!-- Code example in RUST -->
-pub trait CDCBackend {
-    async fn listen(&self, entity_types: Vec<String>) -> Result<EventStream>;
-    async fn query_events(&self, after_seq: u64) -> Result<Vec<CDCEvent>>;
-    async fn get_current_position(&self) -> Result<u64>;
-}
-
-// Implementations per database
-impl CDCBackend for PostgresCDC { ... }
-impl CDCBackend for MySQLCDC { ... }
-impl CDCBackend for SQLServerCDC { ... }
-impl CDCBackend for SQLiteCDC { ... }
-```text
-<!-- Code example in TEXT -->
+The handshake (`connection_init` / `connection_ack`), the `subscribe` /
+`next` / `complete` message flow, and sub-protocol negotiation are handled by the
+client library on one side and by FraiseQL's `WebSocketConnection` /
+`SubscriptionManager` on the other.
 
 ---
 
-## 8. System Architecture
+## 7. Operational notes
 
-### 8.1 Compilation
-
-Subscriptions are **compiled at schema build time** into the CompiledSchema:
-
-**Compile-time processing:**
-
-- Parse subscription declarations (all authoring languages)
-- Validate subscription fields against event entity types
-- Compile WHERE filters to SQL predicates
-- Bind authorization rules for event matching
-- Generate subscription dispatch tables
-- Type-check against type system (same rules as queries/mutations)
-
-**Output:** Subscription metadata in CompiledSchema includes:
-
-- Event entity type(s) and operation types (INSERT/UPDATE/DELETE)
-- WHERE filter predicates
-- Field projection list
-- Authorization requirements
-- Transport adapter configurations
-
-### 8.2 Event Capture & Dispatch
-
-At runtime, subscriptions follow a unified event pipeline:
-
-**FraiseQL Architecture (database-centric):**
-
-- Application code explicitly inserts events into `tb_entity_change_log` after mutations
-- `ChangeLogListener` polls table every 100ms with checkpoint tracking
-- `ObserverRuntime` processes events in background task
-- Events routed to both `ObserverExecutor` (actions) and `SubscriptionManager` (transports)
-
-**Event capture across databases:**
-
-- PostgreSQL: Direct table polling (reference implementation)
-- MySQL: Table polling (same as PostgreSQL)
-- SQL Server: Table polling (same as PostgreSQL)
-- SQLite: Table polling for development/testing
-
-**Event buffer (`tb_entity_change_log`):** All events written with:
-
-- Monotonic sequence numbers (for replay and ordering)
-- Debezium-compatible envelope format
-- Full entity data in JSONB column
-- Timestamp for chronological ordering
-
-### 8.3 Transport Adapters
-
-Same event stream dispatched to multiple transports simultaneously:
-
-**graphql-ws (WebSocket)** — Real-time UI clients
-
-- Standard graphql-ws protocol
-- Sub-millisecond latency (reference deployment)
-- Connection pooling and state management
-
-**Webhooks** — External system integration
-
-- Outgoing HTTP POST with signed payloads
-- Retry logic with exponential backoff
-- Delivery status tracking
-
-**Kafka** — Event streaming to data warehouses
-
-- Producer integration with topic mapping
-- Offset tracking for consumer resume
-- Batching and buffer management
-
-**gRPC** — Inter-service events (future)
-
-- Server streaming for scalable event delivery
-- Language-agnostic protocol
-- Connection multiplexing
-
-### 8.4 Authorization & Filtering
-
-Authorization enforced at **event capture time** (not delivery time):
-
-**Compile-time rules:**
-
-- WHERE clauses applied to event stream
-- Row-level security policies enforced
-- Field-level masking/redaction applied
-- Multi-tenant isolation guaranteed
-
-**Runtime binding:**
-
-- Auth context variables resolved per subscriber
-- User-specific filtering applied
-- Compliance audits generated
+- **Per-connection.** Each subscription is bound to a single WebSocket
+  connection and runs its own async generator. There is no shared server-side
+  fan-out buffer and no cross-process coordination.
+- **No server-side replay.** FraiseQL does not persist a stream of past events.
+  On disconnect, restart, or crash, the client simply **reconnects and
+  resubscribes**; it will receive updates from that point forward. If your
+  application needs gap-free delivery, make the generator re-read current state
+  on each (re)subscribe — for example, emit the latest snapshot from a `v_`/`tv_`
+  view first, then stream subsequent changes.
+- **Resource cleanup.** When a client disconnects, FraiseQL stops iterating the
+  generator. Use `with_lifecycle(on_complete=...)` (or a `finally` block in your
+  generator) to release listeners, cursors, or background tasks.
+- **Latency vs. load.** `LISTEN/NOTIFY` gives near-immediate delivery; polling
+  trades latency for simplicity. Choose per subscription.
+- **Authentication.** Authorization is enforced at subscribe time via the
+  per-operation `authorizer` (see [Authorization](#5-authorization)).
 
 ---
 
-## 9. Performance Characteristics
-
-### 9.1 Event Latency
-
-**Database to subscription delivery:**
-
-| Path | Latency (Observed) | Notes |
-|------|----------|-------|
-| ChangeLogListener polling | 100ms (P50), 200ms (P99) | Polling interval + checkpoint |
-| graphql-ws client (local) | 100-150ms | Polling + network round-trip |
-| graphql-ws client (remote) | 150-300ms | Polling + WAN latency |
-| Webhook delivery | 150-400ms | Polling + HTTP request + retry logic |
-| Kafka producer | 100-150ms | Polling + async write to broker |
-
-**Example: User creates order in UI, sees confirmation**
-
-```text
-<!-- Code example in TEXT -->
-
-1. Mutation committed (1ms)
-2. Event inserted into tb_entity_change_log (1ms)
-3. ChangeLogListener polls (0-100ms, average 50ms)
-4. ObserverRuntime processes event (1ms)
-5. Filter evaluates (0.5ms)
-6. Transform to GraphQL (0.5ms)
-7. Send to WebSocket (1ms)
-8. Client receives (5-10ms network)
-────────────────
-Total: ~100-150ms (imperceptible to users)
-```text
-<!-- Code example in TEXT -->
-
-### 9.2 Throughput
-
-**Concurrent subscriptions:**
-
-- Single process: 1,000-10,000 concurrent WebSocket connections (depends on memory)
-- Horizontal scaling: Multiple FraiseQL instances behind load balancer
-- Event buffering: `tb_entity_change_log` handles burst traffic
-
-**Event throughput (observed in reference deployments):**
-
-- ChangeLogListener polling: 1,000-2,000 events/second (database-limited)
-- Webhook delivery: Limited by HTTP endpoint capacity (external factor)
-- Kafka: 100,000+ events/second (broker-dependent; target with typical configurations)
-
-### 9.3 Memory Usage
-
-**Per subscription:**
-
-- graphql-ws connection: ~10-50 KB (WebSocket buffer)
-- Event filter state: Negligible (compiled SQL predicates)
-- Buffered events: 1-10 MB (configurable retention)
-
-**Example:** 1,000 concurrent subscriptions (reference deployment)
-
-- Connection buffers: ~50 MB
-- Event buffer: ~100 MB
-- **Total observed: ~150 MB** (typical, single process)
-
-### 9.4 Resource Utilization
-
-**CPU:**
-
-- Event filtering: <1% per 1,000 events/second (database-side)
-- GraphQL transformation: <1% per 1,000 events/second (deterministic)
-- Negligible overhead for idle subscriptions
-
-**Network:**
-
-- graphql-ws keeps connection open (minimal bandwidth if idle)
-- Webhook bursts: Limited by retry backoff
-- Kafka: Configurable batch size
-
----
-
-## 10. Limitations & Trade-Offs
-
-### 10.1 Supported Semantics
-
-**✅ Subscriptions CAN:**
-
-- Project database entities (same fields as queries)
-- Filter by compile-time WHERE clauses
-- Filter by runtime variables
-- Support nested projections
-- Enforce row-level authorization (compile-time)
-- Replay events from `tb_entity_change_log`
-- Deliver to multiple transport adapters simultaneously
-- Order events per entity (not globally)
-
-### 10.2 Explicitly NOT Supported
-
-**❌ Subscriptions CANNOT:**
-
-- Execute arbitrary user code
-- Modify subscription filter at runtime (must be declared at compile time)
-- Subscribe across multiple entities in single query
-
-  ```graphql
-<!-- Code example in GraphQL -->
-  # NOT ALLOWED: Subscribes to Order changes, but also User changes
-  subscription {
-    orderCreated { id }
-    userUpdated { id }
-  }
-  ```text
-<!-- Code example in TEXT -->
-
-- Guarantee global event ordering (only per-entity ordering)
-- Transform events via resolvers
-- Access fields not declared in subscription schema
-
-**Why these limitations exist:**
-
-- Subscriptions are **projections**, not programs
-- Filters must be compile-time deterministic
-- No user code execution (aligned with FraiseQL philosophy)
-
-### 10.3 Delivery Guarantees
-
-**Guaranteed:**
-
-- At-least-once delivery (events not lost)
-- Per-entity ordering (events for same entity in order)
-- Event idempotence (can process same event twice safely)
-
-**NOT guaranteed:**
-
-- Exactly-once delivery (transport-dependent)
-- Global event ordering (use event sequence_number for ordering)
-- Delivery to all transports simultaneously (Kafka may lag WebSocket)
-
-### 10.4 Database Limitations
-
-**All Databases (Polling Architecture):**
-
-- Manual event population required (application must INSERT into `tb_entity_change_log`)
-- 100-200ms latency (polling interval)
-- Single table write bottleneck (can scale with partitioning)
-
-**PostgreSQL:**
-
-- None specific (reference implementation)
-
-**MySQL:**
-
-- JSON type less efficient than PostgreSQL JSONB
-- No native UUID type (stored as CHAR(36))
-
-**SQL Server:**
-
-- JSON stored as NVARCHAR(MAX) (less efficient than native JSON)
-- Different date/time types (DATETIME2 vs TIMESTAMP)
-
-**SQLite:**
-
-- Single process (no network clients)
-- Not suitable for production subscriptions
-- Good for development/testing only
-
----
-
-## 11. Security & Authorization
-
-### 11.1 Authentication
-
-Subscriptions require authentication same as mutations:
-
-```python
-<!-- Code example in Python -->
-# Only authenticated users can subscribe
-@FraiseQL.subscription
-class OrderCreated:
-    where: WhereOrder = FraiseQL.where(
-        user_id=FraiseQL.context.user_id
-    )
-    # Fails if context.user_id is None (unauthenticated)
-```text
-<!-- Code example in TEXT -->
-
-### 11.2 Row-Level Authorization
-
-WHERE clauses enforce row-level access control through compile-time rule definition and runtime-safe parameter binding:
-
-**Mechanism:**
-
-- Authorization rules **defined** at compile time in schema (WHERE clause states who can access what)
-- Authorization values **bound** at runtime (context.user_id, context.org_id resolved from AuthContext when subscription established)
-- Filters are deterministic SQL predicates—no dynamic logic
-
-**Examples:**
-
-```python
-<!-- Code example in Python -->
-# User only sees their own orders
-where: WhereOrder = FraiseQL.where(user_id=FraiseQL.context.user_id)
-
-# Org admin sees org's orders
-where: WhereOrder = FraiseQL.where(fk_org=FraiseQL.context.org_id)
-
-# Admin sees everything (no WHERE filter)
-where: WhereOrder = FraiseQL.where()  # No filter = all rows
-```text
-<!-- Code example in TEXT -->
-
-### 11.3 Field-Level Authorization
-
-Projected fields can have authorization rules:
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class OrderCreated:
-    id: ID  # Always visible
-    amount: Decimal  # Always visible
-
-    # sensitive_notes only visible to admin
-    sensitive_notes: Optional[str] = FraiseQL.field(
-        auth_required=["admin"]
-    )
-
-# If context.role != "admin", sensitive_notes omitted from events
-```text
-<!-- Code example in TEXT -->
-
-### 11.4 Signature Verification (Webhooks)
-
-Webhooks include HMAC-SHA256 signature for verification:
-
-```javascript
-<!-- Code example in JAVASCRIPT -->
-// Webhook handler
-const signature = req.headers['x-FraiseQL-signature'];
-const payload = req.rawBody;
-
-const expected = crypto
-  .createHmac('sha256', WEBHOOK_SECRET)
-  .update(payload)
-  .digest('hex');
-
-if (signature !== expected) {
-  return res.status(401).send('Signature mismatch');
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 12. Examples
-
-### Example 1: Real-Time Order Dashboard
-
-**Schema definition:**
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class OrderCreated:
-    """Stream new orders for the organization."""
-
-    where: WhereOrder = FraiseQL.where(
-        fk_org=FraiseQL.context.org_id
-    )
-
-    id: ID
-    user_id: ID
-    amount: Decimal
-    created_at: DateTime
-    user: User  # Nested projection
-
-
-@FraiseQL.subscription
-class OrderStatusChanged:
-    """Stream status updates for organization's orders."""
-
-    where: WhereOrder = FraiseQL.where(
-        fk_org=FraiseQL.context.org_id
-    )
-
-    id: ID
-    old_status: OrderStatus
-    new_status: OrderStatus
-    updated_at: DateTime
-```text
-<!-- Code example in TEXT -->
-
-**Client (React):**
-
-```typescript
-<!-- Code example in TypeScript -->
-import { useSubscription } from '@apollo/client';
-
-export function OrderDashboard() {
-  const { data: newOrders } = useSubscription(gql`
-    subscription {
-      orderCreated {
-        id
-        user_id
-        amount
-        created_at
-        user { name email }
-      }
-    }
-  `);
-
-  const { data: statusChanges } = useSubscription(gql`
-    subscription {
-      orderStatusChanged {
-        id
-        old_status
-        new_status
-        updated_at
-      }
-    }
-  `);
-
-  return (
-    <div>
-      <LiveOrderList orders={newOrders?.orderCreated || []} />
-      <StatusUpdateFeed updates={statusChanges?.orderStatusChanged || []} />
-    </div>
-  );
-}
-```text
-<!-- Code example in TEXT -->
-
-### Example 2: Event Streaming to Analytics
-
-**Schema definition:**
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class UserRegistered:
-    """Stream new user registrations (no filter, analytics event)."""
-
-    where: WhereUser = FraiseQL.where()  # All users
-
-    id: ID
-    email: Email
-    created_at: DateTime
-    source: str  # How they registered
-
-
-@FraiseQL.subscription
-class PurchaseMade:
-    """Stream purchases for analytics and revenue tracking."""
-
-    where: WhereOrder = FraiseQL.where(
-        status="completed"  # Only completed orders
-    )
-
-    id: ID
-    user_id: ID
-    amount: Decimal
-    items: list[OrderItem]
-    created_at: DateTime
-```text
-<!-- Code example in TEXT -->
-
-**Kafka configuration:**
-
-```python
-<!-- Code example in Python -->
-config = FraiseQLConfig(
-    kafka={
-        "enabled": True,
-        "bootstrap_servers": ["kafka:9092"],
-        "subscriptions": {
-            "UserRegistered": {
-                "topic": "analytics.users.registered",
-                "partition_by": "id"
-            },
-            "PurchaseMade": {
-                "topic": "analytics.orders.completed",
-                "partition_by": "user_id"
-            }
-        }
-    }
-)
-```text
-<!-- Code example in TEXT -->
-
-**Consumer (Python):**
-
-```python
-<!-- Code example in Python -->
-from kafka import KafkaConsumer
-import json
-
-consumer = KafkaConsumer(
-    'analytics.orders.completed',
-    bootstrap_servers=['kafka:9092'],
-    value_deserializer=lambda m: json.loads(m.decode('utf-8'))
-)
-
-for message in consumer:
-    event = message.value
-    # Insert into data warehouse
-    warehouse.insert_order(
-        order_id=event['data']['id'],
-        user_id=event['data']['user_id'],
-        amount=event['data']['amount'],
-        event_time=event['timestamp']
-    )
-```text
-<!-- Code example in TEXT -->
-
-### Example 3: Multi-Tenant Filtering with Variables
-
-**Schema definition:**
-
-```python
-<!-- Code example in Python -->
-@FraiseQL.subscription
-class ActivityInOrganization:
-    """Stream activity (creates, updates, deletes) in organization."""
-
-    where: WhereAuditLog = FraiseQL.where(
-        fk_org=FraiseQL.context.org_id
-    )
-
-    @FraiseQL.variable(name="min_severity")
-    class Filter:
-        """Optional severity filter."""
-        severity: AuditSeverity
-
-    id: ID
-    entity_type: str
-    entity_id: UUID  # UUID v4 for GraphQL ID
-    operation: str
-    severity: AuditSeverity
-    user: User
-    created_at: DateTime
-```text
-<!-- Code example in TEXT -->
-
-**Client with filtering:**
-
-```graphql
-<!-- Code example in GraphQL -->
-subscription ActivityInOrganization($min_severity: AuditSeverity) {
-  activityInOrganization(min_severity: $min_severity) {
-    id
-    entity_type
-    operation
-    severity
-    user { name }
-    created_at
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Usage:**
-
-```javascript
-<!-- Code example in JAVASCRIPT -->
-// Subscribe to high-priority events only
-useSubscription(ActivityInOrganization, {
-  variables: {
-    min_severity: "HIGH"
-  }
-});
-```text
-<!-- Code example in TEXT -->
-
----
-
-## 13. Appendix
-
-### A. Debugging Subscriptions
-
-**Check if subscription is defined:**
-
-```bash
-<!-- Code example in BASH -->
-# Query introspection
-query {
-  __type(name: "Subscription") {
-    fields {
-      name
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Monitor event flow:**
-
-```sql
-<!-- Code example in SQL -->
--- Check event buffer
-SELECT COUNT(*) as pending_events
-FROM tb_entity_change_log
-WHERE created_at > NOW() - INTERVAL '1 minute';
-
--- Monitor subscription lag
-SELECT entity_type, MAX(created_at) as last_event
-FROM tb_entity_change_log
-GROUP BY entity_type;
-```text
-<!-- Code example in TEXT -->
-
-**Enable subscription tracing (Rust runtime):**
-
-```rust
-<!-- Code example in RUST -->
-if config.debug {
-    trace!("Subscription: OrderCreated");
-    trace!("  Filter: WHERE user_id = {} AND deleted_at IS NULL", user_id);
-    trace!("  Event matched: {}", event_matches_filter);
-    trace!("  Delivered to: {} clients", client_count);
-}
-```text
-<!-- Code example in TEXT -->
-
-### B. Monitoring Metrics
-
-**Key metrics to track:**
-
-```text
-<!-- Code example in TEXT -->
-FraiseQL.subscription.connections     # Current active connections
-FraiseQL.subscription.events_emitted   # Events matching filters
-FraiseQL.subscription.events_delivered # Events sent to clients
-FraiseQL.subscription.lag_seconds      # Delay from database to client
-FraiseQL.subscription.error_count      # Delivery failures
-```text
-<!-- Code example in TEXT -->
-
-### C. Connection Pool Sizing
-
-**Recommendation:**
-
-- Pool size = (expected_concurrent_subscriptions / 10) + overhead
-- Default: 20 connections
-- Monitor connection count and adjust
-
-**Example:**
-
-```python
-<!-- Code example in Python -->
-config = FraiseQLConfig(
-    database_url="postgresql://...",
-    subscriptions={
-        "connection_pool_size": 50,  # For 500+ concurrent subscriptions
-        "connection_timeout": 300,
-        "idle_timeout": 60
-    }
-)
-```text
-<!-- Code example in TEXT -->
-
-### D. References
-
-**Related specifications:**
-
-- `docs/specs/cdc-format.md` — CDC event structure and format
-- `docs/specs/schema-conventions.md section 6` — `tb_entity_change_log` table definition
-- `docs/architecture/core/execution-model.md section 9.3` — CDC integration
-- Apollo Federation v2: `docs/architecture/integration/federation.md` — Cross-subgraph subscriptions (future)
-
-**External standards:**
-
-- graphql-ws protocol: <https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md>
-- Debezium format: <https://debezium.io/>
-- Kafka consumers: <https://kafka.apache.org/documentation/#consumerconfigs>
-
----
-
-## Summary
-
-**Subscriptions in FraiseQL are event projections from the database, not GraphQL resolver-based subscriptions.**
-
-**Key properties:**
-
-- ✅ Database-centric (table polling, not message channels)
-- ✅ Compiled, not interpreted
-- ✅ Transport-agnostic (graphql-ws, webhooks, Kafka, etc.)
-- ✅ Deterministic, no user code
-- ✅ Durable (buffered in `tb_entity_change_log`)
-
-**Architecture:**
-
-1. Database transaction commits
-2. Application inserts event into `tb_entity_change_log`
-3. ChangeLogListener polls table every 100ms
-4. ObserverRuntime routes events to SubscriptionManager
-5. Filters evaluated against compiled predicates
-6. Delivered via transport adapter (graphql-ws, webhook, Kafka)
-
-**Performance:**
-
-- **Latency:** 100-150ms (polling + processing + network)
-- **Throughput:** 1,000-2,000 events/sec (database-limited)
-- **Perceived latency:** Imperceptible to users for UI updates
-
-**Relationship to Observers:**
-
-- Subscriptions and Observers share the same event source (`tb_entity_change_log`)
-- Observers can optionally use NATS for distributed action processing
-- Subscriptions use direct transports (graphql-ws, Kafka) for client notifications
-- Default: composition (in-process routing), NATS optional for distributed deployments
-
-**Security:**
-
-- Row-level filtering enforced at compile time
-- No cross-tenant data leakage
-- Authorization via AuthContext
-
-**Limitations:**
-
-- Subscriptions are read-only (no mutations)
-- Filters compile-time determined
-- Per-entity ordering only
-- Manual event population required (automatic triggers pending)
-
-*End of Subscriptions Specification*
+## Related
+
+- [Integration patterns](../integration/integration-patterns.md) — connecting
+  FraiseQL to other systems.
+- [Consistency model](../reliability/consistency-model.md) — read/write
+  consistency guarantees.
+- [Failure modes and recovery](../reliability/failure-modes-and-recovery.md) —
+  reconnection and degradation behavior.
+- [Core concepts](../../foundation/02-core-concepts.md) — types, queries, and
+  the CQRS read/write model.
+- [First hour](../../getting-started/first-hour.md) — getting a FraiseQL app
+  running.


### PR DESCRIPTION
Phase 2 of the docs cleanup (follows #418–#421). Rewrites the **Architecture → Decisions / Integration / Realtime** nav pages, which described a v2 system (fictional plugin decorators, Apollo Federation, CDC/NATS event bus, a Rust observer / compiled-subscription runtime). All 5 are rewritten onto the **real v1 APIs**, each verified against `src/`.

## Per-file summary

| File | Key v2→v1 changes |
|------|-------------------|
| `decisions/anti-patterns` | keep the anti-pattern concepts, reframe onto real APIs (`@fraiseql.query/mutation`, `fn_`, `v_/tv_`, `@fraiseql.dataloader_field`, `Authorizer`, `cached_query`); add real v1 anti-patterns (logic in Python vs `fn_`; missing indexes/pagination) |
| `decisions/state-management` | reframe around the real PostgreSQL caching layer (`ResultCache`/`CachedRepository`/`cached_query`/`CascadeRule`/`setup_auto_cascade_rules`); remove CDC/Debezium/NATS/Kafka + `@FraiseQL.on_*` + multi-instance event bus |
| `integration/extension-points` | **document the real extension points** (`@fraiseql.field`, `@fraiseql.dataloader_field`, custom scalars, FastAPI middleware/mounting, `Authorizer`/RBAC, PostgreSQL `fn_`/triggers/types/extensions); purge the fictional `@FraiseQL.*` plugin framework |
| `integration/integration-patterns` | reframe around PostgreSQL **FDW-in-views**, `fn_` + transactional outbox, FastAPI mounting/middleware, GraphQL clients; remove Apollo Federation/subgraphs/`@FraiseQL.webhook`/`kafka_publisher`/multi-DB |
| `realtime/subscriptions` | rewrite around the real `@fraiseql.subscription` **async-generator-over-WebSocket** model (`graphql-transport-ws`/`graphql-ws`) with LISTEN/NOTIFY + polling event sources and real helpers (`subscription_filter`/`complexity`/`with_lifecycle`/`cache`/`authorizer`); remove the `tb_entity_change_log`/`ObserverRuntime`/Rust/NATS/gRPC engine (**2045→392 lines**) |

## Verification

- `grep`: **zero** `@FraiseQL.` / plugin-decorator / federation / CDC / NATS / `ObserverRuntime` / multi-DB artifacts (the lone "subgraph" mention is an explicit negation).
- **Every asserted API source-verified**: `@fraiseql.field`/`dataloader_field`, `subscription_filter(expression)`/`complexity`/`with_lifecycle`/`cache(ttl)`, `Authorizer`/`AuthorizationCacheConfig`/`setup_rbac_cache`, `cached_query`/`CascadeRule`/`setup_auto_cascade_rules`, and the `pg_fraiseql_cache` extension.
- All cross-links resolve; fences balanced; no Rust leftovers; `mkdocs build` no new warnings.

Net: **+1970 / −4572** lines. Completes the **entire Architecture nav section** (with #420, #421).

🤖 Generated with [Claude Code](https://claude.com/claude-code)