### PR TITLE
docs(reference): rewrite Reference + Specs pages for v1 (Phase 2)

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,124 +1,101 @@
-<!-- Skip to main content -->
 ---
-
-title: FraiseQL v2 Reference
-description: Complete API and operator references.
-keywords: ["directives", "types", "scalars", "schema", "api"]
+title: FraiseQL Reference
+description: API, scalar, and operator references for FraiseQL v1.
+keywords: ["decorators", "types", "scalars", "operators", "config", "cli"]
 tags: ["documentation", "reference"]
 ---
 
-# FraiseQL v2 Reference
+# FraiseQL Reference
 
-Complete API and operator references.
+FraiseQL is a Python runtime GraphQL framework for PostgreSQL. You define types,
+queries, and mutations with decorators; at app startup the schema is built in
+memory and served over FastAPI. This section is the API and operator reference.
 
----
-
-## 📚 Reference Documentation
-
-### Type System & Schema
-
-| Document | Description | Lines | Est. Time |
-|----------|-------------|-------|-----------|
-| [naming-patterns.md](naming-patterns.md) | FraiseQL naming conventions and patterns | 600+ | Reference |
-| [scalars.md](scalars.md) | Scalar type library and custom scalars | 1,492 | Reference |
-
-**Naming Patterns Topics:**
-
-- `id: UUID v4` — GraphQL entity identifiers
-- `pk_`, `fk_` — Internal BIGINT database keys
-- `tb_{entity}` — Write-side normalized tables
-- `v_{entity}` — Read-side denormalized views
-- `tv_{entity}` — Materialized table-backed views
-- `tf_{entity}` — Analytics fact tables with JSONB
-
-**Scalar Topics:**
-
-- Built-in scalar types (String, Int, Float, Boolean, ID)
-- Extended scalars (Date, DateTime, Time, UUID, JSON, etc.)
-- Custom scalar creation
-- Scalar validation rules
-- Serialization formats
-- Database type mappings
+New here? Start with the [Quickstart](../getting-started/quickstart.md), or browse
+the full [Documentation Home](../index.md).
 
 ---
 
-### Query Operators
-
-| Document | Description | Lines | Est. Time |
-|----------|-------------|-------|-----------|
-| [where-operators.md](where-operators.md) | Complete WHERE operator catalog | 1,137 | Reference |
-
-**Topics Covered:**
-
-- Comparison operators (eq, neq, gt, gte, lt, lte)
-- String operators (contains, startsWith, endsWith, regex)
-- List operators (in, notIn, isEmpty, isNotEmpty)
-- Null operators (isNull, isNotNull)
-- Logical operators (and, or, not)
-- JSON operators (jsonPath, jsonContains)
-- Array operators (arrayContains, arrayOverlap)
-- Database-specific operators (PostgreSQL JSONB, full-text search)
-- SQL generation examples
-
----
-
-### Authoring Tools
+## Decorators & API
 
 | Document | Description |
 |----------|-------------|
-| [cli-schema-format.md](cli-schema-format.md) | FraiseQL CLI schema format reference |
-| [view-selection-api.md](view-selection-api.md) | View selection API for automatic schema generation |
+| [decorators.md](decorators.md) | `@fraiseql.type`, `@fraiseql.query`, `@fraiseql.mutation`, `@fraiseql.input`, `@fraiseql.success`/`@fraiseql.error`, and friends |
+| [mutations-api.md](mutations-api.md) | Mutation result types and calling PostgreSQL `fn_` functions |
+| [repositories.md](repositories.md) | The CQRS repository (`db.find`, `db.find_one`, `db.execute_function`) on `info.context["db"]` |
+
+## Types & Scalars
+
+| Document | Description |
+|----------|-------------|
+| [scalars.md](scalars.md) | The built-in and domain scalar library (`ID`, `UUID`, `DateTime`, `EmailAddress`, `JSON`, `LTree`, and many more) |
+
+## Filtering Operators
+
+All operators are PostgreSQL-specific and generated at runtime from your `WHERE`
+input types.
+
+| Document | Description |
+|----------|-------------|
+| [where-operators.md](where-operators.md) | The complete WHERE operator catalog (comparison, text/pattern, array, JSON) |
+| [ltree-operators.md](ltree-operators.md) | `ltree` hierarchy operators (`ancestor_of`, `descendant_of`, `matches_lquery`, …) |
+| [vector-operators.md](vector-operators.md) | pgvector distance operators (`cosine_distance`, `inner_product`, `hamming_distance`, …) |
+
+## Conventions
+
+| Document | Description |
+|----------|-------------|
+| [naming-patterns.md](naming-patterns.md) | Database naming conventions (`tb_`, `v_`, `tv_`, `fn_`, `pk_`/`fk_`, the trinity `pk_`/`id`/`identifier`) |
+| [database.md](database.md) | Read views, table-backed views, and the `data` JSONB pattern |
+| [terminology.md](terminology.md) | Glossary of FraiseQL terms |
+
+## Configuration & CLI
+
+| Document | Description |
+|----------|-------------|
+| [config.md](config.md) | `FraiseQLConfig`, `create_fraiseql_app(...)` kwargs, and `FRAISEQL_` environment variables |
+| [cli.md](cli.md) | Command-line tooling for development workflows |
+| [quick-reference.md](quick-reference.md) | One-page cheat sheet of common patterns |
 
 ---
 
-### Distributed Transactions
+## Using these references
 
-| Document | Description | Lines | Est. Time |
-|----------|-------------|-------|-----------|
-| [saga-api.md](saga-api.md) | SAGA API reference for distributed transactions | 800+ | Reference |
+A minimal v1 app ties the pieces together at startup:
 
-**Topics Covered:**
+```python
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.types import ID
 
-- SAGA pattern for multi-database transactions
-- Coordinator API
-- Participant API
-- Compensation strategies
-- Retry policies
-- Timeout handling
 
----
+@fraiseql.type(sql_source="v_user")
+class User:
+    id: ID
+    name: str
+    email: str
 
-### REST API Reference
 
-- **[API Reference](api/graphql-api.md)** — Complete HTTP API endpoint documentation
+@fraiseql.query
+async def users(info) -> list[User]:
+    db = info.context["db"]
+    return await db.find("v_user")
 
----
 
-## 🎯 Using These References
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users],
+    production=False,  # enables the GraphQL playground
+)
+```
 
-**For Schema Authors:**
-
-- Reference [scalars.md](scalars.md) when defining types
-- Use [where-operators.md](where-operators.md) to understand available filters
-
-**For Frontend Developers:**
-
-- Bookmark [where-operators.md](where-operators.md) for query building
-- Check [scalars.md](scalars.md) for type serialization
-
-**For Compiler/Runtime Developers:**
-
-- Implement operators from [where-operators.md](where-operators.md)
-- Add new scalars following patterns in [scalars.md](scalars.md)
+- **Schema authors** — reach for [decorators.md](decorators.md),
+  [scalars.md](scalars.md), and [naming-patterns.md](naming-patterns.md).
+- **Frontend developers** — bookmark [where-operators.md](where-operators.md)
+  and [scalars.md](scalars.md) for query building and type serialization.
+- **Operators / deployers** — see [config.md](config.md) and [cli.md](cli.md).
 
 ---
 
-## 📚 Related Documentation
-
-- **[Specs: Authoring Contract](../specs/authoring-contract.md)** — Schema authoring rules
-- **[Specs: Compiled Schema](../specs/compiled-schema.md)** — Compiled type system
-- **[View Selection Guide](../architecture/database/view-selection-guide.md)** — Database view patterns and type mappings
-
----
-
-**Back to:** [Documentation Home](../README.md)
+**Back to:** [Documentation Home](../index.md)

--- a/docs/reference/scalars.md
+++ b/docs/reference/scalars.md
@@ -1,1588 +1,249 @@
-<!-- Skip to main content -->
 ---
-
 title: Custom Scalar Types Reference
-description: 1. [Overview](#overview)
-keywords: ["directives", "types", "scalars", "schema", "api"]
+description: Reference for FraiseQL v1's built-in GraphQL scalar types and their validation rules.
+keywords: ["scalars", "types", "schema", "validation", "reference"]
 tags: ["documentation", "reference"]
 ---
 
 # Custom Scalar Types Reference
 
-**Status:** ✅ Production Ready
-**Version:** FraiseQL v2.0.0-alpha.1+
-**Categories**: 18 domain categories
-**Total Scalars**: 56 types
+FraiseQL v1 ships a large set of domain-specific GraphQL scalar types in addition to the
+GraphQL built-ins. They give you:
 
-## Table of Contents
+- **Type safety** — validation at the GraphQL boundary, before values reach PostgreSQL.
+- **Format standardization** — ISO standards, RFC compliance, and domain conventions.
+- **Consistent serialization** — stable JSON representations in and out.
+- **Clear errors** — validation failures surface as GraphQL errors, not stack traces.
 
-1. [Overview](#overview)
-2. [Scalar Categories](#scalar-categories)
-3. [Database Mappings](#database-mappings)
-4. [Using Scalars in Type Definitions](#using-scalars-in-type-definitions)
-5. [Performance Considerations](#performance-considerations)
-6. [Best Practices](#best-practices)
-7. [Scalar Import Locations](#scalar-import-locations)
-8. [Summary](#summary)
-
----
-
-## Overview
-
-FraiseQL provides 56 domain-specific custom scalar types beyond GraphQL's built-in scalars. These scalars provide:
-
-- **Type safety**: Validation at the GraphQL layer
-- **Database mapping**: Native PostgreSQL column types
-- **Format standardization**: ISO standards, RFC compliance, domain conventions
-- **Serialization**: Consistent JSON representations
-- **Error handling**: Clear validation error messages
-
-All scalars are imported from the main FraiseQL package and available for use in type definitions:
+All scalars are imported from the lowercase `fraiseql.types` module:
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.types import Date, DateTime, UUID, Money, Vector, IpAddressString
-```text
-<!-- Code example in TEXT -->
+from fraiseql.types import ID, UUID, Date, DateTime, EmailAddress, Money, LTree
+```
+
+> FraiseQL v1 is **PostgreSQL only**. Read types are backed by a `data` JSONB column on a
+> `v_`/`tv_` view, so a scalar's "stored" representation is whatever you place inside that
+> JSONB document — there is no per-database type matrix. The schema is built in memory at
+> application startup, fully at runtime.
 
 ---
 
-## Scalar Categories
-
-### 1. Core System Scalars
-
-#### **UUID**
-
-- **GraphQL Type**: `UUID`
-- **Format**: RFC 4122 UUID format
-- **Validation**: Standard UUID v4 validation
-- **Database Type**: `uuid`
-- **Examples**: `550e8400-e29b-41d4-a716-446655440000`
-- **Use Cases**: Entity identifiers, unique resource IDs
-- **Notes**: Hyphenated format required (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
-
-#### **ID**
-
-- **GraphQL Type**: `ID` (built-in GraphQL scalar)
-- **Format**: Any string or number
-- **Python Marker**: `IDField`, `ID` (NewType)
-- **Notes**:
-  - GraphQL specification allows any serializable string-like value
-  - UUID validation handled at input level via `SchemaConfig.id_policy`
-  - Can represent database integers, strings, UUIDs, or custom formats
-- **Use Cases**: Primary keys, entity identifiers
-
-#### **JSON**
-
-- **GraphQL Type**: `JSON`
-- **Format**: Arbitrary JSON-serializable values
-- **Python Marker**: `JSONField`
-- **Accepts**: Objects, arrays, strings, numbers, booleans, null
-- **Database Type**: `jsonb` (PostgreSQL JSONB with operators)
-- **Examples**: `{"key": "value", "nested": {"deep": true}}`
-- **Use Cases**: Flexible data storage, metadata, semi-structured data
-
----
-
-### 2. Temporal Scalars
-
-Temporal scalars represent dates, times, durations, and date ranges with ISO 8601 compliance.
-
-#### **Date**
-
-- **GraphQL Type**: `Date`
-- **Format**: ISO 8601 date format
-- **Pattern**: `YYYY-MM-DD`
-- **Database Type**: `date`
-- **Examples**: `2025-01-11`, `2024-12-25`, `1999-05-15`
-- **Validation**: Valid calendar dates (accounts for leap years)
-- **Timezone**: Date only (no timezone)
-- **Use Cases**: Birthdate, event dates, contract dates
-
-#### **DateTime**
-
-- **GraphQL Type**: `DateTime`
-- **Format**: ISO 8601 datetime with timezone
-- **Pattern**: `YYYY-MM-DDTHH:mm:ssZ` (always UTC)
-- **Timezone**: Always UTC, serialized with 'Z' suffix
-- **Database Type**: `timestamp with time zone`
-- **Examples**:
-  - `2025-01-11T15:30:00Z`
-  - `2024-12-25T00:00:00Z`
-  - `2025-01-10T23:45:30Z`
-- **Precision**: Milliseconds supported
-- **Use Cases**: Created timestamps, event times, log timestamps
-- **Notes**: Input accepts timezone offsets (converted to UTC), output always in UTC with Z
-
-#### **Time**
-
-- **GraphQL Type**: `Time`
-- **Format**: 24-hour time format
-- **Pattern**: `HH:MM` or `HH:MM:SS`
-- **Database Type**: `time`
-- **Examples**: `14:30`, `09:15:30`, `23:59:00`, `00:00:00`
-- **Validation**: Hours 0-23, Minutes 0-59, Seconds 0-59
-- **Timezone**: No timezone (wall clock time)
-- **Use Cases**: Business hours, meeting times, scheduled tasks
-- **Notes**: Seconds and milliseconds optional in input
-
-#### **Duration**
-
-- **GraphQL Type**: `Duration`
-- **Format**: ISO 8601 duration format
-- **Pattern**: `P[n]Y[n]M[n]DT[n]H[n]M[n]S`
-- **Components**:
-  - `P`: Period marker (required)
-  - `Y`: Years
-  - `M`: Months (before T) or Minutes (after T)
-  - `D`: Days
-  - `T`: Time separator (required if time components present)
-  - `H`: Hours
-  - `S`: Seconds
-- **Examples**:
-  - `P1Y2M3DT4H5M6S` (1 year, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds)
-  - `PT30M` (30 minutes)
-  - `P1D` (1 day)
-  - `PT2H` (2 hours)
-  - `P6M` (6 months)
-- **Use Cases**: Subscription periods, retention policies, SLA durations
-- **Notes**: No timezone, represents an abstract duration
-
-#### **DateRange**
-
-- **GraphQL Type**: `DateRange`
-- **Format**: Range notation with inclusive/exclusive boundaries
-- **Database Type**: `daterange` (PostgreSQL range type)
-- **Syntax**:
-  - Inclusive: `[YYYY-MM-DD, YYYY-MM-DD]` (square brackets)
-  - Exclusive: `(YYYY-MM-DD, YYYY-MM-DD)` (parentheses)
-  - Mixed: `[YYYY-MM-DD, YYYY-MM-DD)` or `(YYYY-MM-DD, YYYY-MM-DD]`
-- **Examples**:
-  - `[2025-01-01, 2025-12-31]` (all of 2025, inclusive)
-  - `(2024-12-31, 2026-01-01)` (all of 2025, exclusive boundaries)
-  - `[2025-01-01, 2025-06-30)` (Jan 1 inclusive to Jun 30 exclusive)
-- **Use Cases**: Project timelines, availability windows, contract periods
-- **Database Operators**: Can use PostgreSQL range operators (`,`@>`,`<@`, etc.)
-
-#### **Timezone**
-
-- **GraphQL Type**: `Timezone`
-- **Format**: IANA timezone identifier
-- **Pattern**: `Region/City` (case-sensitive)
-- **Examples**:
-  - `America/New_York` (EST/EDT)
-  - `Europe/Paris` (CET/CEST)
-  - `Asia/Tokyo` (JST)
-  - `Australia/Sydney` (AEDT/AEST)
-  - `UTC` (Coordinated Universal Time)
-- **Validation**: Must be valid IANA timezone
-- **Case-Sensitive**: Yes, standard IANA format is case-sensitive
-- **Use Cases**: User timezone preferences, timestamp interpretation, scheduling
-- **Notes**: PostgreSQL supports IANA timezones for timestamp conversion
-
----
-
-### 3. Geographic Scalars
-
-Geographic scalars represent coordinates, latitude/longitude with GPS precision.
-
-#### **Coordinate**
-
-- **GraphQL Type**: `Coordinate`
-- **Format**: Multiple input formats supported, single canonical format
-- **Input Formats**:
-  - String: `"37.7749,-122.4194"` or `"(37.7749,-122.4194)"`
-  - Array: `[37.7749, -122.4194]`
-  - Object: `{lat: 37.7749, lng: -122.4194}`
-- **Output Format**: `{lat: float, lng: float}`
-- **Validation**:
-  - Latitude: -90.0 to +90.0 degrees
-  - Longitude: -180.0 to +180.0 degrees
-  - Precision: Up to 8 decimal places (≈1.1 mm accuracy)
-- **Database Type**: PostgreSQL `POINT` (internally stores longitude, latitude in that order)
-- **Examples**:
-  - `37.7749,-122.4194` (San Francisco)
-  - `-33.8688,151.2093` (Sydney)
-  - `40.7128,-74.0060` (New York)
-  - `0.0,0.0` (Null Island)
-- **Use Cases**: Location tracking, geolocation, map markers, geographic queries
-- **Database Operators**: PostgreSQL point operators (`<->`, distance calculations)
-
-#### **Latitude**
-
-- **GraphQL Type**: `Latitude`
-- **Format**: Decimal degrees
-- **Range**: -90.0 to +90.0 degrees
-  - Negative: Southern hemisphere
-  - Positive: Northern hemisphere
-  - 0: Equator
-- **Precision**: Up to 8 decimal places
-- **Resolution per Decimal Place**:
-  - 1 decimal: ≈11.1 km
-  - 2 decimals: ≈1.1 km
-  - 3 decimals: ≈111 m
-  - 4 decimals: ≈11.1 m
-  - 5 decimals: ≈1.1 m
-  - 6 decimals: ≈0.11 m (11 cm)
-  - 7 decimals: ≈1.1 cm
-  - 8 decimals: ≈1.1 mm
-- **Examples**: `40.7128`, `-33.8688`, `0.0`, `51.5074`
-- **Use Cases**: Geolocation filtering, distance calculations, map visualization
-- **Database Type**: `numeric` or `double precision` depending on precision needs
-
-#### **Longitude**
-
-- **GraphQL Type**: `Longitude`
-- **Format**: Decimal degrees
-- **Range**: -180.0 to +180.0 degrees
-  - Negative: Western hemisphere
-  - Positive: Eastern hemisphere
-  - Prime meridian: ±0 or ±180
-- **Precision**: Up to 8 decimal places
-- **Examples**: `-74.0060`, `151.2093`, `0.0`, `-0.1278`
-- **Use Cases**: Geolocation filtering, distance calculations, geographic boundaries
-- **Database Type**: `numeric` or `double precision`
-- **Notes**: Value wrapping at ±180 (cyclical coordinate)
-
----
-
-### 4. Network Scalars
-
-Network scalars represent IP addresses, MAC addresses, domains, and URLs.
-
-#### **IpAddressString**
-
-- **GraphQL Type**: `IpAddressString`
-- **Format**: IP address (IPv4 or IPv6)
-- **IPv4 Examples**: `192.168.1.1`, `10.0.0.1`, `8.8.8.8`
-- **IPv6 Examples**: `2001:db8::1`, `::1`, `fe80::1`
-- **CIDR Notation**: Accepted with `/prefix` (e.g., `192.168.1.0/24`)
-- **Database Type**: `inet` (PostgreSQL, supports both address and netmask)
-- **Validation**: Valid IPv4 or IPv6 address format
-- **Use Cases**:
-  - Server IP addresses
-  - Client IP logging
-  - Network configuration
-  - ACL (Access Control List) rules
-- **Notes**: PostgreSQL `inet` type supports:
-  - IP address + optional netmask
-  - Comparison operators
-  - Network containment queries
-
-#### **SubnetMaskString**
-
-- **GraphQL Type**: `SubnetMaskString`
-- **Format**: IPv4 netmask notation (CIDR prefix format also accepted)
-- **Examples**: `255.255.255.0`, `255.255.0.0`, `255.0.0.0`
-- **CIDR Equivalents**:
-  - `/24` = `255.255.255.0`
-  - `/16` = `255.255.0.0`
-  - `/8` = `255.0.0.0`
-  - `/32` = `255.255.255.255`
-- **Validation**: Valid IPv4 netmask (contiguous 1-bits from left)
-- **Use Cases**: Network configuration, subnet planning, ACL specification
-- **Notes**: Only IPv4 (IPv6 uses CIDR prefix notation directly)
-
-#### **CIDR**
-
-- **GraphQL Type**: `CIDR`
-- **Format**: CIDR notation (Classless Inter-Domain Routing)
-- **Pattern**: `address/prefix`
-- **IPv4 Example**: `192.168.1.0/24`, `10.0.0.0/8`
-- **IPv6 Examples**: `2001:db8::/32`, `fe80::/10`
-- **Prefix Length**:
-  - IPv4: 0-32 bits
-  - IPv6: 0-128 bits
-- **Validation**:
-  - `strict=False` (default): Allows host bits (e.g., `192.168.1.5/24`)
-  - `strict=True`: Rejects host bits (requires `192.168.1.0/24`)
-- **Database Type**: `cidr` (PostgreSQL, network address type)
-- **Use Cases**:
-  - Network ranges
-  - IP allowlisting/blocklisting
-  - VPC/subnet definitions
-  - Firewall rules
-- **Database Operators**: PostgreSQL supports network operators (`<<`, `>>`, `&&`)
-
-#### **MacAddress**
-
-- **GraphQL Type**: `MacAddress`
-- **Format**: Media Access Control (MAC/Physical) address
-- **Input Formats** (all equivalent, normalized to canonical):
-  - Colon: `00:11:22:33:44:55`
-  - Hyphen: `00-11-22-33-44-55`
-  - Cisco: `0011.2233.4455`
-  - Bare: `001122334455`
-- **Canonical Output**: Uppercase colon-separated (e.g., `00:11:22:33:44:55`)
-- **Database Type**: `macaddr` (PostgreSQL)
-- **Validation**:
-  - 48 bits total (6 octets)
-  - Valid hexadecimal digits
-  - Proper separators
-- **Examples**: `00:11:22:33:44:55`, `FF:FF:FF:FF:FF:FF`
-- **Use Cases**:
-  - Device identification
-  - Network interface discovery
-  - DHCP configuration
-  - ARP (Address Resolution Protocol) tables
-- **Notes**: PostgreSQL `macaddr` type also supports network functions
-
-#### **Hostname**
-
-- **GraphQL Type**: `Hostname`
-- **Format**: RFC 1123 hostname format
-- **Rules**:
-  - Labels: 1-63 characters each
-  - Max total length: 253 characters
-  - Valid characters: `a-z`, `0-9`, hyphen (`-`)
-  - No leading or trailing hyphens per label
-  - No TLD required (single labels allowed)
-- **Examples**:
-  - `localhost`
-  - `api-server`
-  - `my-app.local`
-  - `server-1`
-  - `db.internal`
-- **Case**: Normalized to lowercase
-- **Use Cases**:
-  - Server names
-  - Container hostnames
-  - Internal DNS names
-  - Local service discovery
-- **Notes**: Less strict than DomainName (doesn't require TLD)
-
-#### **DomainName**
-
-- **GraphQL Type**: `DomainName`
-- **Format**: RFC-compliant fully qualified domain name (FQDN)
-- **Rules**:
-  - Labels: 1-63 characters each
-  - Max total length: 253 characters
-  - Valid characters: `a-z`, `0-9`, hyphen (`-`)
-  - No leading or trailing hyphens per label
-  - TLD required (at least 2 labels)
-  - Valid TLDs: `.com`, `.org`, `.co.uk`, etc.
-- **Examples**:
-  - `example.com`
-  - `api.example.com`
-  - `subdomain.example.co.uk`
-  - `service.internal.company.com`
-- **Case**: Normalized to lowercase
-- **Use Cases**:
-  - Public domain names
-  - Email domains
-  - API endpoints
-  - CORS origins
-- **Notes**: Stricter than Hostname (requires TLD)
-
-#### **URL**
-
-- **GraphQL Type**: `URL`
-- **Format**: RFC 3986 compliant URL
-- **Required Components**: Scheme, domain
-- **Scheme**: Must be `http://` or `https://`
-- **Structure**: `https://domain.com[/path][?query][#fragment]`
-- **Examples**:
-  - `https://example.com`
-  - `https://api.example.com/v1/users`
-  - `https://example.com:8080/path?key=value#section`
-  - `http://localhost:3000`
-- **Validation**:
-  - Valid domain
-  - Proper encoding (spaces → %20, etc.)
-  - Valid characters in each URL component
-- **Use Cases**:
-  - Webhooks
-  - Redirects
-  - External API endpoints
-  - Resource URLs
-- **Notes**: HTTPS preferred for security
-
----
-
-### 5. Financial Scalars
-
-Financial scalars represent monetary values, currency codes, and exchange rates with proper precision.
-
-#### **Money**
-
-- **GraphQL Type**: `Money`
-- **Format**: Decimal number with exactly 4 decimal places
-- **Precision**: Up to 15 digits before decimal
-- **Database Type**: `NUMERIC(19,4)` (PostgreSQL)
-- **Range**:
-  - Min: `-9999999999999.9999`
-  - Max: `9999999999999.9999`
-- **Examples**:
-  - `123.45` (stored as `123.4500`)
-  - `-999.9999` (negative amount)
-  - `1000000.00` (million)
-  - `0.01` (one cent)
-- **Precision Purpose**: Accounts for fractional cents in currency conversion
-- **Use Cases**:
-  - Prices
-  - Account balances
-  - Transaction amounts
-  - Exchange amounts
-- **Notes**: Always 4 decimal places for accounting precision
-
-#### **CurrencyCode**
-
-- **GraphQL Type**: `CurrencyCode`
-- **Format**: ISO 4217 three-letter currency code
-- **Validation**: Must be valid ISO 4217 code
-- **Case**: Normalized to uppercase
-- **Examples**:
-  - `USD` (US Dollar)
-  - `EUR` (Euro)
-  - `GBP` (British Pound)
-  - `JPY` (Japanese Yen)
-  - `CHF` (Swiss Franc)
-- **Common Codes**: USD, EUR, GBP, JPY, AUD, CAD, CHF, CNY, SEK, NZD, MXN, SGD, HKD, NOK, KRW
-- **Use Cases**:
-  - Currency specification for Money values
-  - Multi-currency transactions
-  - Exchange rates
-  - Payment processing
-- **Notes**: Often paired with Money scalar for complete monetary values
-
-#### **Percentage**
-
-- **GraphQL Type**: `Percentage`
-- **Format**: Decimal number 0.00 to 100.00
-- **Precision**: Exactly 2 decimal places
-- **Database Type**: `NUMERIC(5,2)` (PostgreSQL)
-- **Range**: `0.00` to `100.00`
-- **Examples**:
-  - `25.5` (25.5%)
-  - `100` (stored as `100.00`)
-  - `0.01` (0.01%)
-  - `99.99`
-- **Interpretation**: Direct percentage value (25.5 means 25.5%, not 0.255)
-- **Use Cases**:
-  - Tax rates
-  - Discount rates
-  - Interest rates
-  - Commission percentages
-  - Completion percentages
-- **Notes**: 2 decimal places for percentage precision
-
-#### **ExchangeRate**
-
-- **GraphQL Type**: `ExchangeRate`
-- **Format**: High-precision decimal
-- **Database Type**: `NUMERIC(20,8)` (PostgreSQL)
-- **Precision**: Up to 12 digits before decimal, 8 after
-- **Examples**:
-  - `1.23456789` (EUR to USD)
-  - `1234.5` (JPY to USD)
-  - `0.8765` (GBP to USD)
-- **Use Cases**:
-  - Currency conversion rates
-  - Cross-rate calculations
-  - Historical rate storage
-- **Notes**: High precision for accurate currency conversions
-
----
-
-### 6. Financial Identifiers
-
-Financial identifier scalars represent standardized security and financial institution identifiers.
-
-#### **ISIN**
-
-- **GraphQL Type**: `ISIN`
-- **Format**: International Securities Identification Number (ISO 6166)
-- **Length**: Exactly 12 characters
-- **Structure**:
-  - Characters 1-2: ISO 3166-1 alpha-2 country code
-  - Characters 3-11: 9-character alphanumeric base number
-  - Character 12: Check digit (Luhn algorithm)
-- **Validation**: Luhn algorithm check digit verification
-- **Examples**:
-  - `US0378331005` (Apple Inc.)
-  - `GB0002374006` (BP p.l.c.)
-  - `US5949181045` (Microsoft Corporation)
-  - `IE00B4L5Y983` (iShares MSCI World UCITS ETF)
-- **Use Cases**:
-  - Equity identification
-  - Bond identification
-  - Fund identification
-  - International securities trading
-- **Notes**: Globally unique identifier for any security worldwide
-
-#### **CUSIP**
-
-- **GraphQL Type**: `CUSIP`
-- **Format**: Committee on Uniform Security Identification Procedures
-- **Length**: Exactly 9 characters
-- **Structure**:
-  - Characters 1-3: Issuer code (alphanumeric)
-  - Characters 4-8: Issue code (alphanumeric)
-  - Character 9: Check digit
-- **Coverage**: US and Canadian securities
-- **Validation**: Check digit verification
-- **Examples**:
-  - `037833100` (Apple Inc.)
-  - `594918104` (Microsoft Corporation)
-  - `000481022` (AT&T Inc.)
-- **Use Cases**:
-  - North American security identification
-  - Settlement processing
-  - Trading systems
-- **Notes**: CUSIP number is proprietary; ISIN is international equivalent
-
-#### **SEDOL**
-
-- **GraphQL Type**: `SEDOL`
-- **Format**: Stock Exchange Daily Official List (ISO 10149)
-- **Length**: Exactly 7 characters
-- **Structure**:
-  - Characters 1-6: Base code (alphanumeric, excluding A, E, I, O, U, I, O, Q)
-  - Character 7: Check digit
-- **Excluded Characters**: A, E, I, O, U, and letters I, O, Q
-- **Coverage**: UK securities
-- **Validation**: Check digit verification
-- **Examples**:
-  - `0263494` (BP p.l.c.)
-  - `0540528` (HSBC Holdings plc)
-  - `0540814` (Shell plc)
-- **Use Cases**:
-  - UK and European securities trading
-  - London Stock Exchange
-  - UK fund identification
-- **Notes**: Vowel restriction reduces confusion with numbers
-
-#### **LEI**
-
-- **GraphQL Type**: `LEI`
-- **Format**: Legal Entity Identifier (ISO 17442)
-- **Length**: Exactly 20 characters
-- **Structure**:
-  - Characters 1-4: Local Operating Unit (LOU) code
-  - Characters 5-18: Entity-specific code
-  - Characters 19-20: Check digits (mod-97 algorithm)
-- **Scope**: Globally unique legal entities
-- **Validation**: Check digit verification
-- **Examples**:
-  - `549300E9PC51EN656011` (Apple Inc.)
-  - `5493001KJTIIGC8K1162` (Microsoft Corporation)
-- **Use Cases**:
-  - Banking and finance regulations
-  - EMIR/Dodd-Frank compliance
-  - Counter-party identification
-  - Financial reporting
-- **Notes**: Required for large financial transactions in many jurisdictions
-
----
-
-### 7. Stock Market Scalars
-
-Stock market scalars represent ticker symbols, exchange codes, and market identifiers.
-
-#### **StockSymbol**
-
-- **GraphQL Type**: `StockSymbol`
-- **Format**: Stock ticker symbol
-- **Length**: 1-5 uppercase letters
-- **Class Suffix**: Optional (`.A`, `.B`, `.C` for multiple share classes)
-- **Case**: Normalized to uppercase
-- **Examples**:
-  - `AAPL` (Apple)
-  - `MSFT` (Microsoft)
-  - `BRK.A` (Berkshire Hathaway Class A)
-  - `BRK.B` (Berkshire Hathaway Class B)
-  - `GOOGL` (Alphabet/Google)
-  - `IBM` (IBM)
-- **Validation**: 1-5 alphanumeric, hyphen, or period
-- **Use Cases**:
-  - Stock identification
-  - Trading systems
-  - Market data feeds
-  - Financial analysis
-- **Notes**: Same symbol can exist on different exchanges
-
-#### **ExchangeCode**
-
-- **GraphQL Type**: `ExchangeCode`
-- **Format**: Market exchange identifier
-- **Length**: 2-6 uppercase letters
-- **Case**: Normalized to uppercase
-- **Common Examples**:
-  - `NYSE` (New York Stock Exchange)
-  - `NASDAQ` (NASDAQ)
-  - `LSE` (London Stock Exchange)
-  - `TSE` (Tokyo Stock Exchange)
-  - `HKE` (Hong Kong Exchanges)
-  - `SGX` (Singapore Exchange)
-- **Use Cases**:
-  - Market specification
-  - Trading venue identification
-  - Regional market routing
-  - Compliance reporting
-- **Notes**: Symbol+Exchange combo uniquely identifies a tradable security
-
-#### **MIC**
-
-- **GraphQL Type**: `MIC`
-- **Format**: Market Identifier Code (ISO 10383)
-- **Length**: Exactly 4 alphanumeric characters
-- **Standard**: ISO 10383
-- **Examples**:
-  - `XNYS` (NYSE - New York Stock Exchange)
-  - `XNAS` (NASDAQ)
-  - `XETRA` (Xetra - Deutsche Börse)
-  - `XLSE` (LSE - London Stock Exchange)
-  - `XTSE` (Toronto Stock Exchange)
-  - `XHKG` (Hong Kong Stock Exchange)
-- **Use Cases**:
-  - Standardized market identification
-  - ISO-compliant systems
-  - International trading systems
-  - Market data standards
-- **Notes**: Official ISO standard for market identification
-
----
-
-### 8. Banking & Payment Scalars
-
-Banking and payment scalars represent account numbers, phone numbers, and payment identifiers.
-
-#### **IBAN**
-
-- **GraphQL Type**: `IBAN`
-- **Format**: International Bank Account Number (ISO 13616)
-- **Structure**:
-  - Positions 1-2: Country code (ISO 3166-1 alpha-2)
-  - Positions 3-4: Check digits (mod-97)
-  - Positions 5+: Country-specific BBAN (Basic Bank Account Number)
-- **Length**: Varies by country (15-32 characters)
-- **Validation**:
-  - Check digit verification (mod-97)
-  - Country-specific format and length
-  - Valid country codes
-- **Case**: Normalized to uppercase
-- **Examples**:
-  - `GB82WEST12345698765432` (UK, Barclays)
-  - `DE89370400440532013000` (Germany)
-  - `FR1420041010050500013M02606` (France)
-  - `IT60X0542811101000000123456` (Italy)
-  - `ES9121000418450200051332` (Spain)
-  - `NL91ABNA0417164300` (Netherlands)
-- **Country-Specific Lengths**:
-  - UK: 22 characters
-  - Germany: 22 characters
-  - France: 27 characters
-  - Italy: 27 characters
-  - Spain: 24 characters
-  - Netherlands: 18 characters
-- **Use Cases**:
-  - International wire transfers
-  - Direct debit setup
-  - SEPA payments
-  - Bank account verification
-- **Notes**: More common in Europe; Asia uses SWIFT/BIC
-
-#### **PhoneNumber**
-
-- **GraphQL Type**: `PhoneNumber`
-- **Format**: E.164 international format
-- **Pattern**: `+[country code][number]`
-- **Country Code**: 1-3 digits
-- **Local Number**: 6-14 digits
-- **Total Length**: 7-15 digits (after + prefix)
-- **Examples**:
-  - `+14155552671` (San Francisco)
-  - `+447911123456` (UK mobile)
-  - `+33123456789` (France)
-  - `+81312345678` (Japan)
-  - `+886212345678` (Taiwan)
-- **Validation**:
-  - Valid country code
-  - Proper length for country
-  - Digits only
-- **Case**: No spaces or formatting
-- **Use Cases**:
-  - User contact information
-  - SMS notifications
-  - Two-factor authentication
-  - Contact verification
-- **Notes**: E.164 is international standard for phone numbers
-
----
-
-### 9. Identifier Scalars
-
-Identifier scalars represent unique identifiers and URL-friendly slugs.
-
-#### **Slug**
-
-- **GraphQL Type**: `Slug`
-- **Format**: URL-friendly identifier
-- **Valid Characters**: `a-z`, `0-9`, hyphen (`-`)
-- **Rules**:
-  - All lowercase
-  - No leading or trailing hyphens
-  - No consecutive hyphens
-  - Must be non-empty
-- **Examples**:
-  - `hello-world`
-  - `my-blog-post`
-  - `api-documentation`
-  - `feature-request-123`
-- **Use Cases**:
-  - URL paths
-  - Article titles
-  - Resource identifiers
-  - Human-readable URLs
-- **Notes**: Often generated from title or name fields
-
----
-
-### 10. Cryptographic & Security Scalars
-
-Cryptographic scalars represent hashes, keys, and security-related values.
-
-#### **HashSHA256**
-
-- **GraphQL Type**: `HashSHA256`
-- **Format**: SHA256 hexadecimal hash
-- **Length**: Exactly 64 hexadecimal characters
-- **Validation**:
-  - Exactly 64 hex digits (0-9, a-f, A-F)
-  - Valid hexadecimal
-- **Case**: Both lowercase and uppercase accepted
-- **Examples**:
-  - `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` (empty string hash)
-  - `2c26b46911185131006745196031e88e3e3ca8bfc5fbc36cb7c97b5d8b282d42` (first hash)
-- **Use Cases**:
-  - File integrity verification
-  - Password hashing (when salted)
-  - Document fingerprints
-  - Data deduplication
-- **Notes**: Always 256 bits = 64 hex characters
-
-#### **ApiKey**
-
-- **GraphQL Type**: `ApiKey`
-- **Format**: Access token or API key
-- **Length**: 16-128 characters
-- **Valid Characters**:
-  - Alphanumeric (`a-z`, `A-Z`, `0-9`)
-  - Hyphen (`-`)
-  - Underscore (`_`)
-- **Examples**:
-  - `test_key_4eC39HqLyjWDarjtT1zdp7dc`
-  - `sk_live_ABC123xyz-def456`
-  - `api_key_abcdef0123456789`
-- **Use Cases**:
-  - API authentication
-  - Service credentials
-  - OAuth tokens (simplified format)
-  - Third-party integrations
-- **Notes**: Should be treated as sensitive data (never log, use HTTPS)
-
----
-
-### 11. Vehicle & Transportation Scalars
-
-Vehicle and transportation scalars represent vehicle identifiers, license plates, and tracking numbers.
-
-#### **VIN**
-
-- **GraphQL Type**: `VIN`
-- **Format**: Vehicle Identification Number (ISO 3779/3780)
-- **Length**: Exactly 17 characters
-- **Valid Characters**: A-H, J-N, P, R-Z, 0-9 (no I, O, Q)
-- **Structure**:
-  - Positions 1-3: World Manufacturer Identifier (WMI)
-  - Positions 4-8: Vehicle Descriptor Section (VDS)
-  - Position 9: Check digit
-  - Positions 10-17: Vehicle Identifier Section (VIS)
-- **Validation**: Check digit at position 9
-- **Examples**:
-  - `1HGBH41JXMN109186` (Honda)
-  - `JH4KA8260MC000000` (Acura)
-  - `WBADT63492G942742` (BMW)
-  - `JTDKN3AU5E0022619` (Toyota)
-- **Use Cases**:
-  - Vehicle registration
-  - Insurance claims
-  - Recall identification
-  - Used car market
-- **Notes**: Unique for each vehicle, used globally
-
-#### **LicensePlate**
-
-- **GraphQL Type**: `LicensePlate`
-- **Format**: International vehicle license plate
-- **Length**: 2-12 characters
-- **Valid Characters**:
-  - Alphanumeric (`A-Z`, `0-9`)
-  - Space
-  - Hyphen (`-`)
-- **Examples**:
-  - `ABC123` (US standard)
-  - `NY 1234 AB` (US with state)
-  - `ABC-1234` (Hyphenated)
-  - `AB19 CDZ` (UK format)
-  - `75 ABC 123` (French format)
-- **Format Variation**: Highly country-specific
-- **Use Cases**:
-  - Vehicle identification
-  - Parking systems
-  - Traffic enforcement
-  - Vehicle tracking
-- **Notes**: Format varies significantly by country
-
-#### **AirportCode**
-
-- **GraphQL Type**: `AirportCode`
-- **Format**: IATA airport code
-- **Length**: Exactly 3 uppercase letters
-- **Standard**: IATA (International Air Transport Association)
-- **Case**: Normalized to uppercase
-- **Examples**:
-  - `LAX` (Los Angeles International)
-  - `JFK` (John F. Kennedy, New York)
-  - `LHR` (London Heathrow)
-  - `CDG` (Paris Charles de Gaulle)
-  - `NRT` (Narita, Tokyo)
-  - `SYD` (Sydney)
-- **Use Cases**:
-  - Flight bookings
-  - Travel information
-  - Routing
-  - Airline systems
-- **Notes**: Different from ICAO codes (4 letters)
-
-#### **TrackingNumber**
-
-- **GraphQL Type**: `TrackingNumber`
-- **Format**: Shipping tracking number
-- **Length**: 8-30 characters
-- **Valid Characters**: Alphanumeric (`A-Z`, `0-9`)
-- **Examples**:
-  - `1Z999AA10123456784` (UPS format)
-  - `123456789012` (FedEx format)
-  - `9400111899223456789012345678` (USPS format)
-  - `DHL tracking example`
-- **Use Cases**:
-  - Shipment tracking
-  - Logistics
-  - Package delivery
-  - Return management
-- **Notes**: Format varies by carrier
-
----
-
-### 12. Localization Scalars
-
-Localization scalars represent language and locale information.
-
-#### **LanguageCode**
-
-- **GraphQL Type**: `LanguageCode`
-- **Format**: ISO 639-1 two-letter language code
-- **Standard**: ISO 639-1
-- **Length**: Exactly 2 letters
-- **Case**: Normalized to lowercase
-- **Examples**:
-  - `en` (English)
-  - `fr` (French)
-  - `de` (German)
-  - `es` (Spanish)
-  - `ja` (Japanese)
-  - `zh` (Chinese)
-  - `ru` (Russian)
-  - `pt` (Portuguese)
-  - `ar` (Arabic)
-  - `hi` (Hindi)
-- **Use Cases**:
-  - UI language selection
-  - Content localization
-  - Multi-language support
-  - User preferences
-- **Notes**: 2-letter codes; 3-letter codes (ISO 639-2/3) also exist
-
-#### **LocaleCode**
-
-- **GraphQL Type**: `LocaleCode`
-- **Format**: BCP 47 locale identifier
-- **Structure**: `language[-script][-region][-variant]`
-- **Components**:
-  - `language`: ISO 639-1 code (required, 2 letters)
-  - `script`: ISO 15924 code (optional, 4 letters)
-  - `region`: ISO 3166-1 alpha-2 code (optional, 2 letters)
-  - `variant`: Custom variant (optional)
-- **Simple Examples**: `en-US`, `fr-FR`, `de-DE`, `ja-JP`, `zh-CN`
-- **Complex Examples**:
-  - `zh-Hans-CN` (Simplified Chinese, China)
-  - `zh-Hant-TW` (Traditional Chinese, Taiwan)
-  - `sr-Cyrl-RS` (Serbian in Cyrillic, Serbia)
-  - `pt-BR` (Portuguese, Brazil)
-- **Use Cases**:
-  - Full localization (language + region)
-  - Currency/date/time formatting
-  - Regional variants
-  - Content targeting
-- **Notes**: More specific than LanguageCode, includes region
-
----
-
-### 13. Versioning Scalar
-
-#### **SemanticVersion**
-
-- **GraphQL Type**: `SemanticVersion`
-- **Format**: Semantic Versioning (semver) specification
-- **Pattern**: `MAJOR.MINOR.PATCH[-prerelease][+build]`
-- **Components**:
-  - `MAJOR`: Major version (breaking changes)
-  - `MINOR`: Minor version (backwards-compatible features)
-  - `PATCH`: Patch version (bug fixes)
-  - `prerelease` (optional): Pre-release identifier (alpha, beta, rc)
-  - `build` (optional): Build metadata
-- **Examples**:
-  - `1.0.0` (Production release)
-  - `2.3.4` (Standard semver)
-  - `1.0.0-alpha` (Alpha pre-release)
-  - `2.0.0-beta.1` (Beta pre-release)
-  - `3.0.0-rc.1` (Release candidate)
-  - `1.0.0+20130313144700` (Build metadata)
-  - `2.1.3-beta+build.123` (Combined)
-- **Validation**:
-  - Numeric MAJOR.MINOR.PATCH
-  - Valid pre-release format
-  - Valid build metadata format
-- **Use Cases**:
-  - Version tracking
-  - Dependency management
-  - API versioning
-  - Software releases
-- **Notes**: Industry standard for versioning
-
----
-
-### 14. Content & Format Scalars
-
-Content scalars represent rich content and file formats.
-
-#### **Color**
-
-- **GraphQL Type**: `Color`
-- **Format**: Hexadecimal color code
-- **Formats**:
-  - Short: `#RGB` (3 hex digits)
-  - Long: `#RRGGBB` (6 hex digits)
-- **Validation**: Valid hexadecimal digits
-- **Case**: Normalized to lowercase
-- **Examples**:
-  - `#ff0000` (Red)
-  - `#00ff00` (Green)
-  - `#0000ff` (Blue)
-  - `#f00` (Red, short form)
-  - `#3366cc` (Blue)
-  - `#ffffff` (White)
-  - `#000000` (Black)
-- **Use Cases**:
-  - Brand colors
-  - UI customization
-  - Theme configuration
-  - Design systems
-- **Notes**: RGB color space (not CMYK or HSL)
-
-#### **HTMLScalar**
-
-- **GraphQL Type**: `HTML`
-- **Format**: HTML content (any valid HTML)
-- **Database Type**: `text`
-- **Validation**: Minimal (raw HTML allowed)
-- **Use Cases**:
-  - Rich text content
-  - Page templates
-  - Email templates
-  - Blog content with formatting
-- **Security Notes**: Use with Content Security Policy (CSP)
-- **Notes**: No validation; sanitization recommended on display
-
-#### **MarkdownScalar**
-
-- **GraphQL Type**: `Markdown`
-- **Format**: Markdown content (GitHub Flavored Markdown compatible)
-- **Database Type**: `text`
-- **Validation**: Minimal (raw markdown allowed)
-- **Use Cases**:
-  - Documentation
-  - Blog posts
-  - User-generated content
-  - Comments with formatting
-- **Notes**: No validation; render to HTML on display
-
-#### **MimeType**
-
-- **GraphQL Type**: `MimeType`
-- **Format**: MIME media type (RFC 6838)
-- **Pattern**: `type/subtype[+suffix]`
-- **Examples**:
-  - `text/plain`
-  - `text/html`
-  - `application/json`
-  - `application/xml`
-  - `image/png`
-  - `image/jpeg`
-  - `audio/mpeg`
-  - `video/mp4`
-  - `application/pdf`
-  - `text/csv`
-- **Type Categories**:
-  - `text/*`: Text-based (plain, html, css)
-  - `image/*`: Images (png, jpeg, gif, webp, svg)
-  - `audio/*`: Audio (mpeg, wav, ogg)
-  - `video/*`: Video (mp4, webm, avi)
-  - `application/*`: Applications (json, pdf, xml, octet-stream)
-- **Use Cases**:
-  - File upload validation
-  - Content-Type headers
-  - API request/response types
-  - File type detection
-- **Notes**: Case-insensitive (normalized to lowercase)
-
-#### **Image**
-
-- **GraphQL Type**: `Image`
-- **Format**: Image file URL or path
-- **Supported Formats**:
-  - Extensions: `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.svg`, `.bmp`, `.tiff`, `.tif`
-  - Case-insensitive matching
-- **Examples**:
-  - `https://example.com/image.jpg`
-  - `/uploads/avatar.png`
-  - `s3://bucket/images/photo.webp`
-- **Validation**: Valid image file extension
-- **Use Cases**:
-  - User avatars
-  - Product images
-  - Gallery images
-  - Thumbnails
-- **Notes**: Validation is extension-based; actual image validation recommended
-
-#### **FileScalar**
-
-- **GraphQL Type**: `File`
-- **Format**: File reference (URL or file path)
-- **Can Represent**:
-  - HTTP URLs
-  - File system paths
-  - Cloud storage URLs (S3, GCS, Azure)
-- **Use Cases**:
-  - File downloads
-  - Document references
-  - Attachment storage
-  - File links
-- **Notes**: Generic file type; specific formats use specialized scalars
-
----
-
-### 15. Postal & Address Scalars
-
-Postal scalars represent address-related information.
-
-#### **PostalCode**
-
-- **GraphQL Type**: `PostalCode`
-- **Format**: International postal code
-- **Validation**: Flexible format (no strict validation)
-- **Examples**:
-  - `90210` (US ZIP code)
-  - `75001` (French postal code)
-  - `SW1A 1AA` (UK postcode)
-  - `M5V 3A8` (Canadian postal code)
-  - `1000` (Austrian postal code)
-- **Use Cases**:
-  - Shipping addresses
-  - Billing addresses
-  - Location identification
-  - Delivery routing
-- **Notes**: Highly country-specific formats
-
-#### **PortCode**
-
-- **GraphQL Type**: `PortCode`
-- **Format**: Shipping port identifier
-- **Length**: Typically 3-5 characters
-- **Standard**: UN/LOCODE (sometimes)
-- **Examples**:
-  - `USLA` (Port of Los Angeles)
-  - `USNY` (Port of New York)
-  - `GBFXT` (Southampton)
-  - `JPTYO` (Tokyo)
-- **Use Cases**:
-  - Shipping routes
-  - Port operations
-  - Logistics planning
-  - International trade
-- **Notes**: Various coding standards exist (UN/LOCODE, IATA)
-
----
-
-### 16. Networking Port
-
-#### **Port**
-
-- **GraphQL Type**: `Port`
-- **Format**: Network port number
-- **Type**: Integer
-- **Range**: 1-65535
-  - Reserved: 0 (not allowed)
-  - Well-known: 1-1023
-  - Registered: 1024-49151
-  - Dynamic: 49152-65535
-- **Examples**:
-  - `80` (HTTP)
-  - `443` (HTTPS/SSL)
-  - `22` (SSH)
-  - `3306` (MySQL)
-  - `5432` (PostgreSQL)
-  - `8080` (Alternative HTTP)
-  - `6379` (Redis)
-  - `27017` (MongoDB)
-  - `3000` (Node.js default)
-- **Validation**: Integer 1-65535
-- **Use Cases**:
-  - Network configuration
-  - Service endpoints
-  - Docker port mapping
-  - Database connections
-- **Notes**: Port 0 reserved; beyond 65535 invalid
-
----
-
-### 17. Hierarchical Scalar
-
-#### **LTreePath**
-
-- **GraphQL Type**: `LTreePath`
-- **Format**: PostgreSQL `ltree` hierarchical path
-- **Structure**: Dot-separated labels
-- **Pattern**: `label.sublabel.subsubLabel`
-- **Validation**:
-  - Labels 1-255 characters
-  - Valid characters: `a-z`, `A-Z`, `0-9`, `_`
-  - Dots separate labels
-- **Database Type**: `ltree` (PostgreSQL extension)
-- **Examples**:
-  - `top` (root)
-  - `top.science` (category)
-  - `top.science.physics` (subcategory)
-  - `top.science.physics.quantum` (sub-subcategory)
-  - `org.company.department.team`
-  - `products.electronics.computers.laptops`
-- **Database Operators**:
-  - `@>` (contains)
-  - `<@` (is contained by)
-  - `~` (matches pattern)
-  - `?` (matches pattern)
-- **Use Cases**:
-  - Category hierarchies
-  - Organizational structures
-  - File system-like data
-  - Taxonomy navigation
-  - Menu structures
-- **Notes**: PostgreSQL `ltree` extension must be installed
-
----
-
-### 18. Vector Scalars (pgvector)
-
-Vector scalars represent embeddings and vector data for semantic search and RAG (Retrieval-Augmented Generation).
-
-#### **Vector**
-
-- **GraphQL Type**: `Vector`
-- **Format**: List of floating-point numbers
-- **Precision**: 32-bit floats (IEEE 754)
-- **Database Type**: PostgreSQL `vector` (pgvector extension)
-- **Dimension**: Variable (specified at column creation)
-- **Examples**:
-  - `[0.1, 0.2, 0.3]` (3-dimensional)
-  - `[0.5, -0.3, 0.1, 0.2, -0.1]` (5-dimensional)
-  - Typical use: 384-1536 dimensions for embeddings
-- **Validation**: Array of floats
-- **Distance Operators** (pgvector):
-  - `<->` (L2/Euclidean distance)
-  - `<#>` (Inner product)
-  - `<=>` (Cosine similarity)
-- **Use Cases**:
-  - Semantic search
-  - Recommendation engines
-  - Similarity matching
-  - Vector embeddings (OpenAI, Cohere, etc.)
-  - RAG (Retrieval-Augmented Generation)
-- **Notes**:
-  - pgvector extension required
-  - Common sizes: 384 (small), 768 (medium), 1536 (GPT-3)
-  - Memory: ~4 bytes per dimension
-
-#### **HalfVector**
-
-- **GraphQL Type**: `HalfVector`
-- **Format**: List of floating-point numbers (16-bit precision)
-- **Precision**: 16-bit floats (half precision, bfloat16)
-- **Database Type**: PostgreSQL `halfvec` (pgvector extension)
-- **Dimension**: Variable
-- **Memory Advantage**: 50% memory savings vs Vector (2 bytes per dimension)
-- **Examples**:
-  - `[0.1, 0.2, 0.3]` (3-dimensional, stored as half precision)
-- **Precision Trade-off**:
-  - Full precision: 32-bit (±3.4e±38)
-  - Half precision: 16-bit (±6.5e±4)
-  - Suitable for: Large-scale similarity search where slight precision loss is acceptable
-- **Distance Operators**: Same as Vector
-- **Use Cases**:
-  - Large-scale embeddings (millions of vectors)
-  - Cost-optimized similarity search
-  - Memory-constrained systems
-  - Batch similarity scoring
-- **Notes**:
-  - pgvector extension required
-  - Requires PostgreSQL 11+
-  - Recommended: 384-1536 dimensions
-
-#### **SparseVector**
-
-- **GraphQL Type**: `SparseVector`
-- **Format**: Dictionary with indices and values
-- **Structure**: `{indices: [int], values: [float]}`
-- **Database Type**: PostgreSQL `sparsevec` (pgvector extension)
-- **Dimension**: Implicit from max index
-- **Example**:
-
-  ```json
-<!-- Code example in JSON -->
-  {
-    "indices": [0, 2, 5],
-    "values": [0.1, 0.3, 0.2]
-  }
-  ```text
-<!-- Code example in TEXT -->
-
-- **Memory Advantage**: Extremely efficient for high-dimensional, sparse data
-- **Use Cases**:
-  - Text BOW (Bag of Words) embeddings
-  - High-dimensional sparse data
-  - TF-IDF vectors
-  - Categorical embeddings
-  - Term frequency vectors
-- **Notes**:
-  - pgvector extension required
-  - Ideal for 10,000+ dimension vectors
-  - Only stores non-zero values
-
-#### **QuantizedVector**
-
-- **GraphQL Type**: `QuantizedVector`
-- **Format**: Dictionary with quantization metadata
-- **Structure**: `{codebook_id: int, code: int, scale: float, offset: [float]}`
-- **Database Type**: PostgreSQL `sparsevec` with metadata
-- **Compression**: Product quantization (PQ) for extreme compression
-- **Memory**: Dramatically reduced vs Vector or HalfVector
-- **Example**:
-
-  ```json
-<!-- Code example in JSON -->
-  {
-    "codebook_id": 1,
-    "code": 42,
-    "scale": 0.5,
-    "offset": [0.1, 0.2, 0.3]
-  }
-  ```text
-<!-- Code example in TEXT -->
-
-- **Use Cases**:
-  - Extremely large-scale embeddings (billions of vectors)
-  - Mobile/edge deployment
-  - Real-time similarity search at massive scale
-  - Memory-critical environments
-- **Trade-offs**:
-  - Highest compression
-  - Reduced precision (still high for similarity)
-  - Suitable for retrieval (not fine-grained comparison)
-- **Notes**:
-  - Most aggressive compression
-  - Requires pgvector extension
-  - Recommended for production at scale
-
----
-
-## Database Mappings
-
-| Scalar | PostgreSQL Type | Notes |
-|--------|-----------------|-------|
-| **Temporal** | | |
-| Date | `date` | ISO 8601 date |
-| DateTime | `timestamp with time zone` | Always UTC |
-| Time | `time` | Wall clock time |
-| Duration | Internal | ISO 8601 duration |
-| DateRange | `daterange` | Range with operators |
-| Timezone | `text` | IANA timezone |
-| **Geographic** | | |
-| Coordinate | `point` | (lat, lng) |
-| Latitude | `numeric` | -90 to +90 |
-| Longitude | `numeric` | -180 to +180 |
-| **Network** | | |
-| IpAddressString | `inet` | IPv4 or IPv6 |
-| SubnetMaskString | `inet` | Subnet notation |
-| CIDR | `cidr` | Network range |
-| MacAddress | `macaddr` | Hardware address |
-| Hostname | `text` | RFC 1123 |
-| DomainName | `text` | RFC with TLD |
-| URL | `text` | RFC 3986 |
-| **Financial** | | |
-| Money | `NUMERIC(19,4)` | 4 decimals |
-| CurrencyCode | `text` | ISO 4217 |
-| Percentage | `NUMERIC(5,2)` | 0.00-100.00 |
-| ExchangeRate | `NUMERIC(20,8)` | High precision |
-| **Financial IDs** | | |
-| ISIN | `text` | 12 chars + check |
-| CUSIP | `text` | 9 chars + check |
-| SEDOL | `text` | 7 chars + check |
-| LEI | `text` | 20 chars + check |
-| **Stock Market** | | |
-| StockSymbol | `text` | 1-5 chars |
-| ExchangeCode | `text` | 2-6 chars |
-| MIC | `text` | 4 chars (ISO) |
-| **Banking** | | |
-| IBAN | `text` | 15-32 chars |
-| PhoneNumber | `text` | E.164 format |
-| **Identifiers** | | |
-| UUID | `uuid` | RFC 4122 |
-| ID | `text` or `bigint` | Generic |
-| Slug | `text` | URL-friendly |
-| **Cryptographic** | | |
-| HashSHA256 | `text` | 64 hex chars |
-| ApiKey | `text` | 16-128 chars |
-| **Vehicle** | | |
-| VIN | `text` | 17 chars |
-| LicensePlate | `text` | 2-12 chars |
-| AirportCode | `text` | 3 chars |
-| TrackingNumber | `text` | 8-30 chars |
-| **Localization** | | |
-| LanguageCode | `text` | ISO 639-1 |
-| LocaleCode | `text` | BCP 47 |
-| **Versioning** | | |
-| SemanticVersion | `text` | MAJOR.MINOR.PATCH |
-| **Content** | | |
-| Color | `text` | #RRGGBB |
-| HTMLScalar | `text` | Raw HTML |
-| MarkdownScalar | `text` | Raw Markdown |
-| MimeType | `text` | RFC 6838 |
-| Image | `text` | URL or path |
-| FileScalar | `text` | URL or path |
-| **Postal** | | |
-| PostalCode | `text` | Variable format |
-| PortCode | `text` | 3-5 chars |
-| **Port** | | |
-| Port | `integer` | 1-65535 |
-| **Hierarchical** | | |
-| LTreePath | `ltree` | Dot-separated |
-| **Vector** | | |
-| Vector | `vector` | 32-bit floats |
-| HalfVector | `halfvec` | 16-bit floats |
-| SparseVector | `sparsevec` | Sparse values |
-| QuantizedVector | `sparsevec` | Quantized with metadata |
-
----
-
-## Using Scalars in Type Definitions
-
-Scalars are used in `@FraiseQL.type` decorators:
+## Using scalars in type definitions
+
+Annotate fields on a `@fraiseql.type` with these scalars. The `sql_source` names the
+read view; `jsonb_column` names the JSONB column that holds the row's data (defaults to
+`"data"`).
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL import type, field
-from FraiseQL.types import (
-    Date, DateTime, UUID, Money, CurrencyCode,
-    EmailAddress, PhoneNumber, Vector, LTreePath
+import fraiseql
+from fraiseql.types import (
+    UUID,
+    DateTime,
+    Date,
+    EmailAddress,
+    PhoneNumber,
+    Money,
+    CurrencyCode,
+    Slug,
+    Markdown,
+    Coordinate,
+    LTree,
 )
 
-@type
+
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
     """A user in the system."""
+
     id: UUID
     email: EmailAddress
     phone: PhoneNumber | None = None
     created_at: DateTime
-    born_date: Date
-    last_login: DateTime | None = None
-    timezone: Timezone = "UTC"
+    born_date: Date | None = None
 
-@type
+
+@fraiseql.type(sql_source="v_product", jsonb_column="data")
 class Product:
     """A product with pricing and location."""
+
     id: UUID
     name: str
+    slug: Slug
     price: Money
     currency: CurrencyCode = "USD"
-    category_path: LTreePath
-    location: Coordinate
-    vector_embedding: Vector
+    category_path: LTree
+    location: Coordinate | None = None
 
-@type
+
+@fraiseql.type(sql_source="v_blog_post", jsonb_column="data")
 class BlogPost:
-    """A blog post with content and metadata."""
+    """A blog post with rich content."""
+
     id: UUID
     title: str
     slug: Slug
     content: Markdown
     created_at: DateTime
     tags: list[str]
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
-## Performance Considerations
+## Core scalars
 
-### Validation Overhead
+The everyday identifiers, temporal, and structured-data types.
 
-- **Minimal**: Most scalars use simple pattern matching
-- **Moderate**: Luhn algorithm (ISIN, CUSIP, LEI, IBAN)
-- **Database**: Geographic, network operations via PostgreSQL
+| Scalar | Python import | GraphQL type | Description / validation | Example |
+|--------|---------------|--------------|--------------------------|---------|
+| `ID` | `from fraiseql.types import ID` | `ID` | GraphQL built-in identifier; any serializable string-like value. | `"42"`, `"550e8400-..."` |
+| `UUID` | `from fraiseql.types import UUID` | `UUID` | RFC 4122 UUID, hyphenated. | `550e8400-e29b-41d4-a716-446655440000` |
+| `Date` | `from fraiseql.types import Date` | `Date` | ISO 8601 calendar date `YYYY-MM-DD`. | `2026-01-11` |
+| `DateTime` | `from fraiseql.types import DateTime` | `DateTime` | ISO 8601 timestamp; output in UTC with `Z`. | `2026-01-11T15:30:00Z` |
+| `Time` | `from fraiseql.types import Time` | `Time` | 24-hour wall-clock time `HH:MM[:SS]`. | `14:30`, `09:15:30` |
+| `JSON` | `from fraiseql.types import JSON` | `JSON` | Arbitrary JSON-serializable value (object, array, scalar, null). | `{"key": "value"}` |
+| `EmailAddress` | `from fraiseql.types import EmailAddress` | `EmailAddress` | RFC 5322 email address. | `user@example.com` |
+| `URL` | `from fraiseql.types import URL` | `URL` | RFC 3986 URL; scheme + host required. | `https://api.example.com/v1` |
+| `LTree` | `from fraiseql.types import LTree` | `LTree` | PostgreSQL `ltree` dot-separated label path (requires the `ltree` extension). | `top.science.physics` |
 
-### Storage Efficiency
-
-| Type | Bytes | Notes |
-|------|-------|-------|
-| UUID | 16 | Binary storage in DB |
-| DateTime | 8 | UTC timestamp |
-| Money (NUMERIC) | Variable | Precision-dependent |
-| Vector (1536-dim) | ~6KB | 32-bit floats |
-| HalfVector (1536-dim) | ~3KB | 16-bit floats (50% savings) |
-| SparseVector | Variable | Only non-zero values |
-| QuantizedVector | Minimal | Extreme compression |
-
----
-
-## Best Practices
-
-### Scalar Selection
-
-1. **Always use specific scalars** instead of generic string:
-   - ✅ `email: EmailAddress`
-   - ❌ `email: str`
-
-2. **Type-safe identifiers**:
-   - ✅ `id: UUID` or `id: Slug`
-   - ❌ `id: str`
-
-3. **Precision for financial data**:
-   - ✅ `price: Money` (NUMERIC with 4 decimals)
-   - ❌ `price: float` (precision loss)
-
-4. **Temporal data**:
-   - ✅ `created_at: DateTime`, `birth_date: Date`
-   - ❌ `created_at: str`, `birth_date: str`
-
-5. **Geographic data**:
-   - ✅ `location: Coordinate`, `latitude: Latitude`
-   - ❌ `location: str`, `latitude: float`
-
-### Validation
-
-- Scalars validate input at GraphQL execution time
-- Errors are returned as GraphQL errors (not exceptions)
-- Invalid values are rejected before reaching database
-
-### Database Operations
-
-- Use PostgreSQL native types for indexing
-- Take advantage of type-specific operators (ltree, inet, vector)
-- Query optimization: index commonly filtered fields
-
-### Security
-
-- **Sensitive data**: Use dedicated scalar types (ApiKey, HashSHA256)
-- **Email/Phone**: Validate format and consider additional verification
-- **Cryptographic**: Store hashes securely, never store plaintext equivalents
-- **Vector data**: Consider privacy implications for embeddings
+See [`../foundation/09-type-system.md`](../foundation/09-type-system.md) for how Python type
+hints map onto GraphQL types.
 
 ---
 
-## Scalar Import Locations
+## Network scalars
 
-All scalars are available from:
+IP addresses, hosts, domains, and ports.
 
-```python
-<!-- Code example in Python -->
-from FraiseQL.types import (
-    # Temporal
-    Date, DateTime, Time, Duration, DateRange, Timezone,
-
-    # Geographic
-    Coordinate, Latitude, Longitude,
-
-    # Network
-    IpAddressString, SubnetMaskString, CIDR, MacAddress,
-    Hostname, DomainName, URL,
-
-    # Financial
-    Money, CurrencyCode, Percentage, ExchangeRate,
-
-    # Financial IDs
-    ISIN, CUSIP, SEDOL, LEI,
-
-    # Stock Market
-    StockSymbol, ExchangeCode, MIC,
-
-    # Banking
-    IBAN, PhoneNumber,
-
-    # Identifiers
-    UUID, Slug,
-
-    # Cryptographic
-    HashSHA256, ApiKey,
-
-    # Vehicle
-    VIN, LicensePlate, AirportCode, TrackingNumber,
-
-    # Localization
-    LanguageCode, LocaleCode,
-
-    # Versioning
-    SemanticVersion,
-
-    # Content
-    Color, HTMLScalar, MarkdownScalar, MimeType, Image, FileScalar,
-
-    # Postal
-    PostalCode, PortCode,
-
-    # Port
-    Port,
-
-    # Hierarchical
-    LTreePath,
-
-    # Vector
-    Vector, HalfVector, SparseVector, QuantizedVector,
-)
-```text
-<!-- Code example in TEXT -->
+| Scalar | Python import | GraphQL type | Description / validation | Example |
+|--------|---------------|--------------|--------------------------|---------|
+| `IpAddress` | `from fraiseql.types import IpAddress` | `IpAddress` | IPv4 or IPv6 address (CIDR suffix accepted). | `192.168.1.1`, `2001:db8::1` |
+| `CIDR` | `from fraiseql.types import CIDR` | `CIDR` | CIDR network range `address/prefix`. | `192.168.1.0/24`, `2001:db8::/32` |
+| `MacAddress` | `from fraiseql.types import MacAddress` | `MacAddress` | 48-bit MAC address; normalized to colon form. | `00:11:22:33:44:55` |
+| `Hostname` | `from fraiseql.types import Hostname` | `Hostname` | RFC 1123 hostname; TLD not required. | `api-server`, `db.internal` |
+| `DomainName` | `from fraiseql.types import DomainName` | `DomainName` | RFC-compliant FQDN; TLD required. | `api.example.com` |
+| `Port` | `from fraiseql.types import Port` | `Port` | Network port integer, 1–65535. | `443`, `5432` |
 
 ---
 
-## Summary
+## Geographic scalars
 
-FraiseQL's 56 custom scalar types provide:
+Coordinates and individual latitude/longitude components.
 
-✅ **Type Safety**: Compile-time and runtime validation
-✅ **Database Integration**: Native PostgreSQL column types
-✅ **Format Standards**: ISO, RFC, and domain-specific compliance
-✅ **Developer Experience**: Clear error messages, intuitive validation
-✅ **Performance**: Optimized serialization and database operations
-✅ **Enterprise Features**: Security (crypto), localization, vector search
+| Scalar | Python import | GraphQL type | Description / validation | Example |
+|--------|---------------|--------------|--------------------------|---------|
+| `Coordinate` | `from fraiseql.types import Coordinate` | `Coordinate` | Lat/lng pair; serialized as `{lat, lng}`. | `37.7749,-122.4194` |
+| `Latitude` | `from fraiseql.types import Latitude` | `Latitude` | Decimal degrees, -90.0 to +90.0. | `40.7128` |
+| `Longitude` | `from fraiseql.types import Longitude` | `Longitude` | Decimal degrees, -180.0 to +180.0. | `-74.0060` |
 
-Whether you're building financial systems, geospatial applications, or AI-powered semantic search, FraiseQL's scalar library provides domain-specific validation and database integration.
+---
+
+## Money and number scalars
+
+Monetary values, currencies, percentages, and exchange rates.
+
+| Scalar | Python import | GraphQL type | Description / validation | Example |
+|--------|---------------|--------------|--------------------------|---------|
+| `Money` | `from fraiseql.types import Money` | `Money` | Fixed-precision decimal amount (4 fractional digits). | `123.45` → `123.4500` |
+| `CurrencyCode` | `from fraiseql.types import CurrencyCode` | `CurrencyCode` | ISO 4217 three-letter code; uppercased. | `USD`, `EUR` |
+| `Percentage` | `from fraiseql.types import Percentage` | `Percentage` | Decimal 0.00–100.00 (direct percentage). | `25.5` |
+| `ExchangeRate` | `from fraiseql.types import ExchangeRate` | `ExchangeRate` | High-precision conversion rate. | `1.23456789` |
+
+---
+
+## Web and text scalars
+
+URLs, slugs, colors, markup, and version strings.
+
+| Scalar | Python import | GraphQL type | Description / validation | Example |
+|--------|---------------|--------------|--------------------------|---------|
+| `URL` | `from fraiseql.types import URL` | `URL` | RFC 3986 URL (also listed under core). | `https://example.com/path` |
+| `Slug` | `from fraiseql.types import Slug` | `Slug` | Lowercase URL-friendly identifier; no leading/trailing or repeated hyphens. | `my-blog-post` |
+| `Color` | `from fraiseql.types import Color` | `Color` | Hex color `#RGB` or `#RRGGBB`; lowercased. | `#3366cc` |
+| `Markdown` | `from fraiseql.types import Markdown` | `Markdown` | Markdown text (GitHub-flavored). | `# Title\n\nBody` |
+| `HTML` | `from fraiseql.types import HTML` | `HTML` | Raw HTML content; sanitize on display. | `<p>Hello</p>` |
+| `MimeType` | `from fraiseql.types import MimeType` | `MimeType` | RFC 6838 media type `type/subtype`. | `application/json` |
+| `SemanticVersion` | `from fraiseql.types import SemanticVersion` | `SemanticVersion` | Semver `MAJOR.MINOR.PATCH[-pre][+build]`. | `2.0.0-beta.1` |
+
+---
+
+## Finance and securities scalars
+
+Standardized financial-institution and security identifiers.
+
+| Scalar | Python import | GraphQL type | Description / validation | Example |
+|--------|---------------|--------------|--------------------------|---------|
+| `IBAN` | `from fraiseql.types import IBAN` | `IBAN` | ISO 13616 account number; mod-97 check; uppercased. | `DE89370400440532013000` |
+| `ISIN` | `from fraiseql.types import ISIN` | `ISIN` | ISO 6166 security ID, 12 chars; Luhn check. | `US0378331005` |
+| `CUSIP` | `from fraiseql.types import CUSIP` | `CUSIP` | 9-char North American security ID; check digit. | `037833100` |
+| `SEDOL` | `from fraiseql.types import SEDOL` | `SEDOL` | 7-char UK security ID; check digit. | `0263494` |
+| `LEI` | `from fraiseql.types import LEI` | `LEI` | ISO 17442 legal entity ID, 20 chars. | `549300E9PC51EN656011` |
+| `MIC` | `from fraiseql.types import MIC` | `MIC` | ISO 10383 market identifier code, 4 chars. | `XNYS`, `XNAS` |
+| `StockSymbol` | `from fraiseql.types import StockSymbol` | `StockSymbol` | Ticker symbol; optional class suffix; uppercased. | `AAPL`, `BRK.A` |
+| `ExchangeCode` | `from fraiseql.types import ExchangeCode` | `ExchangeCode` | Market exchange identifier; uppercased. | `NYSE`, `NASDAQ` |
+
+---
+
+## Logistics and transport scalars
+
+Codes for travel, shipping, and vehicles.
+
+| Scalar | Python import | GraphQL type | Description / validation | Example |
+|--------|---------------|--------------|--------------------------|---------|
+| `AirportCode` | `from fraiseql.types import AirportCode` | `AirportCode` | IATA 3-letter airport code; uppercased. | `LAX`, `LHR` |
+| `PortCode` | `from fraiseql.types import PortCode` | `PortCode` | Shipping port identifier (e.g. UN/LOCODE). | `USLA`, `JPTYO` |
+| `FlightNumber` | `from fraiseql.types import FlightNumber` | `FlightNumber` | Airline + numeric flight designator. | `BA117`, `AF1680` |
+| `ContainerNumber` | `from fraiseql.types import ContainerNumber` | `ContainerNumber` | ISO 6346 shipping-container number. | `MSCU1234565` |
+| `TrackingNumber` | `from fraiseql.types import TrackingNumber` | `TrackingNumber` | Carrier shipment tracking number. | `1Z999AA10123456784` |
+| `LicensePlate` | `from fraiseql.types import LicensePlate` | `LicensePlate` | Vehicle registration plate (format varies by country). | `AB19 CDZ` |
+| `VIN` | `from fraiseql.types import VIN` | `VIN` | ISO 3779/3780 vehicle ID, 17 chars; check digit. | `1HGBH41JXMN109186` |
+
+---
+
+## Miscellaneous scalars
+
+Durations, ranges, contact details, localization, files, and security values.
+
+| Scalar | Python import | GraphQL type | Description / validation | Example |
+|--------|---------------|--------------|--------------------------|---------|
+| `Duration` | `from fraiseql.types import Duration` | `Duration` | ISO 8601 duration `P…T…`. | `P1Y2M3DT4H5M6S` |
+| `DateRange` | `from fraiseql.types import DateRange` | `DateRange` | Date range with inclusive/exclusive bounds. | `[2026-01-01, 2026-12-31]` |
+| `PhoneNumber` | `from fraiseql.types import PhoneNumber` | `PhoneNumber` | E.164 international phone number. | `+14155552671` |
+| `PostalCode` | `from fraiseql.types import PostalCode` | `PostalCode` | International postal code (flexible format). | `90210`, `SW1A 1AA` |
+| `LanguageCode` | `from fraiseql.types import LanguageCode` | `LanguageCode` | ISO 639-1 two-letter language code; lowercased. | `en`, `fr` |
+| `LocaleCode` | `from fraiseql.types import LocaleCode` | `LocaleCode` | BCP 47 locale identifier. | `en-US`, `zh-Hant-TW` |
+| `Timezone` | `from fraiseql.types import Timezone` | `Timezone` | IANA timezone identifier (case-sensitive). | `Europe/Paris`, `UTC` |
+| `File` | `from fraiseql.types import File` | `File` | File reference (URL or path). | `s3://bucket/doc.pdf` |
+| `Image` | `from fraiseql.types import Image` | `Image` | Image URL or path; extension-validated. | `/uploads/avatar.png` |
+| `HashSHA256` | `from fraiseql.types import HashSHA256` | `HashSHA256` | 64-character SHA-256 hex digest. | `e3b0c442...b7852b855` |
+| `ApiKey` | `from fraiseql.types import ApiKey` | `ApiKey` | API key / access token, 16–128 chars. Treat as sensitive. | `sk_live_ABC123xyz-def456` |
+
+---
+
+## Validation and serialization
+
+- Scalars validate input at GraphQL execution time. Invalid values are rejected and
+  returned as GraphQL errors before any database access.
+- Output values are serialized to their canonical string/JSON form (for example, MAC
+  addresses normalize to colon form and currency codes to uppercase).
+- Because read data lives in a JSONB `data` column, scalar values round-trip as JSON; use
+  the corresponding PostgreSQL operators (for example `ltree`, `inet`, range operators)
+  inside your `v_`/`tv_` view SQL when you need server-side filtering.
+
+## Best practices
+
+1. Prefer a specific scalar over a bare `str`:
+   - Good: `email: EmailAddress`
+   - Avoid: `email: str`
+2. Use precise types for money and identifiers:
+   - Good: `price: Money`, `id: UUID`
+   - Avoid: `price: float`, `id: str`
+3. Treat `ApiKey` and `HashSHA256` as sensitive — never log them and always serve over HTTPS.
+4. Sanitize `HTML` on render; it is stored as-is.
+
+---
+
+## See also
+
+- [`./decorators.md`](./decorators.md) — `@fraiseql.type`, `@fraiseql.query`, and related decorators.
+- [`./where-operators.md`](./where-operators.md) — PostgreSQL WHERE operators for filtering.
+- [`../foundation/09-type-system.md`](../foundation/09-type-system.md) — how Python types map to GraphQL.

--- a/docs/reference/where-operators.md
+++ b/docs/reference/where-operators.md
@@ -1,1330 +1,317 @@
-<!-- Skip to main content -->
----
-
-title: WHERE Clause Operators Reference
-description: FraiseQL provides 150+ WHERE clause operators for filtering, searching, and comparing data across all supported column types. These operators enable:
-keywords: ["directives", "types", "scalars", "schema", "api"]
-tags: ["documentation", "reference"]
----
-
 # WHERE Clause Operators Reference
 
-**Status:** ✅ Production Ready
-**Version:** FraiseQL v2.0.0-alpha.1+
-**Total Operators**: 150+
-**Categories**: 15 operator categories
-
----
+FraiseQL provides a rich set of WHERE clause operators for filtering, searching, and comparing data in your GraphQL queries. Operators are translated directly to **PostgreSQL** SQL (including JSONB and PostgreSQL-specific operators) at runtime when a query is executed.
 
 ## Overview
 
-FraiseQL provides 150+ WHERE clause operators for filtering, searching, and comparing data across all supported column types. These operators enable:
+Filters are supplied through the generated `where:` input argument on a query. Each field exposes the operators appropriate for its type, and FraiseQL maps each operator to the equivalent PostgreSQL expression:
 
-- **Type-safe filtering**: Operators validated at GraphQL execution time
-- **Database efficiency**: Direct SQL translation with optimal query plans
-- **Complex queries**: Boolean logic (AND/OR/NOT) with nested conditions
-- **Specialized operations**: Geographic distance, vector similarity, hierarchical paths, full-text search
+- **Type-aware filtering** — each field only accepts operators valid for its column type.
+- **Direct SQL translation** — operators map to PostgreSQL operators (`=`, `LIKE`, `ILIKE`, `@>`, `&&`, etc.) for efficient, index-friendly query plans.
+- **Boolean composition** — combine conditions with `AND` / `OR` / `NOT`.
+- **Specialized families** — hierarchical paths (`ltree`) and vector similarity (`pgvector`) have dedicated references; see [LTree operators](./ltree-operators.md) and [Vector operators](./vector-operators.md).
 
-All operators are type-aware and only work with compatible column types. Invalid operator/type combinations return GraphQL errors at query time.
-
----
-
-## Database Support Matrix
-
-**Quick Reference**: Operators supported per database
-
-| Operator Category | PostgreSQL | MySQL | SQLite | SQL Server | Notes |
-|---|:---:|:---:|:---:|:---:|---|
-| **Basic Comparison** (eq, neq, gt, gte, lt, lte) | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Universal, always available |
-| **String Operators** (contains, startswith, icontains) | ✅ Full | ✅ Full | ✅ Full | ✅ Full | All databases support LIKE/ILIKE equivalents |
-| **Array Operators** (@>, @<, ? ANY, IN) | ✅ Full | ⚠️ Limited | ❌ None | ⚠️ Workaround | PostgreSQL native arrays optimal; MySQL needs workaround |
-| **JSON/JSONB Operators** (->>, @>, @?) | ✅ Full | ⚠️ Limited | ⚠️ Limited | ⚠️ Limited | PostgreSQL JSONB best; others use JSON operators |
-| **Full-Text Search** (fts, plainto_tsquery) | ✅ Full | ✅ Full | ⚠️ Limited | ⚠️ Limited | PostgreSQL FTS most complete; MySQL/SQL Server partial |
-| **Geometric** (ST_Distance, <@) | ✅ Full | ⚠️ Limited | ❌ None | ⚠️ Limited | Requires PostGIS or equivalent; PostgreSQL best support |
-| **Range Operators** (contained_by, overlaps) | ✅ Full | ❌ None | ❌ None | ❌ None | PostgreSQL range types only |
-| **UUID Operations** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | All support UUID as string/binary |
-| **Date/Time Operators** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | All support standard date/time functions |
-| **Case-Insensitive** (ilike, icontains) | ✅ Native | ✅ Native | ✅ Full | ✅ Full | All support case-insensitive comparisons |
-| **NULL Handling** (is_null, is_not_null) | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Universal |
-| **Bitwise** (& bitwise AND, \| bitwise OR) | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Universal for numeric types |
-
-**Legend**:
-
-- ✅ **Full** = Fully supported, optimal performance
-- ⚠️ **Limited** = Supported with workarounds or reduced functionality
-- ❌ **None** = Not supported; no direct equivalent
-
----
-
-### Database-Specific Notes
-
-#### PostgreSQL (Recommended for operators)
-
-- ✅ All operators fully supported
-- ✅ JSONB operators optimized with GIN indexes
-- ✅ Full-text search with tsvector
-- ✅ PostGIS for geometric queries
-- ✅ Range types with native operators
-
-### MySQL
-
-- ✅ Standard SQL operators all work
-- ⚠️ JSON operators available but slower than PostgreSQL
-- ⚠️ Full-text search available (MATCH AGAINST) but less powerful than PostgreSQL
-- ⚠️ No array types; use JSON workaround
-- ⚠️ No range types; use comparison operators
-
-### SQLite
-
-- ✅ Standard SQL operators work
-- ⚠️ Minimal JSON support (JSON1 extension required)
-- ⚠️ Limited full-text search (FTS5 extension needed)
-- ❌ No array, range, or geometric types
-- ⚠️ Case-insensitive searches with `COLLATE NOCASE`
-
-### SQL Server
-
-- ✅ Standard SQL operators work
-- ⚠️ JSON operators available (JSON_VALUE, JSON_QUERY)
-- ⚠️ Full-text search available but different syntax
-- ❌ No array or range types
-- ✅ Case-insensitive by default (collation)
-
----
-
-## Operator Categories
-
-### 1. Basic Comparison Operators
-
-Basic comparison operators work with all comparable types (numeric, string, date, etc.).
-
-#### **Equality Operators**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `eq` | `=` | Equality | `{age: {eq: 25}}` |
-| `neq` | `!=` / `<>` | Not equal | `{status: {neq: "inactive"}}` |
-
-**Supported Types**: All types (strings, numbers, dates, UUIDs, etc.)
-
-**Examples**:
+A `where:` filter is an input object keyed by field name; each field holds an object keyed by operator name:
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Numeric
-{age: {eq: 25}}
-{price: {eq: 99.99}}
-
-# String
-{status: {eq: "active"}}
-{email: {eq: "user@example.com"}}
-
-# Date
-{birthDate: {eq: "1990-05-15"}}
-
-# UUID
-{id: {eq: "550e8400-e29b-41d4-a716-446655440000"}}
-
-# Boolean
-{isActive: {eq: true}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Comparison Operators**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `gt` | `>` | Greater than | `{age: {gt: 18}}` |
-| `gte` | `>=` | Greater than or equal | `{age: {gte: 21}}` |
-| `lt` | `<` | Less than | `{age: {lt: 65}}` |
-| `lte` | `<=` | Less than or equal | `{age: {lte: 65}}` |
-
-**Supported Types**: Numeric (int, float, decimal), Date, DateTime, String (lexical comparison)
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Numeric ranges
-{age: {gte: 18, lte: 65}}
-{price: {gt: 100, lt: 500}}
-
-# Date ranges
-{createdAt: {gte: "2024-01-01", lt: "2025-01-01"}}
-{birthDate: {lte: "2007-01-01"}}
-
-# String lexical comparison
-{name: {gte: "A", lt: "B"}}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 2. String/Text Operators
-
-String operators provide flexible text searching with case-sensitivity control and pattern matching.
-
-#### **Substring Operators**
-
-| Operator | SQL Equivalent | Description | Case-Sensitive | Example |
-|----------|---|---|---|---|
-| `contains` | `LIKE '%value%'` | Contains substring | Yes | `{name: {contains: "John"}}` |
-| `icontains` | `ILIKE '%value%'` | Contains substring | No | `{name: {icontains: "john"}}` |
-| `startswith` | `LIKE 'value%'` | Starts with | Yes | `{name: {startswith: "J"}}` |
-| `istartswith` | `ILIKE 'value%'` | Starts with | No | `{name: {istartswith: "j"}}` |
-| `endswith` | `LIKE '%value'` | Ends with | Yes | `{name: {endswith: "son"}}` |
-| `iendswith` | `ILIKE '%value'` | Ends with | No | `{name: {iendswith: "SON"}}` |
-
-**Supported Types**: String, Text, Slug, domains, URLs
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Case-sensitive
-{email: {contains: "@example.com"}}
-{title: {startswith: "The"}}
-{filename: {endswith: ".pdf"}}
-
-# Case-insensitive
-{name: {icontains: "smith"}}
-{city: {istartswith: "san"}}
-
-# Combined
-{email: {contains: "@"}}
-{url: {startswith: "https://"}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Pattern Operators**
-
-| Operator | SQL Equivalent | Description | Pattern Support | Example |
-|----------|---|---|---|---|
-| `like` | `LIKE` | User-provided pattern | SQL wildcards (% = any, _ = single) | `{name: {like: "%J_hn%"}}` |
-| `ilike` | `ILIKE` | Case-insensitive pattern | SQL wildcards | `{name: {ilike: "%SMITH%"}}` |
-
-**Wildcard Rules**:
-
-- `%` = Any characters (0 or more)
-- `_` = Exactly one character
-- Escape with backslash: `\%` for literal percent
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Find names with pattern
-{name: {like: "John%"}}        # Starts with John
-{name: {like: "%Smith"}}       # Ends with Smith
-{name: {like: "%Robert%"}}     # Contains Robert
-{name: {like: "A_C"}}          # Three-letter, starts with A, ends with C
-
-# Case-insensitive
-{email: {ilike: "%@example.com"}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Regular Expression Operators**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `matches` | `~` | Regex match (case-sensitive) | `{email: {matches: ".*@example\\.com$"}}` |
-| `imatches` | `~*` | Regex match (case-insensitive) | `{email: {imatches: ".*@example\\.com$"}}` |
-| `not_matches` | `!~` | Negated regex match | `{email: {not_matches: ".*@spam\\.com$"}}` |
-
-**PostgreSQL POSIX Regular Expressions**:
-
-- `.` = Any character
-- `*` = Zero or more
-- `+` = One or more
-- `?` = Zero or one
-- `^` = Start of string
-- `$` = End of string
-- `[...]` = Character class
-- `(...)` = Group
-- `|` = OR
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Email validation pattern
-{email: {matches: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"}}
-
-# Phone number pattern
-{phone: {matches: "^\\+?[1-9]\\d{1,14}$"}}
-
-# Exclude pattern
-{email: {not_matches: ".*@(spam|test)\\.com$"}}
-
-# Case-insensitive domain check
-{email: {imatches: ".*@EXAMPLE\\.COM$"}}
-
-# URL protocol check
-{url: {matches: "^https?://"}}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 3. Containment/List Operators
-
-List operators check if values are in a provided list.
-
-#### **List Operators**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `in` | `IN (...)` | Value in list | `{status: {in: ["active", "pending"]}}` |
-| `nin` / `notin` | `NOT IN (...)` | Value not in list | `{status: {nin: ["deleted", "archived"]}}` |
-
-**Supported Types**: All types (numeric, string, UUID, date, etc.)
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# String values
-{status: {in: ["active", "pending", "approved"]}}
-{country: {nin: ["XX", "YY"]}}
-
-# Numeric values
-{userId: {in: [1, 2, 3, 4, 5]}}
-{priority: {nin: [0, -1]}}
-
-# UUID values
-{parentId: {in: ["550e8400-e29b-41d4-a716-446655440000", "abcd1234-e29b-41d4-a716-446655440000"]}}
-
-# Date values
-{status: {in: ["2024-01-01", "2024-12-31"]}}
-
-# Mixed with other operators
-{status: {in: ["active", "pending"]}, age: {gte: 18}}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 4. NULL Checking
-
-#### **NULL Operators**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `isnull` | `IS NULL` / `IS NOT NULL` | Check if NULL | `{deletedAt: {isnull: true}}` |
-
-**Supported Types**: All types
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Records with NULL values
-{deletedAt: {isnull: true}}
-{middleName: {isnull: true}}
-
-# Records without NULL values
-{email: {isnull: false}}
-{phone: {isnull: false}}
-
-# Soft delete pattern
-{AND: [{isnull: false}, {deletedAt: {isnull: true}}]}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 5. Array Operators
-
-Array operators work with JSONB array columns (columns storing JSON arrays).
-
-#### **Array Comparison**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `eq` / `array_eq` | `=` | Array equality | `{tags: {eq: ["a", "b"]}}` |
-| `neq` / `array_neq` | `!=` | Array inequality | `{tags: {neq: ["x"]}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-{tags: {eq: ["important", "review"]}}
-{items: {neq: []}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Array Containment**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `contains` / `array_contains` | `@>` | Array contains all elements | `{tags: {contains: ["important"]}}` |
-| `contained_by` / `array_contained_by` | `<@` | Array is contained by | `{tags: {contained_by: ["a", "b", "c"]}}` |
-| `overlaps` / `array_overlaps` | `&&` | Arrays have common elements | `{tags: {overlaps: ["urgent", "review"]}}` |
-
-**Containment vs Overlaps**:
-
-- `contains`: Subject array must have ALL elements of provided array
-- `overlaps`: Subject array must have AT LEAST ONE element of provided array
-- `contained_by`: Subject array must be subset of provided array
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Must have ALL these tags
-{tags: {contains: ["important", "urgent"]}}
-
-# Must overlap with any of these
-{tags: {overlaps: ["todo", "review", "pending"]}}
-
-# Must be subset of allowed tags
-{tags: {contained_by: ["dev", "qa", "prod", "staging"]}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Array Length**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `len_eq` / `array_length_eq` | `array_length(,1) =` | Length equals | `{items: {len_eq: 5}}` |
-| `len_neq` / `array_length_neq` | `array_length(,1) !=` | Length not equal | `{items: {len_neq: 0}}` |
-| `len_gt` / `array_length_gt` | `array_length(,1) >` | Length greater than | `{items: {len_gt: 3}}` |
-| `len_gte` / `array_length_gte` | `array_length(,1) >=` | Length >= | `{items: {len_gte: 1}}` |
-| `len_lt` / `array_length_lt` | `array_length(,1) <` | Length less than | `{items: {len_lt: 10}}` |
-| `len_lte` / `array_length_lte` | `array_length(,1) <=` | Length <= | `{items: {len_lte: 20}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Array length checks
-{items: {len_eq: 5}}           # Exactly 5 items
-{tags: {len_gte: 1}}           # At least 1 tag
-{attachments: {len_lt: 100}}   # Fewer than 100
-{reviews: {len_neq: 0}}        # Non-empty reviews
-```text
-<!-- Code example in TEXT -->
-
-#### **Array Element Matching**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `any_eq` / `array_any_eq` | `= ANY(array)` | Any element equals | `{items: {any_eq: "important"}}` |
-| `all_eq` / `array_all_eq` | `= ALL(array)` | All elements equal | `{items: {all_eq: "same"}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Any element matches
-{items: {any_eq: "completed"}}
-
-# All elements match (rarely useful, for uniform arrays)
-{statuses: {all_eq: "active"}}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 6. Network/IP Address Operators
-
-Network operators work with INET and CIDR PostgreSQL types (IPv4 and IPv6 addresses/networks).
-
-#### **IP Address Comparison**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `eq` | `=` | IP equality | `{ip: {eq: "192.168.1.1"}}` |
-| `neq` | `!=` | IP inequality | `{ip: {neq: "10.0.0.1"}}` |
-| `in` | `IN (...)` | IP in list | `{ip: {in: ["192.168.1.1", "10.0.0.1"]}}` |
-| `nin` / `notin` | `NOT IN (...)` | IP not in list | `{ip: {nin: ["10.0.0.0/8"]}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Exact IP match
-{ip: {eq: "192.168.1.100"}}
-
-# IPv6
-{ip: {eq: "2001:db8::1"}}
-
-# IP in list
-{sourceIp: {in: ["192.168.1.1", "192.168.1.2", "192.168.1.3"]}}
-
-# Exclude ranges
-{ip: {nin: ["10.0.0.0/8", "172.16.0.0/12"]}}
-```text
-<!-- Code example in TEXT -->
-
-#### **IP Address Classification**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `isprivate` / `isPrivate` | RFC 1918 check | Is private IP | `{ip: {isprivate: true}}` |
-| `ispublic` / `isPublic` | NOT RFC 1918 check | Is public IP | `{ip: {ispublic: true}}` |
-| `isipv4` / `isIPv4` | `family() = 4` | Is IPv4 address | `{ip: {isipv4: true}}` |
-| `isipv6` / `isIPv6` | `family() = 6` | Is IPv6 address | `{ip: {isipv6: true}}` |
-
-**Private IP Ranges (RFC 1918)**:
-
-- `10.0.0.0/8` (10.0.0.0 to 10.255.255.255)
-- `172.16.0.0/12` (172.16.0.0 to 172.31.255.255)
-- `192.168.0.0/16` (192.168.0.0 to 192.168.255.255)
-- `127.0.0.0/8` (Loopback)
-- `169.254.0.0/16` (Link-local)
-- Etc.
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Find public IPs (security audits)
-{ip: {ispublic: true}}
-
-# Find private/internal IPs
-{ip: {isprivate: true}}
-
-# Filter by IP version
-{ip: {isipv4: true}}          # IPv4 only
-{ip: {isipv6: true}}          # IPv6 only
-
-# Combined filtering
-{AND: [{ip: {isipv4: true}}, {ip: {isprivate: true}}]}
-```text
-<!-- Code example in TEXT -->
-
-#### **Network Range Operators**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `insubnet` / `inSubnet` | `<<=` | IP in subnet | `{ip: {insubnet: "192.168.0.0/16"}}` |
-| `inrange` / `inRange` | `<<=` | IP in CIDR range (alias) | `{ip: {inrange: "10.0.0.0/8"}}` |
-| `overlaps` | `&&` | Networks overlap | `{network: {overlaps: "192.168.0.0/24"}}` |
-| `strictleft` | `<<` | Network strictly left of | `{network: {strictleft: "192.169.0.0/16"}}` |
-| `strictright` | `>>` | Network strictly right of | `{network: {strictright: "192.167.0.0/16"}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Check if IP is in corporate network
-{ip: {insubnet: "203.0.113.0/24"}}
-
-# Check if in restricted range
-{sourceIp: {inrange: "10.0.0.0/8"}}
-
-# Network overlap check
-{network: {overlaps: "192.168.0.0/24"}}
-
-# Ordering checks
-{network: {strictleft: "192.170.0.0/16"}}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 7. MAC Address Operators
-
-MAC address operators work with `macaddr` PostgreSQL type.
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `eq` | `=` | MAC equality | `{mac: {eq: "08:00:2b:01:02:03"}}` |
-| `neq` | `!=` | MAC inequality | `{mac: {neq: "ff:ff:ff:ff:ff:ff"}}` |
-| `in` | `IN (...)` | MAC in list | `{mac: {in: ["00:11:22:33:44:55"]}}` |
-| `nin` / `notin` | `NOT IN (...)` | MAC not in list | `{mac: {nin: ["ff:ff:ff:ff:ff:ff"]}}` |
-| `isnull` | `IS NULL` | Check if NULL | `{mac: {isnull: false}}` |
-
-**Format**: Colon-separated hexadecimal octets
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Device identification
-{mac: {eq: "a0:1d:48:12:34:56"}}
-
-# Allowlist
-{mac: {in: ["08:00:2b:01:02:03", "0c:42:a1:23:45:67"]}}
-
-# Exclude broadcast
-{mac: {neq: "ff:ff:ff:ff:ff:ff"}}
-
-# Exclude DHCP
-{mac: {isnull: false}}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 8. Date Range Operators
-
-Date range operators work with PostgreSQL `daterange` type.
-
-#### **Date Range Comparison**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `eq` | `=` | Range equality | `{period: {eq: "[2024-01-01, 2024-12-31]"}}` |
-| `neq` | `!=` | Range inequality | `{period: {neq: "[2023-01-01, 2023-12-31]"}}` |
-| `in` | `IN (...)` | Range in list | `{period: {in: ["[2024-01-01, 2024-12-31]", "[2025-01-01, 2025-12-31]"]}}` |
-| `nin` / `notin` | `NOT IN (...)` | Range not in list | `{period: {nin: ["[2023-01-01, 2023-12-31]"]}}` |
-
-**Range Notation**:
-
-- `[start, end]` = Inclusive on both sides
-- `(start, end)` = Exclusive on both sides
-- `[start, end)` = Inclusive start, exclusive end
-- `(start, end]` = Exclusive start, inclusive end
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Year 2024 (inclusive)
-{period: {eq: "[2024-01-01, 2024-12-31]"}}
-
-# Excluding year 2023
-{period: {nin: ["[2023-01-01, 2023-12-31]"]}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Date Range Containment**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `contains_date` | `@>` | Range contains date | `{period: {contains_date: "2024-06-15"}}` |
-| `overlaps` | `&&` | Ranges overlap | `{period: {overlaps: "[2024-01-01, 2024-12-31]"}}` |
-| `adjacent` | `-\|-` | Ranges adjacent | `{period: {adjacent: "[2025-01-01, 2025-12-31]"}}` |
-| `strictly_left` | `<<` | Range strictly left of | `{period: {strictly_left: "[2025-01-01, 2025-12-31]"}}` |
-| `strictly_right` | `>>` | Range strictly right of | `{period: {strictly_right: "[2023-01-01, 2023-12-31]"}}` |
-| `not_left` | `&>` | Range does not extend left | `{period: {not_left: "[2024-06-01, 2025-12-31]"}}` |
-| `not_right` | `&<` | Range does not extend right | `{period: {not_right: "[2023-01-01, 2024-06-30]"}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Events during 2024
-{period: {contains_date: "2024-06-15"}}
-
-# Overlapping projects
-{period: {overlaps: "[2024-03-01, 2024-09-30]"}}
-
-# Adjacent phases
-{period: {adjacent: "[2024-Q2, 2024-Q3]"}}
-
-# Before date
-{period: {strictly_left: "[2024-01-01, 2025-01-01]"}}
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 9. LTree (Hierarchical Path) Operators
-
-LTree operators work with PostgreSQL `ltree` type for hierarchical data (categories, org charts, etc.).
-
-#### **Path Comparison**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `eq` | `=` | Path equality | `{path: {eq: "Top.Sciences.Astronomy"}}` |
-| `neq` | `!=` | Path inequality | `{path: {neq: "Other"}}` |
-| `in` | `IN (...)` | Path in list | `{path: {in: ["Top.Science", "Top.Technology"]}}` |
-| `nin` / `notin` | `NOT IN (...)` | Path not in list | `{path: {nin: ["Deleted"]}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-{path: {eq: "Organization.Engineering.Backend"}}
-{path: {in: ["Products.Electronics", "Products.Software"]}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Path Hierarchy**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `ancestor_of` | `@>` | Is ancestor of path | `{path: {ancestor_of: "Top.Sciences.Astronomy.Cosmology"}}` |
-| `descendant_of` | `<@` | Is descendant of path | `{path: {descendant_of: "Top.Sciences"}}` |
-
-**Hierarchy Rules**:
-
-- `ancestor_of`: Current path is parent/ancestor of provided path
-- `descendant_of`: Current path is child/descendant of provided path
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Find all ancestor categories
-{path: {ancestor_of: "Top.Sciences.Physics.Quantum.Superposition"}}
-# Matches: "Top", "Top.Sciences", "Top.Sciences.Physics", etc.
-
-# Find all subcategories
-{path: {descendant_of: "Top.Sciences"}}
-# Matches: "Top.Sciences.Physics", "Top.Sciences.Astronomy", etc.
-
-# Organization hierarchy
-{path: {ancestor_of: "Company.Engineering.Backend.Database.Migration"}}
-# Matches all parent org units
-```text
-<!-- Code example in TEXT -->
-
-#### **Path Pattern Matching**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `matches_lquery` | `~` | Matches lquery pattern | `{path: {matches_lquery: "Top.*.Ast*"}}` |
-| `matches_ltxtquery` | `?` | Matches ltxtquery pattern | `{path: {matches_ltxtquery: "Top & (Sciences \| Technology)"}}` |
-| `matches_any_lquery` | Array of patterns | Matches any lquery pattern | `{path: {matches_any_lquery: ["Top.*", "Other.*"]}}` |
-
-**lquery Pattern Syntax** (SQL wildcards):
-
-- `*` = Any level (single label)
-- `*{n}` = Exactly n levels
-- `*{n,}` = n or more levels
-- `*{,n}` = Up to n levels
-- `*{n,m}` = Between n and m levels
-- `?[*]` = Optional level
-- `!` = Prefix match (case-insensitive alternative)
-
-**ltxtquery Syntax** (Boolean):
-
-- `&` = AND
-- `|` = OR
-- `!` = NOT
-- `(...)` = Grouping
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Find all paths with 3 levels starting with Top
-{path: {matches_lquery: "Top.*.*"}}
-
-# Find all paths in Sciences or Technology
-{path: {matches_ltxtquery: "(Sciences | Technology)"}}
-
-# Complex Boolean queries
-{path: {matches_ltxtquery: "(Physics | Chemistry) & ! Deprecated"}}
-
-# Match any pattern
-{path: {matches_any_lquery: ["Products.*", "Services.*", "Other"]}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Path Depth/Navigation**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `depth_eq` | `nlevel() =` | Depth equals | `{path: {depth_eq: 3}}` |
-| `depth_neq` | `nlevel() !=` | Depth not equal | `{path: {depth_neq: 1}}` |
-| `depth_gt` | `nlevel() >` | Depth greater | `{path: {depth_gt: 2}}` |
-| `depth_gte` | `nlevel() >=` | Depth >= | `{path: {depth_gte: 2}}` |
-| `depth_lt` | `nlevel() <` | Depth less | `{path: {depth_lt: 5}}` |
-| `depth_lte` | `nlevel() <=` | Depth <= | `{path: {depth_lte: 4}}` |
-
-**Depth Calculation**:
-
-- `"Top"` = depth 1
-- `"Top.Sciences"` = depth 2
-- `"Top.Sciences.Physics"` = depth 3
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Top-level categories only
-{path: {depth_eq: 1}}
-
-# No deeply nested paths
-{path: {depth_lt: 5}}
-
-# Second-level categories
-{path: {depth_eq: 2}}
-
-# Deep hierarchies (3+ levels)
-{path: {depth_gte: 3}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Path Concatenation**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `concat` | `\|\|` | Concatenate paths | `{path: {concat: "Astronomy"}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Append label to path
-{path: {concat: "NewSubcategory"}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Lowest Common Ancestor**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `lca` | `lca()` | Lowest common ancestor | `{path: {lca: ["Top.Sciences.Astronomy", "Top.Sciences.Physics"]}}` |
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Find common ancestor
-{path: {lca: ["Org.Engineering.Backend", "Org.Engineering.Frontend"]}}
-# Returns: "Org.Engineering"
-```text
-<!-- Code example in TEXT -->
-
----
-
-### 10. Vector Operators
-
-Vector operators work with pgvector extension for semantic search and similarity matching.
-
-#### **Vector Distance Operators**
-
-| Operator | SQL Equivalent | Distance Metric | Use Case | Example |
-|----------|---|---|---|---|
-| `cosine_distance` | `<=>` | Cosine similarity (0=identical, 2=opposite) | **Default for embeddings** | `{embedding: {cosine_distance: {vector: [...], threshold: 0.1}}}` |
-| `l2_distance` | `<->` | Euclidean (L2) distance | Spatial distance, clustering | `{embedding: {l2_distance: {vector: [...], threshold: 5.0}}}` |
-| `l1_distance` | `<+>` | Manhattan (L1) distance | Grid-based distance | `{embedding: {l1_distance: {vector: [...], threshold: 10.0}}}` |
-| `hamming_distance` | `<~>` | Hamming distance (binary vectors) | Bit similarity | `{bits: {hamming_distance: {vector: [...], threshold: 3}}}` |
-| `jaccard_distance` | `<%>` | Jaccard distance (binary vectors) | Set similarity | `{bits: {jaccard_distance: {vector: [...], threshold: 0.5}}}` |
-
-**Distance Methods Explained**:
-
-**Cosine Distance** (recommended for embeddings):
-
-- Measures angle between vectors (0 = identical, 1 = perpendicular, 2 = opposite)
-- Dimension-invariant (works with any embedding size)
-- Best for: Text embeddings, image embeddings, semantic search
-- Range: [0, 2]
-- Lower = more similar
-
-**Euclidean Distance** (L2):
-
-- Straight-line distance in multi-dimensional space
-- Depends on vector magnitude and dimension
-- Best for: Spatial data, clustering, RMS error
-- Formula: sqrt(sum((a-b)²))
-
-**Manhattan Distance** (L1):
-
-- Sum of absolute differences
-- Useful in high-dimensional spaces (curse of dimensionality)
-- Best for: Categorical data with grid structure
-- Formula: sum(|a-b|)
-
-**Hamming Distance** (binary vectors):
-
-- Count differing bits
-- Best for: Binary vectors, bit flags
-- Range: [0, n] where n = vector length
-
-**Jaccard Distance** (binary vectors):
-
-- Set overlap similarity
-- Best for: Set membership, presence/absence
-
-**Query Format**:
-
-```graphql
-<!-- Code example in GraphQL -->
-{
-  vector_field: {
-    distance_operator: {
-      vector: [dimension1, dimension2, ...],
-      threshold: number_threshold,
-      comparison: "lt" | "lte" | "gt" | "gte"  # How to compare
-    }
+query {
+  users(where: {
+    status: { eq: "active" }
+    age: { gte: 18 }
+  }) {
+    id
+    name
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Examples**:
+Multiple fields at the same level are combined with `AND`.
+
+---
+
+## Comparison Operators
+
+Comparison operators work with comparable scalar types (numeric, string, date, datetime, UUID, etc.).
+
+| Operator | SQL | Description | Example |
+|----------|-----|-------------|---------|
+| `eq` | `=` | Equal | `{ age: { eq: 25 } }` |
+| `neq` | `!=` / `<>` | Not equal | `{ status: { neq: "inactive" } }` |
+| `gt` | `>` | Greater than | `{ age: { gt: 18 } }` |
+| `gte` | `>=` | Greater than or equal | `{ age: { gte: 21 } }` |
+| `lt` | `<` | Less than | `{ age: { lt: 65 } }` |
+| `lte` | `<=` | Less than or equal | `{ age: { lte: 65 } }` |
+| `in` | `IN (...)` | Value in list | `{ status: { in: ["active", "pending"] } }` |
+| `nin` / `notin` | `NOT IN (...)` | Value not in list | `{ status: { nin: ["deleted", "archived"] } }` |
+| `isnull` | `IS NULL` / `IS NOT NULL` | NULL check | `{ deletedAt: { isnull: true } }` |
+
+`notin` is an accepted alias for `nin`.
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Semantic search (find similar embeddings)
-{
-  embedding: {
-    cosine_distance: {
-      vector: [0.1, 0.2, 0.3, -0.1, 0.05],
-      threshold: 0.2,
-      comparison: "lt"  # Find embeddings with distance < 0.2
-    }
+query {
+  users(where: {
+    age: { gte: 18, lte: 65 }
+    status: { in: ["active", "pending"] }
+    deletedAt: { isnull: true }
+  }) {
+    id
+    name
   }
 }
+```
 
-# Spatial search (find nearby points)
-{
-  location: {
-    l2_distance: {
-      vector: [40.7128, -74.0060],  # NYC coordinates
-      threshold: 10,  # Within 10 units
-      comparison: "lt"
-    }
+This translates to roughly:
+
+```sql
+WHERE (data->>'age')::int >= 18
+  AND (data->>'age')::int <= 65
+  AND data->>'status' IN ('active', 'pending')
+  AND data->>'deleted_at' IS NULL
+```
+
+Numeric comparisons (`gt`, `gte`, `lt`, `lte`) apply to numeric, date, datetime, and lexically to text. The equality, list, and NULL operators apply to all scalar types.
+
+---
+
+## Text and Pattern Operators
+
+Text operators provide substring matching, prefix/suffix matching, and regular-expression matching, each with a case-insensitive variant.
+
+### Substring, prefix, and suffix
+
+| Operator | SQL | Description | Case-sensitive |
+|----------|-----|-------------|:---:|
+| `contains` | `LIKE '%value%'` | Contains substring | Yes |
+| `icontains` | `ILIKE '%value%'` | Contains substring | No |
+| `startswith` | `LIKE 'value%'` | Starts with | Yes |
+| `istartswith` | `ILIKE 'value%'` | Starts with | No |
+| `endswith` | `LIKE '%value'` | Ends with | Yes |
+| `iendswith` | `ILIKE '%value'` | Ends with | No |
+
+```graphql
+query {
+  users(where: {
+    email: { contains: "@example.com" }
+    name: { icontains: "smith" }
+    city: { istartswith: "san" }
+  }) {
+    id
   }
 }
+```
 
-# Find closest match
-{
-  embedding: {
-    l2_distance: {
-      vector: [reference_vector],
-      threshold: 100,
-      comparison: "lt"
-    }
+```sql
+WHERE data->>'email' LIKE '%@example.com%'
+  AND data->>'name' ILIKE '%smith%'
+  AND data->>'city' ILIKE 'san%'
+```
+
+### LIKE patterns
+
+| Operator | SQL | Description |
+|----------|-----|-------------|
+| `like` | `LIKE` | Match a user-supplied SQL `LIKE` pattern |
+| `ilike` | `ILIKE` | Case-insensitive `LIKE` pattern |
+
+Wildcards follow PostgreSQL `LIKE` semantics: `%` matches any sequence of characters and `_` matches a single character.
+
+```graphql
+query {
+  users(where: {
+    name: { like: "John%" }
+    email: { ilike: "%@example.com" }
+  }) {
+    id
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
+
+### Regular expressions
+
+| Operator | SQL | Description |
+|----------|-----|-------------|
+| `matches` | `~` | POSIX regex match (case-sensitive) |
+| `imatches` | `~*` | POSIX regex match (case-insensitive) |
+| `not_matches` | `!~` | Negated POSIX regex match |
+
+These use PostgreSQL POSIX regular expressions (`^`, `$`, `.`, `*`, `+`, `?`, `[...]`, `(...)`, `|`).
+
+```graphql
+query {
+  users(where: {
+    email: { matches: "^[a-z0-9._%+-]+@example\\.com$" }
+  }) {
+    id
+  }
+}
+```
+
+```sql
+WHERE data->>'email' ~ '^[a-z0-9._%+-]+@example\.com$'
+```
 
 ---
 
-### 11. Full-Text Search Operators
+## Array Operators
 
-Full-text search operators work with PostgreSQL `tsvector` type for advanced text searching.
+Array operators work with array-valued fields (JSONB arrays). They map to PostgreSQL's array/containment operators.
 
-#### **Full-Text Query Types**
+### Equality
 
-| Operator | Function | Description | Example |
-|----------|---|---|---|
-| `matches` | `tsquery` | Boolean full-text query | `{content: {matches: "search & query"}}` |
-| `plain_query` | `plainto_tsquery` | Simple phrase (auto-split on whitespace) | `{content: {plain_query: "quick brown fox"}}` |
-| `phrase_query` | `phraseto_tsquery` | Exact phrase (consecutive words) | `{content: {phrase_query: "quick brown"}}` |
-| `websearch_query` | `websearch_to_tsquery` | Web search syntax (Google-like) | `{content: {websearch_query: '"exact phrase" -exclude'}}` |
+| Operator | SQL | Description |
+|----------|-----|-------------|
+| `eq` / `array_eq` | `=` | Array equals |
+| `neq` / `array_neq` | `!=` | Array not equal |
 
-**Boolean Query Syntax** (`matches`):
+### Containment and overlap
 
-- `&` = AND (both must match)
-- `|` = OR (either must match)
-- `!` = NOT (negation)
-- `(...)` = Grouping
-- `:*` = Prefix match
-
-**Websearch Syntax** (`websearch_query`):
-
-- `"phrase"` = Exact phrase
-- `-word` = Exclude word
-- `word1 word2` = AND (both required)
-- `word1 | word2` = OR
-
-**Examples**:
+| Operator | SQL | Description |
+|----------|-----|-------------|
+| `contains` / `array_contains` | `@>` | Array contains **all** the given elements |
+| `contained_by` / `array_contained_by` | `<@` | Array is a subset of the given elements |
+| `overlaps` / `array_overlaps` | `&&` | Arrays share **at least one** element |
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Boolean query (AND)
-{content: {matches: "database & search"}}
+query {
+  posts(where: {
+    tags: { contains: ["important", "urgent"] }
+  }) {
+    id
+  }
+  reviewQueue: posts(where: {
+    tags: { overlaps: ["todo", "review", "pending"] }
+  }) {
+    id
+  }
+}
+```
 
-# Boolean query (OR)
-{content: {matches: "python | java"}}
+```sql
+-- contains: must have every listed tag
+WHERE data->'tags' @> '["important", "urgent"]'::jsonb
 
-# Exclude terms
-{content: {matches: "database & !nosql"}}
+-- overlaps: must share at least one tag
+WHERE data->'tags' && '["todo", "review", "pending"]'::text[]
+```
 
-# Complex Boolean
-{content: {matches: "(python | java) & (database & !mongodb)"}}
+Distinguishing the three:
 
-# Prefix match
-{content: {matches: "graphql:*"}}
+- `contains` — the field must include **all** supplied elements.
+- `overlaps` — the field must include **at least one** supplied element.
+- `contained_by` — the field must be a **subset** of the supplied elements.
 
-# Plain phrase (auto-split)
-{content: {plain_query: "apollo federation gateway"}}
+### Array length and element matching
 
-# Exact phrase (consecutive)
-{content: {phrase_query: "apollo federation"}}
-
-# Web search
-{content: {websearch_query: '"exact phrase" -exclude-word"}}
-
-# Web search OR
-{content: {websearch_query: 'python | java'}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Full-Text Ranking**
-
-| Operator | Function | Description | Example |
-|----------|---|---|---|
-| `rank_gt` | `ts_rank() >` | Rank greater than | `{content: {rank_gt: {query: "search", threshold: 0.5}}}` |
-| `rank_lt` | `ts_rank() <` | Rank less than | `{content: {rank_lt: {query: "search", threshold: 0.1}}}` |
-| `rank_cd_gt` | `ts_rank_cd() >` | Cover density rank > | `{content: {rank_cd_gt: "search:0.5"}}` |
-| `rank_cd_lt` | `ts_rank_cd() <` | Cover density rank < | `{content: {rank_cd_lt: "search:0.1"}}` |
-
-**Ranking Types**:
-
-- `ts_rank()`: Standard ranking (0-1 scale)
-  - Uses position and frequency
-  - Faster, suitable for most cases
-- `ts_rank_cd()`: Cover density ranking (0-1 scale)
-  - Considers proximity of query terms
-  - Better for phrase relevance
-  - Slower but more accurate for phrases
-
-**Score Interpretation**:
-
-- 0 = No relevance
-- 0-0.3 = Low relevance
-- 0.3-0.7 = Medium relevance
-- 0.7-1.0 = High relevance
-
-**Examples**:
+| Operator | SQL | Description |
+|----------|-----|-------------|
+| `len_eq` | `array_length(...) =` | Length equals |
+| `len_neq` | `array_length(...) !=` | Length not equal |
+| `len_gt` | `array_length(...) >` | Length greater than |
+| `len_gte` | `array_length(...) >=` | Length greater than or equal |
+| `len_lt` | `array_length(...) <` | Length less than |
+| `len_lte` | `array_length(...) <=` | Length less than or equal |
+| `any_eq` | `= ANY(...)` | Any element equals the value |
+| `all_eq` | `= ALL(...)` | All elements equal the value |
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Only highly relevant results
-{content: {rank_gt: {query: "machine learning", threshold: 0.7}}}
-
-# Filter out low-relevance noise
-{content: {rank_gt: {query: "data", threshold: 0.2}}}
-
-# Cover density ranking (better for phrases)
-{content: {rank_cd_gt: "artificial intelligence:0.5"}}
-```text
-<!-- Code example in TEXT -->
+query {
+  posts(where: {
+    tags: { len_gte: 1 }
+    statuses: { any_eq: "completed" }
+  }) {
+    id
+  }
+}
+```
 
 ---
 
-### 12. JSONB Operators
+## Hierarchical Path and Vector Operators
 
-JSONB operators work with PostgreSQL `jsonb` columns for flexible, semi-structured data.
+Two specialized operator families have their own dedicated references:
 
-#### **JSONB Containment**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `overlaps` | `&&` | JSONB objects/arrays overlap | `{metadata: {overlaps: {"key": "value"}}}` |
-| `strictly_contains` | `@>` AND `!=` | Contains but not equal | `{metadata: {strictly_contains: {"key": "value"}}}` |
-
-**Overlap Rules**:
-
-- Objects: Share at least one key-value pair
-- Arrays: Share at least one element
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Check if metadata contains required field
-{metadata: {strictly_contains: {"environment": "production"}}}
-
-# Check overlap between JSONB fields
-{config: {overlaps: {"debug": true}}}
-```text
-<!-- Code example in TEXT -->
+- **LTree (hierarchical paths)** — operators such as `ancestor_of`, `descendant_of`, `matches_lquery`, and `nlevel_*` for PostgreSQL `ltree` columns. See [LTree operators](./ltree-operators.md).
+- **Vector similarity (pgvector)** — distance operators such as `cosine_distance`, `l2_distance`, `inner_product`, and `hamming_distance` for embedding search. See [Vector operators](./vector-operators.md).
 
 ---
 
-### 13. Coordinate/Geographic Operators
+## Logical Operators
 
-Geographic operators work with PostgreSQL `point` type for coordinate-based filtering.
+Combine field conditions with boolean operators. Conditions at the same level are `AND`-combined by default.
 
-#### **Coordinate Comparison**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `eq` | `POINT = POINT` | Exact coordinate match | `{location: {eq: (40.7128, -74.0060)}}` |
-| `neq` | `POINT != POINT` | Coordinate not equal | `{location: {neq: (0, 0)}}` |
-| `in` | `IN (points)` | Coordinate in list | `{location: {in: [(40.7128, -74.0060), (51.5074, -0.1278)]}}` |
-| `notin` | `NOT IN (points)` | Coordinate not in list | `{location: {notin: [(0, 0)]}}` |
-
-**Format**: `(latitude, longitude)` tuples
-
-**Examples**:
+| Operator | SQL | Description |
+|----------|-----|-------------|
+| `AND` | `AND` | All conditions must match |
+| `OR` | `OR` | At least one condition must match |
+| `NOT` | `NOT` | Negate the condition |
 
 ```graphql
-<!-- Code example in GraphQL -->
-# New York
-{location: {eq: (40.7128, -74.0060)}}
-
-# Major cities
-{location: {in: [(40.7128, -74.0060), (51.5074, -0.1278), (48.8566, 2.3522)]}}
-
-# Exclude null island
-{location: {notin: [(0, 0)]}}
-```text
-<!-- Code example in TEXT -->
-
-#### **Distance-Based Queries**
-
-| Operator | Distance Method | Description | Example |
-|----------|---|---|---|
-| `distance_within` | Haversine / PostGIS / Earthdistance | Find within distance | `{location: {distance_within: ((40.7128, -74.0060), 5000)}}` |
-
-**Distance Methods** (configurable):
-
-| Method | Pros | Cons | Best For |
-|--------|------|------|----------|
-| **Haversine** (default) | No dependencies, fast | Assumes spherical Earth | General purpose, globe-scale |
-| **PostGIS** | Most accurate, rich operators | Requires PostGIS | Advanced geospatial |
-| **Earthdistance** | PostgreSQL native | Requires extension | Earth distances only |
-
-**Distance Units**:
-
-- **Haversine**: Kilometers by default (R = 6,371 km)
-- **PostGIS**: Depends on SRID (usually meters)
-- **Earthdistance**: Earth radii
-
-**Format**: `((latitude, longitude), distance)`
-
-**Examples**:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Find locations within 5 km of NYC
-{location: {distance_within: ((40.7128, -74.0060), 5000)}}
-
-# Within 1 degree (≈111 km at equator)
-{location: {distance_within: ((0, 0), 1)}}
-
-# Cities within 50 km of reference point
-{location: {distance_within: ((48.8566, 2.3522), 50000)}}
-```text
-<!-- Code example in TEXT -->
+query {
+  users(where: {
+    AND: [
+      { age: { gte: 18 } },
+      { OR: [
+        { status: { eq: "active" } },
+        { status: { eq: "pending" } }
+      ] },
+      { NOT: { email: { isnull: true } } }
+    ]
+  }) {
+    id
+    name
+  }
+}
+```
 
 ---
 
-### 14. Logical Operators
+## Combining Operators
 
-Logical operators combine multiple conditions.
-
-#### **Logical Combinations**
-
-| Operator | SQL Equivalent | Description | Example |
-|----------|---|---|---|
-| `AND` | `AND` | All conditions must match (default) | `{AND: [{status: {eq: "active"}}, {age: {gte: 18}}]}` |
-| `OR` | `OR` | At least one condition must match | `{OR: [{status: {eq: "active"}}, {status: {eq: "pending"}}]}` |
-| `NOT` | `NOT` | Negate condition | `{NOT: {status: {eq: "deleted"}}}` |
-
-**Default Behavior**:
-
-- Multiple conditions at same level are ANDed by default
-- Explicit AND/OR for clarity and complex logic
-
-**Examples**:
+Operators across fields and families compose freely in a single `where:` input:
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Implicit AND (default)
-{
-  status: {eq: "active"},
-  age: {gte: 18}
+query {
+  products(where: {
+    AND: [
+      { price: { gte: 100, lte: 500 } },
+      { tags: { overlaps: ["featured", "bestseller"] } },
+      { name: { icontains: "pro" } },
+      { discontinuedAt: { isnull: true } }
+    ]
+  }) {
+    id
+    name
+    price
+  }
 }
-
-# Explicit AND (more readable)
-{
-  AND: [
-    {status: {eq: "active"}},
-    {age: {gte: 18}},
-    {country: {eq: "US"}}
-  ]
-}
-
-# OR logic
-{
-  OR: [
-    {status: {eq: "vip"}},
-    {purchaseTotal: {gte: 10000}}
-  ]
-}
-
-# NOT logic
-{
-  NOT: {status: {eq: "banned"}}
-}
-
-# Complex nested logic
-{
-  AND: [
-    {age: {gte: 18}},
-    {OR: [
-      {status: {eq: "active"}},
-      {status: {eq: "pending"}}
-    ]},
-    {NOT: {email: {isnull: true}}}
-  ]
-}
-
-# De Morgan's Law example
-# Not (A AND B) = (Not A) OR (Not B)
-{
-  OR: [
-    {NOT: {age: {gte: 18}}},
-    {NOT: {status: {eq: "active"}}}
-  ]
-}
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
-### 15. Boolean Operators
+## Performance Notes
 
-Boolean operators work with boolean columns.
+WHERE operators translate to PostgreSQL expressions, so the relevant PostgreSQL indexing strategies apply:
 
-| Operator | Description | Example |
-|----------|---|---|
-| `eq` | Boolean equality | `{isActive: {eq: true}}` |
-| `neq` | Boolean inequality | `{isActive: {neq: false}}` |
-| `isnull` | Check if NULL | `{isActive: {isnull: false}}` |
+| Field type | Recommended index | Operators it accelerates |
+|------------|-------------------|--------------------------|
+| Text / scalar | B-tree | `eq`, `gt`, `gte`, `lt`, `lte`, `in` |
+| Text pattern (`LIKE`/`ILIKE`) | `pg_trgm` GIN/GiST | `contains`, `icontains`, `startswith`, `like`, `ilike` |
+| JSONB / array | GIN | `contains`, `contained_by`, `overlaps` |
+| `ltree` | GiST | `ancestor_of`, `descendant_of`, `matches_lquery` |
+| `vector` (pgvector) | HNSW / IVFFlat | distance operators |
 
-**Examples**:
+Tips:
 
-```graphql
-<!-- Code example in GraphQL -->
-# Active users
-{isActive: {eq: true}}
-
-# Non-deleted records
-{isDeleted: {eq: false}}
-
-# Required boolean fields
-{isVerified: {isnull: false}}
-
-# Inactive AND unverified
-{AND: [{isActive: {eq: false}}, {isVerified: {eq: false}}]}
-```text
-<!-- Code example in TEXT -->
+1. Filter on indexed fields where possible.
+2. Combine narrow filters with `AND` to reduce the candidate set early.
+3. Anchored patterns (`startswith` / `LIKE 'value%'`) use B-tree indexes; unanchored substring patterns benefit from a `pg_trgm` index.
+4. Add a GIN index on JSONB array fields you filter with `contains` / `overlaps`.
 
 ---
 
-## Operator Combinations
+## See Also
 
-Operators can be combined in complex queries:
-
-### Complex Query Examples
-
-```graphql
-<!-- Code example in GraphQL -->
-# Users aged 18-65, active, from specific countries
-{
-  AND: [
-    {age: {gte: 18, lte: 65}},
-    {status: {eq: "active"}},
-    {country: {in: ["US", "CA", "MX"]}}
-  ]
-}
-
-# Products in price range, with matching tags
-{
-  AND: [
-    {price: {gte: 100, lte: 500}},
-    {tags: {overlaps: ["featured", "bestseller"]}}
-  ]
-}
-
-# Articles matching search OR by author
-{
-  OR: [
-    {content: {matches: "postgresql & graphql"}},
-    {author: {icontains: "Smith"}}
-  ]
-}
-
-# Locations within distance with specific properties
-{
-  AND: [
-    {location: {distance_within: ((40.7128, -74.0060), 10000)}},
-    {type: {eq: "restaurant"}},
-    {rating: {gte: 4.0}}
-  ]
-}
-
-# Hierarchical filtering
-{
-  AND: [
-    {category: {descendant_of: "Products.Electronics"}},
-    {inStock: {eq: true}},
-    {OR: [
-      {discount: {gte: 20}},
-      {price: {lt: 100}}
-    ]}
-  ]
-}
-
-# Full-text search with filters
-{
-  AND: [
-    {content: {matches: "machine & learning"}},
-    {createdAt: {gte: "2024-01-01"}},
-    {NOT: {archived: {eq: true}}}
-  ]
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Performance Considerations
-
-### Indexing Recommendations
-
-| Column Type | Recommended Indexes | Operators | Notes |
-|----------|---|---|---|
-| String | B-tree | contains, icontains, startswith, like | Pattern matching slower without indexes |
-| Numeric | B-tree | gt, gte, lt, lte, between | Range queries benefit from B-tree |
-| UUID | B-tree | eq, in | Fast lookups |
-| INET/CIDR | GiST | insubnet, overlaps, isprivate | GiST indexes optimal |
-| tsvector | GIN | matches, plain_query, phrase_query | Full-text search requires GIN |
-| ltree | GiST | ancestor_of, descendant_of, matches_lquery | Hierarchical queries benefit from GiST |
-| vector (pgvector) | IVFFlat or HNSW | cosine_distance, l2_distance | Vector indexes critical for performance |
-| point | GiST | distance_within | Spatial indexes improve distance queries |
-| daterange | GiST | overlaps, contains_date, adjacent | Range queries benefit from GiST |
-
-### Query Optimization Tips
-
-1. **Use indexed operators**: Operators matching indexes execute faster
-2. **Combine filters**: AND multiple simple filters before OR
-3. **Filter early**: Narrow results early to reduce downstream computation
-4. **Use specific types**: Choose typed operators over generic fallbacks
-5. **Limit vector searches**: Use tight thresholds to reduce result set
-6. **Regular expression complexity**: Simple patterns faster than complex regex
-7. **JSONB path indexes**: Consider indexes on frequently queried JSONB paths
-
----
-
-## Error Handling
-
-Invalid operator/type combinations return GraphQL errors:
-
-```graphql
-<!-- Code example in GraphQL -->
-# Error: `matches` not supported for numeric fields
-{age: {matches: "^2[0-9]$"}}
-# GraphQL Error: "Operator 'matches' not supported for type 'integer'"
-
-# Error: `distance_within` requires valid distance value
-{location: {distance_within: (40.7128, -74.0060)}}
-# GraphQL Error: "Operator 'distance_within' requires distance parameter"
-
-# Error: `array_contains` for non-array field
-{name: {contains: ["a", "b"]}}
-# GraphQL Error: "Operator 'array_contains' not supported for type 'string'"
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Summary
-
-FraiseQL's 150+ WHERE clause operators provide:
-
-✅ **Type Safety**: Operators validated per column type
-✅ **SQL Efficiency**: Direct translation to optimal SQL
-✅ **Flexibility**: 15 categories covering all use cases
-✅ **Readability**: Intuitive, chainable syntax
-✅ **Performance**: Indexable operators, efficient execution
-✅ **Specialized Features**: Vector search, full-text, hierarchies, geospatial
-
-Whether filtering simple strings, searching text, querying hierarchies, or finding nearby coordinates, FraiseQL's operators provide efficient, type-safe solutions.
+- [LTree operators](./ltree-operators.md) — hierarchical path filtering
+- [Vector operators](./vector-operators.md) — pgvector similarity search
+- [Scalars reference](./scalars.md) — scalar types accepted by these operators
+- [Type system](../foundation/09-type-system.md) — how fields and types are defined

--- a/docs/specs/aggregation-operators.md
+++ b/docs/specs/aggregation-operators.md
@@ -1,626 +1,276 @@
-<!-- Skip to main content -->
 ---
-
-title: Aggregation Operators Specification
-description: This specification defines the aggregation operators available in FraiseQL, organized by database target and phase of implementation.
-keywords: ["format", "compliance", "protocol", "specification", "standard"]
+title: Aggregation Operators Reference
+description: PostgreSQL aggregate functions supported by FraiseQL v1 runtime auto-aggregation, plus the standard SQL aggregates you can use directly inside your views.
+keywords: ["aggregation", "group by", "having", "postgresql", "analytics", "reference"]
 tags: ["documentation", "reference"]
 ---
 
-# Aggregation Operators Specification
+# Aggregation Operators Reference
 
-**Version:** 1.0
-**Status:** Complete
-**Audience:** Compiler developers, SDK maintainers
-**Date:** January 12, 2026
+**Status:** Stable
 
 ---
 
 ## Overview
 
-This specification defines the aggregation operators available in FraiseQL, organized by database target and phase of implementation.
+FraiseQL v1 performs **runtime auto-aggregation** against PostgreSQL. When a GraphQL
+query selects aggregate fields on a view-backed type, FraiseQL derives the matching
+`GROUP BY` and aggregate SQL automatically and runs it against your `v_`/`tv_` view.
+There is no build step, no compiler, and no schema artifact — everything happens at
+app startup and request time. FraiseQL v1 targets **PostgreSQL only**.
 
-**Phases**:
+Auto-aggregation is implemented by `_derive_auto_aggregation` (with
+`_parse_aggregation_expr`) in `src/fraiseql/db.py`. The aggregate expressions you
+declare per type are parsed and validated against an allowlist, then composed into a
+parameterized `SELECT ... GROUP BY` statement against the registered view.
 
-- **Phase 1-2** (✅ Complete): Basic aggregates (COUNT, SUM, AVG, MIN, MAX, STDDEV, VARIANCE)
-- **Phase 3** (📋 Planned): Advanced aggregates (ARRAY_AGG, JSON_AGG, STRING_AGG, BOOL_AND/OR)
-- **Phase 4** (📋 Planned): Auto-generated GraphQL types (perfect for v2 compiler!)
+This document covers two related things:
 
----
-
-## Capability Manifest Extension
-
-The capability manifest defines which operators are available for each database target.
-
-### PostgreSQL Aggregation Operators
-
-```json
-<!-- Code example in JSON -->
-{
-  "postgresql": {
-    "aggregation": {
-      "basic": [
-        { "function": "COUNT", "sql": "COUNT", "return_type": "Int" },
-        { "function": "COUNT_DISTINCT", "sql": "COUNT(DISTINCT $field)", "return_type": "Int" },
-        { "function": "SUM", "sql": "SUM", "return_type": "Numeric" },
-        { "function": "AVG", "sql": "AVG", "return_type": "Float" },
-        { "function": "MIN", "sql": "MIN", "return_type": "Same as input" },
-        { "function": "MAX", "sql": "MAX", "return_type": "Same as input" }
-      ],
-      "statistical": [
-        { "function": "STDDEV", "sql": "STDDEV", "return_type": "Float" },
-        { "function": "STDDEV_POP", "sql": "STDDEV_POP", "return_type": "Float" },
-        { "function": "STDDEV_SAMP", "sql": "STDDEV_SAMP", "return_type": "Float" },
-        { "function": "VARIANCE", "sql": "VARIANCE", "return_type": "Float" },
-        { "function": "VAR_POP", "sql": "VAR_POP", "return_type": "Float" },
-        { "function": "VAR_SAMP", "sql": "VAR_SAMP", "return_type": "Float" },
-        { "function": "PERCENTILE_CONT", "sql": "PERCENTILE_CONT($fraction) WITHIN GROUP (ORDER BY $field)", "return_type": "Float" },
-        { "function": "PERCENTILE_DISC", "sql": "PERCENTILE_DISC($fraction) WITHIN GROUP (ORDER BY $field)", "return_type": "Same as input" }
-      ],
-      "advanced": [
-        { "function": "ARRAY_AGG", "sql": "ARRAY_AGG", "return_type": "Array", "phase": 3 },
-        { "function": "JSON_AGG", "sql": "JSON_AGG", "return_type": "JSON", "phase": 3 },
-        { "function": "JSONB_AGG", "sql": "JSONB_AGG", "return_type": "JSONB", "phase": 3 },
-        { "function": "STRING_AGG", "sql": "STRING_AGG($field, $separator)", "return_type": "String", "phase": 3 },
-        { "function": "BOOL_AND", "sql": "BOOL_AND", "return_type": "Boolean", "phase": 3 },
-        { "function": "BOOL_OR", "sql": "BOOL_OR", "return_type": "Boolean", "phase": 3 }
-      ],
-      "temporal_bucketing": [
-        { "function": "DATE_TRUNC", "sql": "DATE_TRUNC", "buckets": ["second", "minute", "hour", "day", "week", "month", "quarter", "year"] }
-      ],
-      "conditional": [
-        { "function": "FILTER", "sql": "... FILTER (WHERE ...)", "supported": true }
-      ]
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-### MySQL Aggregation Operators
-
-```json
-<!-- Code example in JSON -->
-{
-  "mysql": {
-    "aggregation": {
-      "basic": [
-        { "function": "COUNT", "sql": "COUNT", "return_type": "Int" },
-        { "function": "COUNT_DISTINCT", "sql": "COUNT(DISTINCT $field)", "return_type": "Int" },
-        { "function": "SUM", "sql": "SUM", "return_type": "Numeric" },
-        { "function": "AVG", "sql": "AVG", "return_type": "Float" },
-        { "function": "MIN", "sql": "MIN", "return_type": "Same as input" },
-        { "function": "MAX", "sql": "MAX", "return_type": "Same as input" }
-      ],
-      "statistical": [
-        { "function": "STDDEV", "sql": "STDDEV", "return_type": "Float", "note": "Sample standard deviation" },
-        { "function": "STDDEV_POP", "sql": "STDDEV_POP", "return_type": "Float" },
-        { "function": "STDDEV_SAMP", "sql": "STDDEV_SAMP", "return_type": "Float" },
-        { "function": "VARIANCE", "sql": "VARIANCE", "return_type": "Float", "note": "Sample variance" },
-        { "function": "VAR_POP", "sql": "VAR_POP", "return_type": "Float" },
-        { "function": "VAR_SAMP", "sql": "VAR_SAMP", "return_type": "Float" }
-      ],
-      "advanced": [
-        { "function": "GROUP_CONCAT", "sql": "GROUP_CONCAT($field SEPARATOR $separator)", "return_type": "String", "phase": 3, "note": "Similar to STRING_AGG" },
-        { "function": "JSON_ARRAYAGG", "sql": "JSON_ARRAYAGG", "return_type": "JSON", "phase": 3 },
-        { "function": "JSON_OBJECTAGG", "sql": "JSON_OBJECTAGG($key, $value)", "return_type": "JSON", "phase": 3 }
-      ],
-      "temporal_bucketing": [
-        { "function": "DATE_FORMAT", "sql": "DATE_FORMAT", "buckets": ["day", "week", "month", "year"], "note": "Limited bucket support" }
-      ],
-      "conditional": [
-        { "function": "FILTER", "sql": "CASE WHEN ... THEN ... END", "supported": "emulated" }
-      ]
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-### SQLite Aggregation Operators
-
-```json
-<!-- Code example in JSON -->
-{
-  "sqlite": {
-    "aggregation": {
-      "basic": [
-        { "function": "COUNT", "sql": "COUNT", "return_type": "Int" },
-        { "function": "COUNT_DISTINCT", "sql": "COUNT(DISTINCT $field)", "return_type": "Int" },
-        { "function": "SUM", "sql": "SUM", "return_type": "Numeric" },
-        { "function": "AVG", "sql": "AVG", "return_type": "Float" },
-        { "function": "MIN", "sql": "MIN", "return_type": "Same as input" },
-        { "function": "MAX", "sql": "MAX", "return_type": "Same as input" }
-      ],
-      "statistical": [],
-      "advanced": [
-        { "function": "GROUP_CONCAT", "sql": "GROUP_CONCAT($field, $separator)", "return_type": "String", "phase": 3 }
-      ],
-      "temporal_bucketing": [
-        { "function": "strftime", "sql": "strftime", "buckets": ["day", "week", "month", "year"] }
-      ],
-      "conditional": [
-        { "function": "FILTER", "sql": "CASE WHEN ... THEN ... END", "supported": "emulated" }
-      ]
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-### SQL Server Aggregation Operators
-
-```json
-<!-- Code example in JSON -->
-{
-  "sqlserver": {
-    "aggregation": {
-      "basic": [
-        { "function": "COUNT", "sql": "COUNT", "return_type": "Int" },
-        { "function": "COUNT_DISTINCT", "sql": "COUNT(DISTINCT $field)", "return_type": "Int" },
-        { "function": "SUM", "sql": "SUM", "return_type": "Numeric" },
-        { "function": "AVG", "sql": "AVG", "return_type": "Float" },
-        { "function": "MIN", "sql": "MIN", "return_type": "Same as input" },
-        { "function": "MAX", "sql": "MAX", "return_type": "Same as input" }
-      ],
-      "statistical": [
-        { "function": "STDEV", "sql": "STDEV", "return_type": "Float", "note": "Sample standard deviation" },
-        { "function": "STDEVP", "sql": "STDEVP", "return_type": "Float", "note": "Population standard deviation" },
-        { "function": "VAR", "sql": "VAR", "return_type": "Float", "note": "Sample variance" },
-        { "function": "VARP", "sql": "VARP", "return_type": "Float", "note": "Population variance" }
-      ],
-      "advanced": [
-        { "function": "STRING_AGG", "sql": "STRING_AGG($field, $separator)", "return_type": "String", "phase": 3, "note": "Requires SQL Server 2017+" }
-      ],
-      "temporal_bucketing": [
-        { "function": "DATEPART", "sql": "DATEPART", "buckets": ["day", "week", "month", "quarter", "year", "hour", "minute"] }
-      ],
-      "conditional": [
-        { "function": "FILTER", "sql": "CASE WHEN ... THEN ... END", "supported": "emulated" }
-      ],
-      "json": [
-        { "function": "JSON_VALUE", "sql": "JSON_VALUE", "supported": true },
-        { "function": "JSON_QUERY", "sql": "JSON_QUERY", "supported": true },
-        { "function": "FOR_JSON", "sql": "FOR JSON PATH", "supported": true, "phase": 3, "note": "Output formatting" }
-      ]
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
+1. The aggregate functions FraiseQL knows how to **derive automatically** at runtime.
+2. The standard PostgreSQL aggregate, grouping, and bucketing constructs you write
+   **directly in your view SQL** when you need behavior beyond auto-aggregation.
 
 ---
 
-## GraphQL Schema Generation
+## Supported aggregate functions
 
-For a fact table `tf_sales` with measures `revenue`, `quantity`, compiler generates database-specific aggregate types.
+The following PostgreSQL aggregates are available for analytics over view-backed types:
 
-### PostgreSQL Target (Full Support)
+| Function   | SQL          | Returns          | Notes |
+|------------|--------------|------------------|-------|
+| `COUNT`    | `COUNT(...)` | integer          | Row counts; `COUNT(DISTINCT col)` for distinct counts. |
+| `SUM`      | `SUM(...)`   | numeric          | Totals over a measure column. |
+| `AVG`      | `AVG(...)`   | double precision | Mean of a measure column. |
+| `MIN`      | `MIN(...)`   | same as input    | Smallest value in the group. |
+| `MAX`      | `MAX(...)`   | same as input    | Largest value in the group. |
+| `STDDEV`   | `STDDEV(...)`| double precision | Sample standard deviation. |
+| `VARIANCE` | `VARIANCE(...)` | double precision | Sample variance. |
 
-```graphql
-<!-- Code example in GraphQL -->
-type SalesAggregate {
-  # Basic aggregates
-  count: Int!
-  revenue_sum: Float
-  revenue_avg: Float
-  revenue_min: Float
-  revenue_max: Float
-  revenue_stddev: Float      # PostgreSQL only
-  revenue_variance: Float    # PostgreSQL only
-  quantity_sum: Int
-  quantity_avg: Float
-  quantity_min: Int
-  quantity_max: Int
+`COUNT`, `SUM`, `AVG`, `MIN`, and `MAX` are wired into runtime auto-aggregation and can
+be derived from the field selection (see below). `STDDEV` and `VARIANCE` are standard
+PostgreSQL aggregates: compute them in your view SQL (or a dedicated analytics view) and
+expose the result as an ordinary field.
 
-  # Grouped dimensions
-  category: String
-  region: String
-  occurred_at_day: String
-  occurred_at_week: String
-  occurred_at_month: String
-}
-
-input SalesGroupByInput {
-  category: Boolean
-  region: Boolean
-  customer_segment: Boolean
-  occurred_at_day: Boolean
-  occurred_at_week: Boolean
-  occurred_at_month: Boolean
-  occurred_at_quarter: Boolean
-  occurred_at_year: Boolean
-}
-
-input SalesHavingInput {
-  count_eq: Int
-  count_gt: Int
-  count_gte: Int
-  revenue_sum_eq: Float
-  revenue_sum_gt: Float
-  revenue_sum_gte: Float
-  revenue_avg_eq: Float
-  revenue_avg_gt: Float
-  revenue_avg_gte: Float
-}
-
-type Query {
-  sales_aggregate(
-    where: SalesWhereInput
-    groupBy: SalesGroupByInput
-    having: SalesHavingInput
-    orderBy: [OrderByInput!]
-    limit: Int
-    offset: Int
-  ): [SalesAggregate!]!
-}
-```text
-<!-- Code example in TEXT -->
-
-### MySQL Target (Good Support)
-
-```graphql
-<!-- Code example in GraphQL -->
-type SalesAggregate {
-  # Basic aggregates (same as PostgreSQL)
-  count: Int!
-  revenue_sum: Float
-  revenue_avg: Float
-  revenue_min: Float
-  revenue_max: Float
-  revenue_stddev: Float      # MySQL has STDDEV
-  revenue_variance: Float    # MySQL has VARIANCE
-  quantity_sum: Int
-  quantity_avg: Float
-
-  # NO advanced aggregates in Phase 1-2
-  # Phase 3 will add GROUP_CONCAT, JSON_ARRAYAGG
-
-  # Grouped dimensions
-  category: String
-  region: String
-  occurred_at_day: String
-  occurred_at_month: String
-  occurred_at_year: String
-  # NO quarter bucket
-}
-```text
-<!-- Code example in TEXT -->
-
-### SQLite Target (Basic Support)
-
-```graphql
-<!-- Code example in GraphQL -->
-type SalesAggregate {
-  # Basic aggregates only
-  count: Int!
-  revenue_sum: Float
-  revenue_avg: Float
-  revenue_min: Float
-  revenue_max: Float
-  # NO stddev/variance
-  quantity_sum: Int
-  quantity_avg: Float
-
-  # Grouped dimensions
-  category: String
-  region: String
-  occurred_at_day: String
-  occurred_at_month: String
-  occurred_at_year: String
-}
-```text
-<!-- Code example in TEXT -->
-
-### SQL Server Target (Enterprise Support)
-
-```graphql
-<!-- Code example in GraphQL -->
-type SalesAggregate {
-  # Basic aggregates
-  count: Int!
-  revenue_sum: Float
-  revenue_avg: Float
-  revenue_min: Float
-  revenue_max: Float
-  revenue_stdev: Float       # SQL Server: STDEV
-  revenue_variance: Float    # SQL Server: VAR
-  quantity_sum: Int
-  quantity_avg: Float
-
-  # Grouped dimensions
-  category: String
-  region: String
-  occurred_at_day: String
-  occurred_at_week: String
-  occurred_at_month: String
-  occurred_at_quarter: String
-  occurred_at_year: String
-}
-```text
-<!-- Code example in TEXT -->
+`SUM` and `AVG` operate on numeric inputs. When a measure is read from a JSONB `data`
+column, FraiseQL casts the extracted text to `numeric` before applying the aggregate;
+when the measure is a native numeric column (see `native_measures`), it aggregates the
+column directly and avoids the cast.
 
 ---
 
-## Phase 3: Advanced Aggregate Functions
+## How runtime auto-aggregation works
 
-**Status**: Implemented (database-dependent availability)
+Auto-aggregation kicks in when a query selects only **dimensions** and **measures** on a
+view-backed type — that is, when no identity field (such as `id`) is requested. FraiseQL
+then:
+
+1. Reads the field selection from the GraphQL query.
+2. Looks up the type's aggregation metadata (registered via `register_type_for_view`).
+3. Splits the selected fields into `GROUP BY` dimensions and aggregate measures.
+4. Builds a parameterized `SELECT <dimensions>, <aggregates> FROM <view> GROUP BY
+   <dimensions>` and executes it.
+
+Aggregate expressions are declared as strings like `SUM(cost)` or `AVG(volume)` and are
+validated against the allowlist before any SQL is composed, so the function name can
+never be injected.
+
+### Registering aggregation metadata
+
+Attach aggregation metadata to a view-backed type with `register_type_for_view`:
+
+```python
+from fraiseql.db import register_type_for_view
+
+register_type_for_view(
+    view_name="v_sales_summary",
+    type_class=SalesSummary,
+    aggregation={
+        "measures": {
+            "measures.revenue": "SUM",
+            "measures.quantity": "SUM",
+        },
+        "dimensions": "dimensions",
+        "native_dimensions": ["period_date", "category_id"],
+        "native_measures": {"measures.quantity": "quantity"},
+        "native_dimension_mapping": {"dimensions.category.id": "category_id"},
+    },
+)
+```
+
+Metadata keys:
+
+- `measures` — maps a JSONB measure path to the aggregate function to apply
+  (`"SUM"`, `"AVG"`, etc.).
+- `dimensions` — the JSONB key (default `"data"` substructure) holding grouping
+  attributes.
+- `native_dimensions` — SQL columns that should be grouped via `t."col"` instead of
+  JSONB extraction. Native columns let PostgreSQL use btree indexes and keep `ORDER BY`
+  correct for dimension columns.
+- `native_measures` — maps JSONB measure paths to flat SQL column names so `SUM`/`AVG`
+  run on native numeric columns and skip the `::numeric` cast.
+- `native_dimension_mapping` — maps deep JSONB dimension paths to flat SQL columns so
+  `GROUP BY` can use native columns even for nested dimension paths.
+
+Use `native_dimensions` whenever your view exposes a real SQL column for a grouping key:
+it is the difference between a sequential scan over extracted JSONB text and an
+index-backed `GROUP BY`.
+
+---
+
+## Aggregation in view SQL
+
+For anything beyond derived `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` — including `STDDEV`,
+`VARIANCE`, conditional aggregates, time bucketing, and the array/JSON/string aggregates
+below — write standard PostgreSQL in your `v_`/`tv_` view. FraiseQL reads the resulting
+rows like any other view.
+
+### GROUP BY
+
+```sql
+SELECT
+    data->>'category'          AS category,
+    SUM((data->>'revenue')::numeric)  AS revenue_sum,
+    AVG((data->>'revenue')::numeric)  AS revenue_avg,
+    COUNT(*)                   AS order_count
+FROM tv_sales
+GROUP BY data->>'category';
+```
+
+### HAVING
+
+Filter groups after aggregation with `HAVING`:
+
+```sql
+SELECT
+    data->>'category'                 AS category,
+    SUM((data->>'revenue')::numeric)  AS revenue_sum
+FROM tv_sales
+GROUP BY data->>'category'
+HAVING SUM((data->>'revenue')::numeric) > 10000;
+```
+
+### Conditional aggregates with FILTER
+
+`FILTER (WHERE ...)` computes an aggregate over a subset of rows in the same pass — the
+idiomatic PostgreSQL way to do conditional sums and counts:
+
+```sql
+SELECT
+    data->>'region'                                          AS region,
+    COUNT(*)                                                 AS total_orders,
+    COUNT(*) FILTER (WHERE (data->>'status') = 'shipped')    AS shipped_orders,
+    SUM((data->>'revenue')::numeric)
+        FILTER (WHERE (data->>'on_sale')::boolean)           AS sale_revenue
+FROM tv_sales
+GROUP BY data->>'region';
+```
+
+### Time bucketing with DATE_TRUNC
+
+Bucket a timestamp into fixed periods with `DATE_TRUNC`. Supported buckets include
+`second`, `minute`, `hour`, `day`, `week`, `month`, `quarter`, and `year`:
+
+```sql
+SELECT
+    DATE_TRUNC('month', (data->>'occurred_at')::timestamptz) AS bucket_month,
+    SUM((data->>'revenue')::numeric)                         AS revenue_sum
+FROM tv_sales
+GROUP BY DATE_TRUNC('month', (data->>'occurred_at')::timestamptz)
+ORDER BY bucket_month;
+```
+
+Expose the bucket as a regular column and group on it. For dimension columns that you
+group on, prefer a native SQL column (and list it in `native_dimensions`) so the
+`GROUP BY` and `ORDER BY` can use an index.
+
+---
+
+## Array, JSON, and string aggregates
+
+PostgreSQL provides several aggregates that collapse a group into a single composite
+value. Use them **directly in your view SQL**; expose the result as a field on the
+view-backed type.
 
 ### ARRAY_AGG
 
-Aggregate values into an array.
-
-**PostgreSQL**:
+Collect group values into an array:
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
-    data->>'category' AS category,
+    data->>'category'                AS category,
     ARRAY_AGG(data->>'product_name') AS product_names
-FROM tf_sales
+FROM tv_sales
 GROUP BY data->>'category';
-```text
-<!-- Code example in TEXT -->
-
-**MySQL**:
-
-```sql
-<!-- Code example in SQL -->
--- Use JSON_ARRAYAGG instead
-SELECT
-    JSON_EXTRACT(data, '$.category') AS category,
-    JSON_ARRAYAGG(JSON_EXTRACT(data, '$.product_name')) AS product_names
-FROM tf_sales
-GROUP BY JSON_EXTRACT(data, '$.category');
-```text
-<!-- Code example in TEXT -->
-
-**SQLite**: Not supported
-
-**SQL Server**: Not directly supported (use FOR JSON)
+```
 
 ### JSON_AGG / JSONB_AGG
 
-Aggregate rows into JSON.
-
-**PostgreSQL**:
+Collect rows into a JSON array — useful for building nested read models inside a `tv_`
+projection view:
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
     data->>'customer_id' AS customer_id,
     JSONB_AGG(jsonb_build_object(
         'product', data->>'product_name',
-        'revenue', revenue
+        'revenue', (data->>'revenue')::numeric
     )) AS orders
-FROM tf_sales
+FROM tv_sales
 GROUP BY data->>'customer_id';
-```text
-<!-- Code example in TEXT -->
+```
 
-**MySQL**:
+### STRING_AGG
 
-```sql
-<!-- Code example in SQL -->
-SELECT
-    JSON_EXTRACT(data, '$.customer_id') AS customer_id,
-    JSON_ARRAYAGG(
-        JSON_OBJECT(
-            'product', JSON_EXTRACT(data, '$.product_name'),
-            'revenue', revenue
-        )
-    ) AS orders
-FROM tf_sales
-GROUP BY JSON_EXTRACT(data, '$.customer_id');
-```text
-<!-- Code example in TEXT -->
-
-**SQLite**: Not supported
-
-**SQL Server**:
+Concatenate group values with a delimiter, optionally ordered:
 
 ```sql
-<!-- Code example in SQL -->
--- Use FOR JSON PATH
-SELECT
-    JSON_VALUE(data, '$.customer_id') AS customer_id,
-    (
-        SELECT
-            JSON_VALUE(data, '$.product_name') AS product,
-            revenue
-        FROM tf_sales s2
-        WHERE JSON_VALUE(s2.data, '$.customer_id') = JSON_VALUE(s1.data, '$.customer_id')
-        FOR JSON PATH
-    ) AS orders
-FROM tf_sales s1
-GROUP BY JSON_VALUE(data, '$.customer_id');
-```text
-<!-- Code example in TEXT -->
-
-### STRING_AGG / GROUP_CONCAT
-
-Concatenate strings with delimiter.
-
-**PostgreSQL**:
-
-```sql
-<!-- Code example in SQL -->
 SELECT
     data->>'customer_id' AS customer_id,
-    STRING_AGG(data->>'product_name', ', ' ORDER BY revenue DESC) AS products
-FROM tf_sales
+    STRING_AGG(data->>'product_name', ', ' ORDER BY (data->>'revenue')::numeric DESC)
+        AS products
+FROM tv_sales
 GROUP BY data->>'customer_id';
-```text
-<!-- Code example in TEXT -->
-
-**MySQL**:
-
-```sql
-<!-- Code example in SQL -->
-SELECT
-    JSON_EXTRACT(data, '$.customer_id') AS customer_id,
-    GROUP_CONCAT(JSON_EXTRACT(data, '$.product_name') ORDER BY revenue DESC SEPARATOR ', ') AS products
-FROM tf_sales
-GROUP BY JSON_EXTRACT(data, '$.customer_id');
-```text
-<!-- Code example in TEXT -->
-
-**SQLite**:
-
-```sql
-<!-- Code example in SQL -->
-SELECT
-    json_extract(data, '$.customer_id') AS customer_id,
-    GROUP_CONCAT(json_extract(data, '$.product_name'), ', ') AS products
-FROM tf_sales
-GROUP BY json_extract(data, '$.customer_id');
-```text
-<!-- Code example in TEXT -->
-
-**SQL Server**:
-
-```sql
-<!-- Code example in SQL -->
-SELECT
-    JSON_VALUE(data, '$.customer_id') AS customer_id,
-    STRING_AGG(JSON_VALUE(data, '$.product_name'), ', ') AS products
-FROM tf_sales
-GROUP BY JSON_VALUE(data, '$.customer_id');
-```text
-<!-- Code example in TEXT -->
+```
 
 ### BOOL_AND / BOOL_OR
 
-Boolean aggregates (all true / any true).
-
-**PostgreSQL**:
+Boolean aggregates — "all true" and "any true" across a group:
 
 ```sql
-<!-- Code example in SQL -->
 SELECT
-    data->>'category' AS category,
-    BOOL_AND((data->>'in_stock')::boolean) AS all_in_stock,
-    BOOL_OR((data->>'on_sale')::boolean) AS any_on_sale
-FROM tf_sales
+    data->>'category'                       AS category,
+    BOOL_AND((data->>'in_stock')::boolean)  AS all_in_stock,
+    BOOL_OR((data->>'on_sale')::boolean)    AS any_on_sale
+FROM tv_sales
 GROUP BY data->>'category';
-```text
-<!-- Code example in TEXT -->
-
-**MySQL/SQLite/SQL Server**: Emulate with MIN/MAX on boolean values or CASE WHEN.
+```
 
 ---
 
-## Compilation Rules
+## Choosing measure and dimension columns
 
-### Measure Column Detection
+When modeling a view for aggregation:
 
-**Criteria**:
+- **Measures** are numeric values you aggregate (`revenue`, `quantity`). Store them as
+  native numeric columns where possible and reference them through `native_measures` to
+  avoid per-row JSONB casts.
+- **Dimensions** are the attributes you group by (`category`, `region`, a `DATE_TRUNC`
+  bucket). Surface them as native SQL columns and list them in `native_dimensions` so
+  PostgreSQL can use btree indexes for `GROUP BY` and `ORDER BY`.
+- Never expose internal keys (`pk_*`, `fk_*`) as dimensions; group on the public `id`
+  (UUID), `identifier`, or a derived dimension column instead.
 
-- Numeric type: INT, BIGINT, DECIMAL, FLOAT, NUMERIC, REAL, DOUBLE PRECISION
-- Non-nullable preferred (but nullable allowed)
-- Excluded by convention: `id`, `created_at`, `updated_at`
-
-**Example**:
-
-```rust
-<!-- Code example in RUST -->
-fn is_measure_column(column: &Column) -> bool {
-    let numeric_types = ["int", "bigint", "decimal", "float", "numeric", "real", "double"];
-    let excluded_names = ["id", "created_at", "updated_at"];
-
-    numeric_types.contains(&column.data_type.to_lowercase().as_str())
-        && !excluded_names.contains(&column.name.to_lowercase().as_str())
-}
-```text
-<!-- Code example in TEXT -->
-
-### Dimension Path Detection
-
-**Criteria**:
-
-- References JSONB column (default: `data`)
-- Supports nested paths: `data->>'key'`, `data#>>'{path,to,key}'`
-- Database-specific operators from capability manifest
-
-**Example**:
-
-```rust
-<!-- Code example in RUST -->
-fn extract_dimension(column_name: &str, jsonb_column: &str) -> String {
-    match database_target {
-        "postgresql" => format!("{}->>'{}' AS {}", jsonb_column, column_name, column_name),
-        "mysql" => format!("JSON_EXTRACT({}, '$.{}') AS {}", jsonb_column, column_name, column_name),
-        "sqlite" => format!("json_extract({}, '$.{}') AS {}", jsonb_column, column_name, column_name),
-        "sqlserver" => format!("JSON_VALUE({}, '$.{}') AS {}", jsonb_column, column_name, column_name),
-    }
-}
-```text
-<!-- Code example in TEXT -->
-
-### Temporal Bucketing
-
-**PostgreSQL**:
-
-```rust
-<!-- Code example in RUST -->
-fn temporal_bucket_postgres(field: &str, bucket: &str) -> String {
-    format!("DATE_TRUNC('{}', {})", bucket, field)
-}
-```text
-<!-- Code example in TEXT -->
-
-**MySQL**:
-
-```rust
-<!-- Code example in RUST -->
-fn temporal_bucket_mysql(field: &str, bucket: &str) -> String {
-    let format = match bucket {
-        "day" => "%Y-%m-%d",
-        "week" => "%Y-%u",
-        "month" => "%Y-%m",
-        "year" => "%Y",
-        _ => panic!("Unsupported bucket: {}", bucket),
-    };
-    format!("DATE_FORMAT({}, '{}')", field, format)
-}
-```text
-<!-- Code example in TEXT -->
-
-**SQLite**:
-
-```rust
-<!-- Code example in RUST -->
-fn temporal_bucket_sqlite(field: &str, bucket: &str) -> String {
-    let format = match bucket {
-        "day" => "%Y-%m-%d",
-        "week" => "%Y-%W",
-        "month" => "%Y-%m",
-        "year" => "%Y",
-        _ => panic!("Unsupported bucket: {}", bucket),
-    };
-    format!("strftime('{}', {})", format, field)
-}
-```text
-<!-- Code example in TEXT -->
-
-**SQL Server**:
-
-```rust
-<!-- Code example in RUST -->
-fn temporal_bucket_sqlserver(field: &str, bucket: &str) -> String {
-    let part = bucket; // day, week, month, quarter, year
-    format!("DATEPART({}, {})", part, field)
-}
-```text
-<!-- Code example in TEXT -->
+For the full naming conventions, see the schema conventions reference linked below.
 
 ---
 
-## Related Specifications
+## Related references
 
-- **Capability Manifest** (`capability-manifest.md`) - Database-specific operator availability
-- **Aggregation Model** (`../architecture/analytics/aggregation-model.md`) - Compilation and execution
-- **Database Targeting** (`../architecture/database/database-targeting.md`) - Multi-database support
-- **Window Operators** (`window-operators.md`) - Window function reference
-
----
+- [Aggregation Model](../architecture/analytics/aggregation-model.md) — how
+  auto-aggregation derives `GROUP BY` and aggregate SQL at runtime.
+- [Fact / Dimension Pattern](../architecture/analytics/fact-dimension-pattern.md) — data
+  modeling for analytics views in PostgreSQL.
+- [Window Functions](../architecture/analytics/window-functions.md) — `ROW_NUMBER`,
+  `RANK`, `LAG`, `LEAD`, and `OVER (PARTITION BY ...)` patterns for view SQL.
+- [Schema Conventions](./schema-conventions.md) — `tb_`/`v_`/`tv_`/`fn_` prefixes, the
+  trinity identifier pattern, and the `data` JSONB convention.

--- a/docs/specs/schema-conventions.md
+++ b/docs/specs/schema-conventions.md
@@ -1,25 +1,30 @@
-<!-- Skip to main content -->
 ---
-
 title: Schema Conventions Specification
-description: FraiseQL enforces opinionated PostgreSQL schema conventions that enable automatic compilation, efficient filtering, and optimal performance. These conventions a
-keywords: ["format", "compliance", "schema", "protocol", "specification", "standard"]
+description: FraiseQL relies on opinionated PostgreSQL schema conventions for read views, write functions, and identifier columns. The runtime reads these conventions at app startup to build and serve the GraphQL API.
+keywords: ["schema", "conventions", "postgresql", "views", "naming", "specification"]
 tags: ["documentation", "reference"]
 ---
 
 # Schema Conventions Specification
 
 **Version:** 1.0
-**Status:** Draft
+**Status:** Stable
 **Audience:** Database architects, schema designers, DBAs
 
 ---
 
 ## 1. Overview
 
-FraiseQL enforces opinionated PostgreSQL schema conventions that enable automatic compilation, efficient filtering, and optimal performance. These conventions are **mandatory** for FraiseQL to function.
+FraiseQL is a runtime GraphQL framework for PostgreSQL. It relies on a small set of
+opinionated schema conventions so that, at application startup, it can build the GraphQL
+schema in memory and serve it over FastAPI. There is no build or code-generation step — the
+runtime reads your views and functions directly.
 
-**Core principle:** The database schema is the source of truth. The authoring layer declares which views to expose as GraphQL types.
+**Core principle:** The database schema is the source of truth. Your Python decorators
+declare which views to expose as GraphQL types and which functions back your mutations; the
+conventions below let FraiseQL map them efficiently.
+
+These conventions are PostgreSQL-specific. FraiseQL v1 targets PostgreSQL only.
 
 ---
 
@@ -30,7 +35,7 @@ FraiseQL enforces opinionated PostgreSQL schema conventions that enable automati
 | Pattern | Purpose | Example | Notes |
 |---------|---------|---------|-------|
 | `tb_{entity}` | Write table (normalized) | `tb_user`, `tb_post`, `tb_order_item` | Singular entity name |
-| `tb_{entity}_relationship` | Junction/bridge tables | `tb_user_role`, `tb_product_tag` | For many-to-many |
+| `tb_{entity}_{relationship}` | Junction/bridge tables | `tb_user_role`, `tb_product_tag` | For many-to-many |
 
 **Rules:**
 
@@ -38,38 +43,41 @@ FraiseQL enforces opinionated PostgreSQL schema conventions that enable automati
 - Must use snake_case
 - No abbreviations (use `tb_customer`, not `tb_cust`)
 - Entity name should be singular
-- Table exists only if there's a write model for the entity
+- A table exists only if there is a write model for the entity
+
+Write tables are the normalized source of truth. They are never exposed directly to GraphQL —
+queries read from views, and mutations write through `fn_` functions.
 
 ### 2.2 View Naming
 
 | Pattern | Purpose | Example |
 |---------|---------|---------|
-| `v_{entity}` | Base projection (JSON plane) | `v_user`, `v_post` |
-| `v_{entities}_by_{parent}` | Pre-aggregated composition | `v_posts_by_user`, `v_order_items_by_order` |
-| `tv_{entity}` | Table-backed view (JSON plane) | `tv_user_summary` |
+| `v_{entity}` | Logical read view producing a `data` JSONB column | `v_user`, `v_post` |
+| `v_{entities}_by_{parent}` | Pre-aggregated composition view | `v_posts_by_user`, `v_order_items_by_order` |
+| `tv_{entity}` | Table-backed projection view (real table holding pre-composed JSONB) | `tv_user_summary` |
 | `mv_{entity}` | Materialized view (cached) | `mv_user_stats` |
-| `va_{entity}` | Logical view (Arrow plane) | `va_user`, `va_post` |
-| `ta_{entity}` | Table-backed view (Arrow plane) | `ta_user`, `ta_orders` |
 
 **Rules:**
 
-- Base views MUST produce a `data` JSONB column
-- Pre-aggregated views group by foreign key
-- Arrow views are flat, single-level only
+- Read views (`v_`, `tv_`) MUST produce a `data` JSONB column
+- Pre-aggregated views group by the internal foreign key
 - View names must be lowercase snake_case
 
 **When to use each pattern:**
 
-See [View Selection Guide](../architecture/database/view-selection-guide.md) for detailed decision trees:
+See the [View Selection Guide](../architecture/database/view-selection-guide.md) for detailed
+decision trees, and the [tv_ table pattern](../architecture/database/tv-table-pattern.md) for
+table-backed projections:
 
-- `v_*` vs `tv_*`: Logical vs table-backed for JSON/GraphQL queries
-- `va_*` vs `ta_*`: Logical vs table-backed for Arrow/Analytics queries
+- `v_*` is a logical view: the SQL runs on every query, composing the `data` JSONB on the fly.
+  Best for simple to moderate reads.
+- `tv_*` is a real table holding pre-composed JSONB, refreshed by functions or triggers. Best
+  for heavy, deeply nested reads where re-composing JSONB on every query would be too slow.
 
 **Quick decision:**
 
-- Simple queries → `v_*` (JSON) or `va_*` (Arrow)
-- Complex queries with 3+ JOINs → `tv_*` (JSON)
-- Large datasets (>1M rows) → `ta_*` (Arrow)
+- Simple to moderate queries → `v_*` (logical view)
+- Complex queries with 3+ JOINs or deep nesting → `tv_*` (table-backed projection)
 
 ### 2.3 Function Naming (Stored Procedures)
 
@@ -82,8 +90,11 @@ See [View Selection Guide](../architecture/database/view-selection-guide.md) for
 
 - Must be lowercase snake_case
 - Action verbs: `create`, `update`, `delete`, `upsert`, `archive`, etc.
-- Function must return JSON with result data
+- Function returns JSON with the result data (see section 5)
 - Function is transaction-safe
+
+All mutation business logic lives in these PostgreSQL functions. A `@fraiseql.mutation`
+resolver calls them via `db.execute_function("fn_...", {...})`.
 
 ### 2.4 Constraint Naming
 
@@ -95,58 +106,62 @@ See [View Selection Guide](../architecture/database/view-selection-guide.md) for
 | Check | `ck_{table}_{condition}` | `ck_order_amount_positive` |
 | Index | `idx_{table}_{columns}` | `idx_post_created_at` |
 
+For a complete listing of identifier patterns, see
+[Naming Patterns](../reference/naming-patterns.md).
+
 ---
 
 ## 3. Column Conventions
 
-### 3.1 Primary & Foreign Keys
+### 3.1 The Trinity Identifier Pattern
+
+Every entity carries three identifiers with distinct roles:
+
+- `pk_{entity}` — internal `BIGINT` primary key. Used for fast joins. **Never** exposed in GraphQL.
+- `id` — public `UUID` column. Stable external identity, exposed as the GraphQL `id`.
+- `identifier` — optional human-readable `TEXT UNIQUE` slug. Exposed when present.
 
 ```sql
-<!-- Code example in SQL -->
 -- Write table (tb_*)
 CREATE TABLE tb_user (
-    pk_user BIGINTEGER PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
+    pk_user BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
     id UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
-    identifier TEXT NOT NULL UNIQUE,
-    ...
+    identifier TEXT NOT NULL UNIQUE
 );
 
 -- Related write table
 CREATE TABLE tb_post (
-    pk_post INTEGER PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
+    pk_post BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
     id UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
-    fk_user BIGINTEGER NOT NULL REFERENCES tb_user(pk_user),
-    ...
+    fk_user BIGINT NOT NULL REFERENCES tb_user(pk_user)
 );
-```text
-<!-- Code example in TEXT -->
+```
 
 **Rules:**
 
-- Primary key: `pk_{entity}` (INTEGER, auto-generated)
-- Foreign key: `fk_{entity}` (INTEGER, NOT NULL, references pk_*)
-- Public ID: `id` (UUID, exposed via GraphQL)
-- Surrogate key: `identifier` (TEXT, human-readable, indexed)
+- Primary key: `pk_{entity}` (`BIGINT`, auto-generated)
+- Foreign key: `fk_{entity}` (`BIGINT`, references `pk_*`)
+- Public ID: `id` (`UUID`, exposed via GraphQL)
+- Human-readable slug: `identifier` (`TEXT`, indexed)
 
 **Why this dual-key strategy?**
 
 | Key | Type | Purpose | Index |
 |-----|------|---------|-------|
-| `pk_user` | INT | Internal joins, max performance | PRIMARY KEY |
-| `id` | UUID | External references, federation | UNIQUE |
-| `identifier` | TEXT | Human-readable URLs | UNIQUE |
+| `pk_user` | `BIGINT` | Internal joins, max performance | PRIMARY KEY |
+| `id` | `UUID` | External references | UNIQUE |
+| `identifier` | `TEXT` | Human-readable URLs | UNIQUE |
+
+GraphQL exposes `id: ID!` and optionally `identifier: String`, never `pk_*`. Keep `pk_*` and
+`fk_*` out of the `data` JSONB entirely.
 
 ### 3.2 Filterable Foreign Keys in Views
 
 ```sql
-<!-- Code example in SQL -->
--- View includes native FK columns for efficient filtering
+-- View includes a UUID FK column for efficient filtering
 CREATE VIEW v_post AS
 SELECT
-    pk_post,
-    fk_user,
     id,
-    identifier,
     (SELECT id FROM tb_user WHERE pk_user = fk_user) AS user_id,
     jsonb_build_object(
         'id', id,
@@ -158,39 +173,38 @@ FROM tb_post
 WHERE deleted_at IS NULL;
 
 -- Index the foreign key column for fast filtering
-CREATE INDEX idx_v_post_user_id ON v_post(user_id);
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_v_post_user_id ON tb_post(fk_user);
+```
 
 **Rules:**
 
-- Related views expose `{parent}_id` as native column
-- This column is UUID (matches public `id`)
+- Related views expose `{parent}_id` as a native column
+- This column is `UUID` (matches the public `id`)
 - Always indexed for fast filtering
-- Appears in both `data` JSONB and as native column
+- Appears in both the `data` JSONB and as a native column
 
 ### 3.3 Deep Path Filter Columns
 
 For frequently-filtered nested paths, add denormalized columns:
 
 ```sql
-<!-- Code example in SQL -->
 CREATE VIEW v_order AS
 SELECT
-    pk_order,
-    id,
-    identifier,
+    o.id,
 
     -- Direct relationships
     user_id,
 
     -- Deep paths (denormalized for filtering)
-    items__product__category_id,
-    items__product__vendor_id,
-    items__product__tag_ids,
+    paths.items__product__category_id,
+    paths.items__product__vendor_id,
+    paths.items__product__tag_ids,
 
-    jsonb_build_object(...) AS data
-FROM ...
+    jsonb_build_object(
+        'id', o.id
+        -- ... remaining fields ...
+    ) AS data
+FROM tb_order o
 LEFT JOIN LATERAL (
     SELECT
         array_agg(DISTINCT c.id) AS items__product__category_id,
@@ -203,80 +217,74 @@ LEFT JOIN LATERAL (
     LEFT JOIN tb_product_tag pt ON pt.fk_product = p.pk_product
     LEFT JOIN tb_tag t ON t.pk_tag = pt.fk_tag
     WHERE oi.fk_order = o.pk_order
-) paths ON true;
+) paths ON true
+WHERE o.deleted_at IS NULL;
 
--- Index each path column
-CREATE INDEX idx_v_order_items__product__category_id
-  ON v_order USING GIN(items__product__category_id);
-```text
-<!-- Code example in TEXT -->
+-- Index each path column (GIN for array columns)
+CREATE INDEX idx_tb_order_category
+  ON tb_order_item(fk_product);
+```
 
 **Rules:**
 
 - Column name = GraphQL filter path with `__` separators
-- Singular relationships: UUID type
-- Array relationships: UUID[] type
-- Must be indexed (B-tree for UUID, GIN for UUID[])
-- Compiler introspects these columns automatically
+- Singular relationships: `UUID` type
+- Array relationships: `UUID[]` type
+- Must be indexed (B-tree for `UUID`, GIN for `UUID[]`)
+- FraiseQL reads these columns at startup and offers them as filter arguments
 
 ### 3.4 Audit Columns
 
-All tables MUST include audit columns:
+All write tables SHOULD include audit columns:
 
 ```sql
-<!-- Code example in SQL -->
 CREATE TABLE tb_user (
-    pk_user BIGINTEGER PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
+    pk_user BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
     id UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
     email TEXT NOT NULL,
 
     -- Audit columns
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    created_by INTEGER REFERENCES tb_user(pk_user),
+    created_by BIGINT REFERENCES tb_user(pk_user),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_by INTEGER REFERENCES tb_user(pk_user),
+    updated_by BIGINT REFERENCES tb_user(pk_user),
     deleted_at TIMESTAMPTZ,
-    deleted_by INTEGER REFERENCES tb_user(pk_user),
+    deleted_by BIGINT REFERENCES tb_user(pk_user),
 
     CHECK (updated_at >= created_at),
     CHECK (deleted_at >= created_at)
 );
 
--- Trigger to update updated_at
+-- Trigger to maintain updated_at
 CREATE TRIGGER trigger_tb_user_updated_at
 BEFORE UPDATE ON tb_user
 FOR EACH ROW
 EXECUTE FUNCTION update_timestamp();
-```text
-<!-- Code example in TEXT -->
+```
 
 **Rules:**
 
-- `created_at`: TIMESTAMPTZ, NOT NULL, default CURRENT_TIMESTAMP
-- `created_by`: INTEGER FK to user (nullable if system creates it)
-- `updated_at`: TIMESTAMPTZ, NOT NULL, updated by trigger
-- `updated_by`: INTEGER FK to user
-- `deleted_at`: TIMESTAMPTZ, NULL if active (soft delete)
-- `deleted_by`: INTEGER FK to user
+- `created_at`: `TIMESTAMPTZ`, NOT NULL, default `CURRENT_TIMESTAMP`
+- `created_by`: `BIGINT` FK to user (nullable if the system creates the row)
+- `updated_at`: `TIMESTAMPTZ`, NOT NULL, maintained by trigger
+- `updated_by`: `BIGINT` FK to user
+- `deleted_at`: `TIMESTAMPTZ`, NULL if active (soft delete)
+- `deleted_by`: `BIGINT` FK to user
 - Add CHECK constraints to prevent invalid timestamps
 
 **Usage:**
 
 - Views filter on `WHERE deleted_at IS NULL` for soft delete
-- Cache invalidation uses `updated_at` as signal
-- CDC events use audit columns for timestamps
+- Cache invalidation can use `updated_at` as a freshness signal
 
 ### 3.5 Projection Data Column
 
-All views MUST include a `data` JSONB column:
+All read views MUST include a `data` JSONB column:
 
 ```sql
-<!-- Code example in SQL -->
 CREATE VIEW v_user AS
 SELECT
-    pk_user,
     id,
-    identifier,
     jsonb_build_object(
         'id', id,
         'identifier', identifier,
@@ -287,32 +295,34 @@ SELECT
     ) AS data
 FROM tb_user
 WHERE deleted_at IS NULL;
-```text
-<!-- Code example in TEXT -->
+```
 
 **Rules:**
 
-- Column must be named `data`
-- Type: JSONB
-- Contains fully-formed projection in GraphQL field case
-- Must be at the END of SELECT (last column)
+- The column must be named `data` (configurable via `jsonb_column`, default `"data"`)
+- Type: `JSONB`
+- Contains the fully-formed projection in GraphQL field case
+- Place it at the END of the SELECT (last column) by convention
 - Never null (use `{}` for empty objects, `[]` for empty arrays)
+- Never put `pk_*` or `fk_*` inside `data`
 
 **Field naming in JSONB:**
 
 - Convert snake_case to camelCase
 - `created_at` → `createdAt`
 - `user_id` → `userId`
-- Avoid nested objects; flatten or use pre-aggregated views
+
+At startup, FraiseQL maps each `@fraiseql.type` field to a key in this `data` JSONB. The hot
+path reads `data` and shapes it to the requested GraphQL fields (the optional `fraiseql_rs`
+Rust extension accelerates this transformation).
 
 ### 3.6 Reserved Column Names
 
-These columns are reserved by FraiseQL and MUST NOT be used elsewhere:
+These columns have a special meaning to FraiseQL and SHOULD NOT be repurposed:
 
 ```text
-<!-- Code example in TEXT -->
-pk_*         — Primary key (internal only)
-fk_*         — Foreign key (internal only)
+pk_*         — Primary key (internal only, never exposed)
+fk_*         — Foreign key (internal only, never exposed)
 id           — Public identifier (UUID)
 identifier   — Human-readable slug
 *_id         — Filterable FK in views (UUID or UUID[])
@@ -324,8 +334,7 @@ updated_at   — Audit column
 updated_by   — Audit column
 deleted_at   — Audit column (soft delete)
 deleted_by   — Audit column
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -334,12 +343,9 @@ deleted_by   — Audit column
 ### 4.1 Base Entity View
 
 ```sql
-<!-- Code example in SQL -->
 CREATE VIEW v_user AS
 SELECT
-    pk_user,                              -- Internal key
     id,                                   -- Public ID
-    identifier,                           -- Slug
     jsonb_build_object(                   -- Projection
         'id', id,
         'identifier', identifier,
@@ -349,27 +355,20 @@ SELECT
     ) AS data
 FROM tb_user
 WHERE deleted_at IS NULL;                 -- Soft delete
-```text
-<!-- Code example in TEXT -->
+```
 
 **Must include:**
 
-- `pk_*` for internal reference
-- `id` for public identity
-- `identifier` for URLs
+- `id` for public identity (and `WHERE id = $1` lookups)
 - `data` JSONB with camelCase fields
-- Soft delete filter
+- A soft-delete filter
 
 ### 4.2 Related Entity View with Foreign Key
 
 ```sql
-<!-- Code example in SQL -->
 CREATE VIEW v_post AS
 SELECT
-    pk_post,
-    fk_user,
     id,
-    identifier,
     (SELECT id FROM tb_user WHERE pk_user = fk_user) AS user_id,
     jsonb_build_object(
         'id', id,
@@ -381,75 +380,70 @@ SELECT
 FROM tb_post
 WHERE deleted_at IS NULL;
 
--- Index the FK column for filtering
-CREATE INDEX idx_v_post_user_id ON v_post(user_id);
-```text
-<!-- Code example in TEXT -->
+-- Index the underlying FK column for filtering
+CREATE INDEX idx_tb_post_fk_user ON tb_post(fk_user);
+```
 
 **Must include:**
 
-- Native `{parent}_id` column for filtering
-- Index on FK columns
-- FK value in `data` JSONB for clients
+- A native `{parent}_id` (`UUID`) column for filtering
+- An index on the underlying FK column
+- The FK value (as `UUID`) in the `data` JSONB for clients
 
 ### 4.3 Pre-aggregated Composition View
 
 ```sql
-<!-- Code example in SQL -->
--- Group related entities by parent key
+-- Group related entities by the parent key
 CREATE VIEW v_posts_by_user AS
 SELECT
-    fk_user,
-    jsonb_agg(data ORDER BY created_at DESC) AS posts
-FROM v_post
-GROUP BY fk_user;
+    p.fk_user,
+    jsonb_agg(v.data ORDER BY p.created_at DESC) AS posts
+FROM v_post v
+JOIN tb_post p ON p.id = (v.data->>'id')::uuid
+GROUP BY p.fk_user;
 
 -- Composition view joins base + pre-aggregated
 CREATE VIEW v_user_with_posts AS
 SELECT
-    u.pk_user,
     u.id,
-    u.identifier,
-    u.data || jsonb_build_object(
+    (u.data || jsonb_build_object(
         'posts', COALESCE(p.posts, '[]'::jsonb)
-    ) AS data
+    )) AS data
 FROM v_user u
-LEFT JOIN v_posts_by_user p ON p.fk_user = u.pk_user;
-```text
-<!-- Code example in TEXT -->
+JOIN tb_user tu ON tu.id = u.id
+LEFT JOIN v_posts_by_user p ON p.fk_user = tu.pk_user;
+```
 
 **Rules:**
 
-- Pre-aggregated views are NOT exposed directly to GraphQL
-- Used only for efficient composition
-- Join on internal `fk_*` columns
-- Compose using JSONB merge (`||`)
+- Pre-aggregated `_by_` views are NOT exposed directly to GraphQL
+- They are used only for efficient composition
+- Join on internal `fk_*` / `pk_*` columns
+- Compose using the JSONB merge operator (`||`)
 
-### 4.3.1 Analytical Fact Tables
+### 4.4 Fact and Dimension Tables (Analytical Modeling)
 
-For analytical workloads, FraiseQL supports **fact tables** with the `tf_` prefix:
+Fact and dimension tables are a legitimate data-modeling pattern. You build the tables and an
+ETL/refresh process; FraiseQL queries them through views like any other read source. When a
+GraphQL query selects aggregate fields, FraiseQL derives `GROUP BY` and aggregate SQL at
+runtime against your views (supported aggregates: `COUNT`, `SUM`, `AVG`, `MIN`, `MAX`,
+`STDDEV`, `VARIANCE`).
 
-**Fact tables** (`tf_*`):
+**Fact tables** hold transactional or event data:
 
-- Transactional/event data at any granularity
-- Measures: SQL columns (numeric types for fast aggregation)
-- Dimensions: JSONB `dimensions` column (flexible grouping)
-- Denormalized filters: Indexed SQL columns (customer_id, occurred_at)
-- Pre-aggregated versions use descriptive suffixes: `tf_sales_daily`, `tf_events_monthly`
+- Measures: SQL columns (numeric types, for fast aggregation)
+- Dimensions: a JSONB `dimensions` column for flexible grouping
+- Denormalized filters: indexed SQL columns (e.g. `customer_id`, `occurred_at`)
 
-**Dimension tables** (`td_*`):
-
-- Reference data used at ETL time to denormalize into fact tables
-- Never joined at query time (FraiseQL does not support joins)
-- Managed by DBA/data team
+**Dimension tables** hold reference data used at ETL time to denormalize into fact tables.
 
 **Example:**
 
 ```sql
-<!-- Code example in SQL -->
--- Fact table: Raw sales transactions (finest granularity)
-CREATE TABLE tf_sales (
-    id BIGSERIAL PRIMARY KEY,
+-- Fact table: raw sales transactions (finest granularity)
+CREATE TABLE tb_sales_fact (
+    pk_sales_fact BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
+    id UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
     -- Measures (SQL columns for fast aggregation)
     revenue DECIMAL(10,2) NOT NULL,
     quantity INT NOT NULL,
@@ -461,82 +455,40 @@ CREATE TABLE tf_sales (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_sales_customer ON tf_sales(customer_id);
-CREATE INDEX idx_sales_occurred ON tf_sales(occurred_at);
-CREATE INDEX idx_sales_dimensions_gin ON tf_sales USING GIN(dimensions);
+CREATE INDEX idx_sales_customer ON tb_sales_fact(customer_id);
+CREATE INDEX idx_sales_occurred ON tb_sales_fact(occurred_at);
+CREATE INDEX idx_sales_dimensions_gin ON tb_sales_fact USING GIN(dimensions);
 
--- Pre-aggregated fact table: Daily granularity (same structure, different granularity)
-CREATE TABLE tf_sales_daily (
-    id BIGSERIAL PRIMARY KEY,
+-- Pre-aggregated fact table: daily granularity
+CREATE TABLE tb_sales_fact_daily (
+    pk_sales_fact_daily BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
     day DATE NOT NULL UNIQUE,
-    -- Pre-aggregated measures
     revenue DECIMAL(10,2) NOT NULL,      -- SUM(revenue)
     quantity INT NOT NULL,               -- SUM(quantity)
     transaction_count INT NOT NULL,      -- COUNT(*)
-    -- Dimensions (can still group within daily aggregates)
     dimensions JSONB NOT NULL,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE UNIQUE INDEX idx_sales_daily_day ON tf_sales_daily(day);
-CREATE INDEX idx_sales_daily_dimensions_gin ON tf_sales_daily USING GIN(dimensions);
+CREATE INDEX idx_sales_daily_dimensions_gin ON tb_sales_fact_daily USING GIN(dimensions);
 
--- Dimension table: Product catalog (for ETL denormalization)
-CREATE TABLE td_products (
-    id UUID PRIMARY KEY,
-    name VARCHAR(255) NOT NULL,
-    category VARCHAR(100) NOT NULL,
+-- Dimension table: product catalog (for ETL denormalization)
+CREATE TABLE tb_product_dim (
+    pk_product_dim BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
+    id UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    category TEXT NOT NULL,
     price DECIMAL(10,2) NOT NULL,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
--- ETL process denormalizes td_products into tf_sales.dimensions
--- Example: dimensions->>'product_name', dimensions->>'product_category'
-```text
-<!-- Code example in TEXT -->
+-- An ETL process denormalizes product attributes into tb_sales_fact.dimensions,
+-- e.g. dimensions->>'product_name', dimensions->>'product_category'.
+```
 
-**Key architectural principle**: FraiseQL does NOT support joins. All dimensional data must be denormalized into the `dimensions` JSONB column at ETL time. The DBA/data team manages ETL pipelines; FraiseQL provides the GraphQL query interface.
-
-**Related documentation**: See `docs/specs/analytical-schema-conventions.md` for complete analytical naming conventions, and `docs/architecture/analytics/fact-dimension-pattern.md` for detailed patterns.
-
-### 4.4 Arrow Plane View (Flat, Single-Level)
-
-```sql
-<!-- Code example in SQL -->
-CREATE VIEW av_user AS
-SELECT
-    pk_user,
-    id,
-    identifier,
-    email,
-    name,
-    created_at,
-    updated_at
-FROM tb_user
-WHERE deleted_at IS NULL;
-
-CREATE VIEW av_post AS
-SELECT
-    pk_post,
-    fk_user,
-    id,
-    identifier,
-    (SELECT id FROM tb_user WHERE pk_user = fk_user) AS user_id,
-    title,
-    content,
-    created_at
-FROM tb_post
-WHERE deleted_at IS NULL;
-```text
-<!-- Code example in TEXT -->
-
-**Rules:**
-
-- Single level only (no nesting)
-- Each entity = separate Arrow batch
-- FK columns included for client-side joins
-- Columnar, not JSONB
-- Suitable for analytics/BI tools
+Window functions (`ROW_NUMBER`, `RANK`, `LAG`, `LEAD`, `OVER (PARTITION BY ...)`) and richer
+analytics are standard PostgreSQL that you embed in your `v_`/`tv_` view SQL — FraiseQL serves
+the resulting view, no special API required.
 
 ---
 
@@ -544,10 +496,11 @@ WHERE deleted_at IS NULL;
 
 ### 5.1 Mutation Response Contract
 
-All stored procedures (mutations) MUST return a standardized JSON response matching this structure:
+A `@fraiseql.mutation` resolver calls a `fn_` function via `db.execute_function(...)`. The
+function performs validation and the write, then returns a JSON response. A practical
+response shape:
 
 ```json
-<!-- Code example in JSON -->
 {
   "status": "success|error|noop",
   "message": "Human-readable message",
@@ -560,66 +513,24 @@ All stored procedures (mutations) MUST return a standardized JSON response match
     "email": "..."
   },
   "updated_fields": ["field1", "field2"],
-  "cascade": {
-    "updated": [
-      {
-        "__typename": "User",
-        "id": "uuid",
-        "operation": "CREATED|UPDATED",
-        "entity": { ... }
-      }
-    ],
-    "deleted": [
-      {
-        "__typename": "User",
-        "id": "uuid",
-        "operation": "DELETED"
-      }
-    ],
-    "invalidations": [
-      {
-        "query_name": "users",
-        "strategy": "INVALIDATE|REPLACE|APPEND",
-        "scope": "PREFIX|EXACT|SUFFIX"
-      }
-    ],
-    "metadata": {
-      "timestamp": "2026-01-11T...",
-      "transaction_id": "txid",
-      "depth": 1,
-      "affected_count": 1
-    }
-  },
   "metadata": {
     "trigger": "api_create|api_update|api_delete",
-    "reason": "entity_created|entity_updated|conflict|not_found",
-    "input_payload": { ... }
+    "reason": "entity_created|entity_updated|conflict|not_found"
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**Response fields (all required):**
+**Response fields:**
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `status` | TEXT | `success`, `error`, or `noop` |
-| `message` | TEXT | Human-readable message for client |
-| `entity_id` | TEXT | UUID of affected entity |
-| `entity_type` | TEXT | Entity type name (e.g., "User") |
-| `entity` | JSONB | The mutated entity (full view data) |
+| `message` | TEXT | Human-readable message for the client |
+| `entity_id` | TEXT | UUID of the affected entity |
+| `entity_type` | TEXT | Entity type name (e.g. `"User"`) |
+| `entity` | JSONB | The mutated entity (full view projection) |
 | `updated_fields` | ARRAY | Fields that were actually changed |
-| `cascade` | JSONB | Cache invalidation + cascaded updates |
-| `metadata` | JSONB | Operation metadata and input |
-
-**Cascade structure:**
-
-| Key | Type | Description |
-|-----|------|-------------|
-| `updated` | ARRAY | Entities that were created/updated with `operation` and `__typename` |
-| `deleted` | ARRAY | Entities that were deleted |
-| `invalidations` | ARRAY | Cache keys to invalidate with strategy |
-| `metadata` | OBJECT | Timestamp, transaction_id, depth, affected_count |
+| `metadata` | JSONB | Operation metadata |
 
 **Status values:**
 
@@ -629,124 +540,82 @@ All stored procedures (mutations) MUST return a standardized JSON response match
 | `error` | Mutation failed (validation, constraint, etc.) |
 | `noop` | No changes applied (idempotent, already exists, etc.) |
 
-**Note:** The mutation response above is the **public-facing API response**. Internally, all mutations are also logged to `tb_entity_change_log` with a full Debezium envelope for complete audit trails. See **section 6: Mutation Logging & Audit Tables** for details. This enables:
+The Python resolver inspects `status` and returns a `@fraiseql.success` or `@fraiseql.error`
+type accordingly.
 
-- Complete audit trail of all entity writes
-- CDC event emission for real-time systems
-- Observability and performance monitoring
-- Error diagnostics and debugging
-- Multi-source mutation tracking (GraphQL, batch imports, ETL, direct SQL)
-
-### 5.2 Basic Create Function (PostgreSQL)
+### 5.2 Basic Create Function
 
 ```sql
-<!-- Code example in SQL -->
 CREATE FUNCTION fn_create_user(
     tenant_id UUID,
     user_id UUID,
     payload JSONB
 )
-RETURNS TEXT  -- Returns JSON response (portable format)
+RETURNS JSONB
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
 DECLARE
     v_new_id UUID := gen_random_uuid();
     v_entity JSONB;
-    v_response JSONB;
 BEGIN
-    -- Insert new user
     INSERT INTO tb_user (id, email, name, created_by)
     VALUES (
         v_new_id,
         payload->>'email',
         payload->>'name',
-        user_id
+        (SELECT pk_user FROM tb_user WHERE id = user_id)
     );
 
-    -- Fetch full projection
-    SELECT data INTO v_entity
-    FROM v_user
-    WHERE id = v_new_id;
+    -- Fetch the full projection from the read view
+    SELECT data INTO v_entity FROM v_user WHERE id = v_new_id;
 
-    -- Build response
-    v_response := jsonb_build_object(
+    RETURN jsonb_build_object(
         'status', 'success',
         'message', 'User created successfully',
         'entity_id', v_new_id::text,
         'entity_type', 'User',
         'entity', v_entity,
         'updated_fields', ARRAY['email', 'name'],
-        'cascade', jsonb_build_object(
-            'updated', jsonb_build_array(
-                jsonb_build_object(
-                    '__typename', 'User',
-                    'id', v_new_id::text,
-                    'operation', 'CREATED',
-                    'entity', v_entity
-                )
-            ),
-            'invalidations', jsonb_build_array(
-                jsonb_build_object(
-                    'query_name', 'users',
-                    'strategy', 'INVALIDATE',
-                    'scope', 'PREFIX'
-                )
-            ),
-            'metadata', jsonb_build_object(
-                'timestamp', NOW()::text,
-                'depth', 1,
-                'affected_count', 1
-            )
-        ),
         'metadata', jsonb_build_object(
             'trigger', 'api_create',
-            'reason', 'entity_created',
-            'input_payload', payload
+            'reason', 'entity_created'
         )
     );
-
-    RETURN v_response::TEXT;
 EXCEPTION WHEN OTHERS THEN
-    v_response := jsonb_build_object(
+    RETURN jsonb_build_object(
         'status', 'error',
         'message', SQLERRM,
         'entity_id', NULL,
         'entity_type', 'User',
         'entity', NULL,
         'updated_fields', ARRAY[]::TEXT[],
-        'cascade', NULL,
         'metadata', jsonb_build_object(
             'trigger', 'api_create',
-            'reason', 'error',
-            'input_payload', payload
+            'reason', 'error'
         )
     );
-    RETURN v_response::TEXT;
 END;
 $$;
-```text
-<!-- Code example in TEXT -->
+```
 
 **Rules:**
 
 - Function name: `fn_{action}_{entity}`
-- Parameters: `tenant_id UUID`, `user_id UUID` (from auth context), `payload JSONB` (input)
-- Return type: **TEXT** (JSON serialized, portable across databases)
-- Must handle errors with try-catch, return error status
-- Entity must be full projection from view
-- Cascade field is REQUIRED (even if empty for simple mutations)
+- Parameters: auth context (`tenant_id`, `user_id`) plus a `payload JSONB`
+- Return type: `JSONB` (the response contract above)
+- Handle errors and return an `error` status rather than propagating raw exceptions
+- The `entity` field is the full projection fetched from the read view
 
 ### 5.3 Update Function with Audit
 
 ```sql
-<!-- Code example in SQL -->
 CREATE FUNCTION fn_update_user(
     tenant_id UUID,
     user_id UUID,
     payload JSONB
 )
-RETURNS TEXT
+RETURNS JSONB
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
@@ -755,9 +624,8 @@ DECLARE
     v_entity JSONB;
     v_before JSONB;
     v_updated_fields TEXT[];
-    v_response JSONB;
 BEGIN
-    -- Fetch BEFORE snapshot
+    -- Fetch the BEFORE snapshot
     SELECT data INTO v_before FROM v_user WHERE id = v_id;
     IF v_before IS NULL THEN
         RETURN jsonb_build_object(
@@ -767,66 +635,35 @@ BEGIN
             'entity_type', 'User',
             'entity', NULL,
             'updated_fields', ARRAY[]::TEXT[],
-            'cascade', NULL,
             'metadata', jsonb_build_object('trigger', 'api_update', 'reason', 'not_found')
-        )::TEXT;
+        );
     END IF;
 
-    -- Update fields conditionally
+    -- Update only the fields present in the payload
     UPDATE tb_user
     SET
         name = COALESCE(payload->>'name', name),
-        updated_by = user_id,
+        updated_by = (SELECT pk_user FROM tb_user WHERE id = user_id),
         updated_at = NOW()
     WHERE id = v_id;
 
-    -- Track which fields actually changed
+    -- Track which fields were actually supplied
     v_updated_fields := ARRAY(
-        SELECT key FROM jsonb_each_text(payload)
-        WHERE key != 'id'
+        SELECT key FROM jsonb_each_text(payload) WHERE key != 'id'
     );
 
-    -- Fetch AFTER snapshot
+    -- Fetch the AFTER snapshot
     SELECT data INTO v_entity FROM v_user WHERE id = v_id;
 
-    -- Build response
-    v_response := jsonb_build_object(
+    RETURN jsonb_build_object(
         'status', 'success',
         'message', 'User updated successfully',
         'entity_id', v_id::text,
         'entity_type', 'User',
         'entity', v_entity,
         'updated_fields', v_updated_fields,
-        'cascade', jsonb_build_object(
-            'updated', jsonb_build_array(
-                jsonb_build_object(
-                    '__typename', 'User',
-                    'id', v_id::text,
-                    'operation', 'UPDATED',
-                    'entity', v_entity
-                )
-            ),
-            'invalidations', jsonb_build_array(
-                jsonb_build_object(
-                    'query_name', 'users',
-                    'strategy', 'INVALIDATE',
-                    'scope', 'PREFIX'
-                )
-            ),
-            'metadata', jsonb_build_object(
-                'timestamp', NOW()::text,
-                'depth', 1,
-                'affected_count', 1
-            )
-        ),
-        'metadata', jsonb_build_object(
-            'trigger', 'api_update',
-            'reason', 'entity_updated',
-            'input_payload', payload
-        )
+        'metadata', jsonb_build_object('trigger', 'api_update', 'reason', 'entity_updated')
     );
-
-    RETURN v_response::TEXT;
 EXCEPTION WHEN OTHERS THEN
     RETURN jsonb_build_object(
         'status', 'error',
@@ -835,95 +672,63 @@ EXCEPTION WHEN OTHERS THEN
         'entity_type', 'User',
         'entity', NULL,
         'updated_fields', ARRAY[]::TEXT[],
-        'cascade', NULL,
         'metadata', jsonb_build_object('trigger', 'api_update', 'reason', 'error')
-    )::TEXT;
+    );
 END;
 $$;
-```text
-<!-- Code example in TEXT -->
+```
 
 **Rules:**
 
-- Extract entity ID from payload
-- Fetch BEFORE snapshot for comparison
-- Update only fields present in payload
+- Extract the entity ID from the payload
+- Fetch a BEFORE snapshot for comparison
+- Update only the fields present in the payload
 - Track which fields actually changed
-- Fetch AFTER snapshot
-- Include both snapshots in cascade
-- Always return standard response format
+- Fetch an AFTER snapshot for the response
+- Always return the standard response shape
 
 ### 5.4 Delete Function (Soft Delete)
 
 ```sql
-<!-- Code example in SQL -->
 CREATE FUNCTION fn_delete_user(
     tenant_id UUID,
     user_id UUID,
     payload JSONB
 )
-RETURNS TEXT
+RETURNS JSONB
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
 DECLARE
     v_id UUID := (payload->>'id')::UUID;
-    v_response JSONB;
 BEGIN
     UPDATE tb_user
     SET
         deleted_at = NOW(),
-        deleted_by = user_id
+        deleted_by = (SELECT pk_user FROM tb_user WHERE id = user_id)
     WHERE id = v_id AND deleted_at IS NULL;
 
     IF NOT FOUND THEN
-        v_response := jsonb_build_object(
+        RETURN jsonb_build_object(
             'status', 'noop',
             'message', 'User already deleted or not found',
             'entity_id', v_id::text,
             'entity_type', 'User',
             'entity', NULL,
             'updated_fields', ARRAY[]::TEXT[],
-            'cascade', jsonb_build_object(
-                'deleted', jsonb_build_array(
-                    jsonb_build_object(
-                        '__typename', 'User',
-                        'id', v_id::text,
-                        'operation', 'DELETED'
-                    )
-                )
-            ),
             'metadata', jsonb_build_object('trigger', 'api_delete', 'reason', 'not_found')
-        );
-    ELSE
-        v_response := jsonb_build_object(
-            'status', 'success',
-            'message', 'User deleted successfully',
-            'entity_id', v_id::text,
-            'entity_type', 'User',
-            'entity', NULL,
-            'updated_fields', ARRAY['deleted_at', 'deleted_by'],
-            'cascade', jsonb_build_object(
-                'deleted', jsonb_build_array(
-                    jsonb_build_object(
-                        '__typename', 'User',
-                        'id', v_id::text,
-                        'operation', 'DELETED'
-                    )
-                ),
-                'invalidations', jsonb_build_array(
-                    jsonb_build_object(
-                        'query_name', 'users',
-                        'strategy', 'INVALIDATE',
-                        'scope', 'PREFIX'
-                    )
-                )
-            ),
-            'metadata', jsonb_build_object('trigger', 'api_delete', 'reason', 'entity_deleted')
         );
     END IF;
 
-    RETURN v_response::TEXT;
+    RETURN jsonb_build_object(
+        'status', 'success',
+        'message', 'User deleted successfully',
+        'entity_id', v_id::text,
+        'entity_type', 'User',
+        'entity', NULL,
+        'updated_fields', ARRAY['deleted_at', 'deleted_by'],
+        'metadata', jsonb_build_object('trigger', 'api_delete', 'reason', 'entity_deleted')
+    );
 EXCEPTION WHEN OTHERS THEN
     RETURN jsonb_build_object(
         'status', 'error',
@@ -932,470 +737,104 @@ EXCEPTION WHEN OTHERS THEN
         'entity_type', 'User',
         'entity', NULL,
         'updated_fields', ARRAY[]::TEXT[],
-        'cascade', NULL,
         'metadata', jsonb_build_object('trigger', 'api_delete', 'reason', 'error')
-    )::TEXT;
+    );
 END;
 $$;
-```text
-<!-- Code example in TEXT -->
+```
 
 **Rules:**
 
 - Soft delete: set `deleted_at` and `deleted_by`
 - Never hard-delete from `tb_*`
-- Use `deleted` array in cascade (no `updated`)
-- Deleted entities have no entity data
-- Return `operation: DELETED` in cascade
-
-### 5.5 Database-Specific Optimizations (Optional)
-
-This spec defines the **response contract** that all databases must follow.
-
-**PostgreSQL can further optimize:**
-
-- See: `docs/specs/stored-procedures-postgresql.md`
-- Use composite types for efficiency
-- Two-layer architecture (app.*wrapper → core.* implementation)
-- Built-in mutation logging and CDC
-- Industry-standard stored procedure patterns
-
-**Other databases:**
-
-- SQLite: See `docs/specs/stored-procedures-sqlite.md`
-- MySQL: See `docs/specs/stored-procedures-mysql.md`
-- Each maintains the JSON response contract above
+- Deleted entities carry no `entity` data in the response
+- Read views filter `WHERE deleted_at IS NULL`, so the row disappears from queries
 
 ---
 
-## 6. Mutation Logging & Audit Tables
+## 6. Many-to-Many Relationships
 
-### 6.1 Entity Change Log Table
-
-The `tb_entity_change_log` table provides a **centralized, source-agnostic audit log** for all entity writes across the system, whether from GraphQL mutations, batch imports, ETL processes, direct SQL, or any other source.
+### 6.1 Junction Table
 
 ```sql
-<!-- Code example in SQL -->
-CREATE TABLE core.tb_entity_change_log (
-    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    pk_entity_change_log UUID NOT NULL DEFAULT gen_random_uuid(),
-
-    fk_customer_org UUID NOT NULL,      -- Multi-tenant isolation
-    fk_contact UUID,                     -- User ID who made the change (nullable)
-
-    object_type TEXT NOT NULL,           -- Entity type (User, Post, Order, etc.)
-    object_id UUID NOT NULL,             -- Entity UUID being modified
-
-    modification_type TEXT NOT NULL CHECK (
-        modification_type IN ('INSERT', 'UPDATE', 'DELETE', 'NOOP')
-    ),
-
-    change_status TEXT NOT NULL CHECK (
-        change_status ~ '^(new|existing|updated|deleted|synced|completed|ok|done|success|failed:[a-z_]+|noop:[a-z_]+|conflict:[a-z_]+|duplicate:[a-z_]+|validation:[a-z_]+|not_found|forbidden|unauthorized|blocked:[a-z_]+)$'
-    ),
-
-    object_data JSONB NOT NULL,          -- Debezium envelope (see 6.2)
-    extra_metadata JSONB DEFAULT '{}'::jsonb,
-
-    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE INDEX idx_entity_log_object ON core.tb_entity_change_log (object_type, object_id);
-CREATE INDEX idx_entity_log_org ON core.tb_entity_change_log (fk_customer_org, created_at);
-CREATE INDEX idx_entity_log_status ON core.tb_entity_change_log (change_status);
-```text
-<!-- Code example in TEXT -->
-
-**Purpose:**
-
-- Centralized audit log for all entity writes (GraphQL mutations, batch imports, ETL, direct SQL, triggers, etc.)
-- Source of truth for observability and debugging
-- Enables CDC event emission for real-time systems
-- Powers admin timelines, analytics, and compliance audits
-- **Source-agnostic:** Tracks any write operation regardless of origin
-
-### 6.2 Debezium Envelope Format
-
-The `object_data` JSONB column contains a **Debezium-style change envelope** for compatibility with CDC systems:
-
-```json
-<!-- Code example in JSON -->
-{
-  "before": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "email": "old@example.com",
-    "updated_at": "2026-01-11T14:00:00Z"
-  },
-  "after": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "email": "new@example.com",
-    "updated_at": "2026-01-11T15:00:00Z"
-  },
-  "op": "u",
-  "source": {
-    "table": "tb_user",
-    "schema": "public",
-    "db": "production",
-    "organization": "550e8400-e29b-41d4-a716-446655440001",
-    "ts_ms": 1704067200000
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Operation Codes:**
-
-- `"c"` — Create (INSERT)
-- `"u"` — Update (UPDATE)
-- `"d"` — Delete (DELETE)
-- `"r"` — Read/Noop (NOOP, no change)
-
-**Field Semantics:**
-
-- `before` — Entity state before modification (null for INSERT)
-- `after` — Entity state after modification (null for DELETE)
-- `op` — Database operation code
-- `source` — Metadata about the change source (table, schema, organization, timestamp)
-
-### 6.3 Status Taxonomy
-
-The `change_status` field uses **structured, machine-readable status codes** for pattern matching and aggregation:
-
-| Category | Pattern | Examples | Use Case |
-|----------|---------|----------|----------|
-| Success | Plain word | `new`, `existing`, `updated`, `deleted`, `synced`, `completed`, `success` | Operation succeeded |
-| Error | `failed:{reason}` | `failed:not_found`, `failed:validation`, `failed:constraint` | Operation failed |
-| Conflict | `conflict:{reason}` | `conflict:already_exists`, `conflict:duplicate_email` | Data conflict detected |
-| Validation | `validation:{reason}` | `validation:invalid_format`, `validation:missing_field` | Validation error |
-| No-op | `noop:{reason}` | `noop:unchanged`, `noop:already_synced`, `noop:duplicate` | No change made |
-| Blocked | `blocked:{reason}` | `blocked:permission_denied`, `blocked:rate_limit` | Operation prevented |
-
-### 6.4 Helper Functions
-
-**log_mutation_event()** — Writes change to `tb_entity_change_log`
-
-```sql
-<!-- Code example in SQL -->
-CREATE OR REPLACE FUNCTION log_mutation_event(
-    input_fk_customer_org UUID,
-    input_fk_contact UUID,
-    input_object_type TEXT,
-    input_object_id UUID,
-    input_modification_type TEXT,
-    input_change_status TEXT,
-    input_payload_before JSONB DEFAULT NULL,
-    input_payload_after JSONB DEFAULT NULL,
-    input_source_table TEXT DEFAULT NULL,
-    input_source_schema TEXT DEFAULT 'public',
-    input_extra_metadata JSONB DEFAULT '{}'::jsonb
-)
-RETURNS UUID
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    -- Builds Debezium envelope and inserts into change log
-    -- Returns pk_entity_change_log for tracing
-    ...
-END;
-$$;
-```text
-<!-- Code example in TEXT -->
-
-**build_mutation_response()** — Constructs mutation response without logging
-
-```sql
-<!-- Code example in SQL -->
-CREATE OR REPLACE FUNCTION core.build_mutation_response(
-    input_change_status TEXT,
-    input_message TEXT,
-    input_entity_id UUID,
-    input_entity_type TEXT,
-    input_custom_entity JSONB,
-    input_fields TEXT[] DEFAULT ARRAY[]::TEXT[],
-    input_cascade_data JSONB DEFAULT NULL,
-    input_extra_metadata JSONB DEFAULT '{}'::JSONB
-)
-RETURNS app.mutation_response
-LANGUAGE plpgsql
-IMMUTABLE
-AS $$
-BEGIN
-    -- Pure function: builds and returns mutation_response type
-    -- No side effects; safe to call multiple times
-    RETURN (
-        input_change_status,
-        input_message,
-        input_entity_id::TEXT,
-        input_entity_type,
-        input_custom_entity,
-        input_fields,
-        input_cascade_data,
-        input_extra_metadata
-    )::app.mutation_response;
-END;
-$$;
-```text
-<!-- Code example in TEXT -->
-
-**log_and_return_mutation()** — Combined helper (logs + returns response)
-
-```sql
-<!-- Code example in SQL -->
-CREATE OR REPLACE FUNCTION core.log_and_return_mutation(
-    input_tenant_id UUID,
-    input_user_id UUID,
-    input_entity_type TEXT,
-    input_entity_id UUID,
-    input_modification_type TEXT,
-    input_change_status TEXT,
-    input_fields TEXT[],
-    input_message TEXT,
-    input_payload_before JSONB DEFAULT NULL,
-    input_payload_after JSONB DEFAULT NULL,
-    input_cascade_data JSONB DEFAULT NULL,
-    input_extra_metadata JSONB DEFAULT '{}'::JSONB
-)
-RETURNS app.mutation_response
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    -- Step 1: Log the mutation (side effect)
-    PERFORM log_mutation_event(
-        input_tenant_id,
-        input_user_id,
-        input_entity_type,
-        input_entity_id,
-        input_modification_type,
-        input_change_status,
-        input_payload_before,
-        input_payload_after,
-        input_entity_type,
-        'public',
-        input_extra_metadata
-    );
-
-    -- Step 2: Build and return response (pure function)
-    RETURN core.build_mutation_response(
-        input_change_status,
-        input_message,
-        input_entity_id,
-        input_entity_type,
-        COALESCE(input_payload_after, input_payload_before),
-        input_fields,
-        input_cascade_data,
-        input_extra_metadata
-    );
-END;
-$$;
-```text
-<!-- Code example in TEXT -->
-
-### 6.5 Usage Patterns
-
-**Standard mutation with automatic logging:**
-
-```sql
-<!-- Code example in SQL -->
-CREATE OR REPLACE FUNCTION fn_create_user(
-    input_tenant_id UUID,
-    input_user_id UUID,
-    input_email TEXT,
-    input_name TEXT
-)
-RETURNS app.mutation_response
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    v_new_user_id UUID;
-    v_before JSONB := NULL;
-    v_after JSONB;
-BEGIN
-    -- Create user
-    INSERT INTO tb_user (email, name)
-    VALUES (input_email, input_name)
-    RETURNING id INTO v_new_user_id;
-
-    -- Fetch created state
-    SELECT jsonb_build_object(
-        'id', id,
-        'email', email,
-        'name', name,
-        'createdAt', created_at
-    ) INTO v_after
-    FROM tb_user WHERE id = v_new_user_id;
-
-    -- Log and return
-    RETURN core.log_and_return_mutation(
-        input_tenant_id,
-        input_user_id,
-        'User',
-        v_new_user_id,
-        'INSERT',
-        'new',
-        ARRAY['id', 'email', 'name', 'createdAt'],
-        'User created successfully',
-        v_before,
-        v_after,
-        NULL,
-        jsonb_build_object('trigger', 'api_create')
-    );
-END;
-$$;
-```text
-<!-- Code example in TEXT -->
-
-**Custom error response:**
-
-```sql
-<!-- Code example in SQL -->
--- Check for conflict
-IF EXISTS (SELECT 1 FROM tb_user WHERE email = input_email) THEN
-    PERFORM log_mutation_event(
-        input_tenant_id,
-        input_user_id,
-        'User',
-        '00000000-0000-0000-0000-000000000000',
-        'NOOP',
-        'conflict:already_exists',
-        NULL,
-        jsonb_build_object('email', input_email),
-        'tb_user',
-        'public',
-        jsonb_build_object('attempted_email', input_email)
-    );
-
-    RETURN core.build_mutation_response(
-        'conflict:already_exists',
-        'User with this email already exists',
-        '00000000-0000-0000-0000-000000000000',
-        'User',
-        jsonb_build_object('email', input_email, 'error', 'duplicate'),
-        ARRAY[]::TEXT[],
-        NULL,
-        jsonb_build_object('trigger', 'api_create', 'conflict_reason', 'duplicate_email')
-    );
-END IF;
-```text
-<!-- Code example in TEXT -->
-
-### 6.6 Separation of Concerns Pattern
-
-This design separates **side effects (logging)** from **pure functions (response building)**:
-
-- `log_mutation_event()` — Side effect only; writes to database
-- `build_mutation_response()` — Pure function; no side effects
-- `log_and_return_mutation()` — Combines both for typical mutations
-
-**Benefits:**
-
-- Testable: Each function can be tested independently
-- Flexible: Can log without returning, or return without logging if needed
-- Clear: Easy to understand what each function does
-- Follows functional programming principles
-
----
-
-## 7. Many-to-Many Relationships
-
-### 7.1 Junction Table
-
-```sql
-<!-- Code example in SQL -->
 CREATE TABLE tb_user_role (
-    pk_user_role INTEGER PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
-    fk_user BIGINTEGER NOT NULL REFERENCES tb_user(pk_user) ON DELETE CASCADE,
-    fk_role INTEGER NOT NULL REFERENCES tb_role(pk_role),
+    pk_user_role BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
+    fk_user BIGINT NOT NULL REFERENCES tb_user(pk_user) ON DELETE CASCADE,
+    fk_role BIGINT NOT NULL REFERENCES tb_role(pk_role),
     assigned_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(fk_user, fk_role)
 );
-```text
-<!-- Code example in TEXT -->
+```
 
-### 7.2 View for Array Aggregation
+### 6.2 View for Array Aggregation
 
 ```sql
-<!-- Code example in SQL -->
 -- Aggregate role IDs per user
 CREATE VIEW v_user_role_ids_by_user AS
 SELECT
-    fk_user,
-    array_agg(fk_role) AS role_ids,
-    array_agg(r.id) AS role_ids_uuid
+    ur.fk_user,
+    array_agg(r.id) AS role_ids
 FROM tb_user_role ur
 JOIN tb_role r ON r.pk_role = ur.fk_role
-GROUP BY fk_user;
+GROUP BY ur.fk_user;
 
--- Include in user view
+-- Include the role IDs in the user view
 CREATE VIEW v_user AS
 SELECT
-    u.pk_user,
     u.id,
-    u.identifier,
-    COALESCE(ur.role_ids_uuid, ARRAY[]::UUID[]) AS role_ids,
+    COALESCE(ur.role_ids, ARRAY[]::UUID[]) AS role_ids,
     jsonb_build_object(
         'id', u.id,
         'identifier', u.identifier,
         'email', u.email,
-        'roleIds', COALESCE(ur.role_ids_uuid, ARRAY[]::UUID[])
+        'roleIds', COALESCE(ur.role_ids, ARRAY[]::UUID[])
     ) AS data
 FROM tb_user u
 LEFT JOIN v_user_role_ids_by_user ur ON ur.fk_user = u.pk_user
 WHERE u.deleted_at IS NULL;
-```text
-<!-- Code example in TEXT -->
+```
 
 **Rules:**
 
-- Junction table uses internal keys (`fk_*`)
-- View aggregates to UUID array
-- Include both array column AND in JSONB
-- Index the array column for GIN filtering
+- The junction table uses internal keys (`fk_*`)
+- The view aggregates to a `UUID[]` array of public IDs
+- Include the array both as a native column AND inside the `data` JSONB
+- Index the array column with GIN for filtering
 
 ---
 
-## 8. Indexing Strategy
+## 7. Indexing Strategy
 
-### 8.1 Essential Indexes
+### 7.1 Essential Indexes
 
 ```sql
-<!-- Code example in SQL -->
--- On write table
+-- On the write table
 CREATE INDEX idx_tb_user_id ON tb_user(id);
 CREATE INDEX idx_tb_user_identifier ON tb_user(identifier);
 CREATE INDEX idx_tb_user_created_at ON tb_user(created_at);
 CREATE UNIQUE INDEX idx_tb_user_email ON tb_user(email) WHERE deleted_at IS NULL;
 
--- On related table
+-- On related tables
 CREATE INDEX idx_tb_post_fk_user ON tb_post(fk_user);
 CREATE INDEX idx_tb_post_id ON tb_post(id);
 CREATE INDEX idx_tb_post_created_at ON tb_post(created_at);
 
--- On view for filtering
-CREATE INDEX idx_v_post_user_id ON v_post(user_id);
-CREATE INDEX idx_v_post_created_at ON v_post(created_at);
-
 -- On array/JSONB columns (GIN)
-CREATE INDEX idx_v_order_items__product__category_id
-  ON v_order USING GIN(items__product__category_id);
-CREATE INDEX idx_v_user_role_ids
-  ON v_user USING GIN(role_ids);
-CREATE INDEX idx_v_post_data_gin
-  ON v_post USING GIN(data);
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_tb_user_role_user ON tb_user_role(fk_user);
+```
 
 **Rules:**
 
 - B-tree on: public `id`, `identifier`, audit columns, FK columns
 - UNIQUE on: `id` and `identifier`
-- GIN on: array columns, deep path columns, `data` JSONB (optional)
-- Index what will be filtered
+- GIN on: array columns, deep path columns, and `data` JSONB (optional)
+- Index what will actually be filtered
 
 ---
 
-## 9. View Materialization Strategy
+## 8. View Materialization Strategy
 
-### 9.1 When to Materialize
+### 8.1 When to Materialize
 
 Use materialized views for:
 
@@ -1405,57 +844,65 @@ Use materialized views for:
 - High-cardinality pre-aggregations
 
 ```sql
-<!-- Code example in SQL -->
 CREATE MATERIALIZED VIEW mv_user_stats AS
 SELECT
-    fk_user,
-    COUNT(DISTINCT fk_post) AS post_count,
-    COUNT(DISTINCT fk_comment) AS comment_count,
-    MAX(post.created_at) AS latest_post_at
+    u.pk_user AS fk_user,
+    COUNT(DISTINCT p.pk_post) AS post_count,
+    MAX(p.created_at) AS latest_post_at
 FROM tb_user u
-LEFT JOIN tb_post ON tb_post.fk_user = u.pk_user
-LEFT JOIN tb_comment ON tb_comment.fk_user = u.pk_user
-GROUP BY fk_user;
+LEFT JOIN tb_post p ON p.fk_user = u.pk_user
+GROUP BY u.pk_user;
 
--- Refresh strategy
 CREATE INDEX idx_mv_user_stats_fk_user ON mv_user_stats(fk_user);
 
--- Refresh manually or on schedule
+-- Refresh manually or on a schedule
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_user_stats;
-```text
-<!-- Code example in TEXT -->
+```
 
 **Rules:**
 
 - Name: `mv_{entity}`
 - Index on grouping columns
-- Refresh strategy documented
-- Use CONCURRENTLY to avoid locks
+- Document the refresh strategy
+- Use `CONCURRENTLY` to avoid locks
+
+For heavy nested reads, prefer a `tv_*` table-backed projection refreshed by triggers — see
+the [tv_ table pattern](../architecture/database/tv-table-pattern.md).
 
 ---
 
-## 10. Validation Checklist
+## 9. Validation Checklist
 
 When creating a schema for FraiseQL:
 
 - [ ] All write tables prefixed `tb_*`
-- [ ] All read views prefixed `v_*`
-- [ ] All functions prefixed `fn_*`
-- [ ] Primary keys: `pk_{entity}` (INTEGER)
-- [ ] Foreign keys: `fk_{entity}` (INTEGER)
-- [ ] Public IDs: `id` (UUID)
-- [ ] Surrogates: `identifier` (TEXT, indexed)
-- [ ] All views have `data` JSONB column
-- [ ] Related entity views expose `{parent}_id`
-- [ ] Deep path columns follow `entity__path__field` pattern
-- [ ] All tables have audit columns
-- [ ] All views filter on `deleted_at IS NULL`
+- [ ] All read views prefixed `v_*` (or `tv_*` for table-backed projections)
+- [ ] All mutation functions prefixed `fn_*`
+- [ ] Primary keys: `pk_{entity}` (`BIGINT`, hidden)
+- [ ] Foreign keys: `fk_{entity}` (`BIGINT`, hidden)
+- [ ] Public IDs: `id` (`UUID`)
+- [ ] Slugs: `identifier` (`TEXT`, indexed) where applicable
+- [ ] All read views have a `data` JSONB column
+- [ ] Related entity views expose `{parent}_id` (`UUID`)
+- [ ] Deep path columns follow the `entity__path__field` pattern
+- [ ] Tables have audit columns
+- [ ] Views filter on `deleted_at IS NULL`
 - [ ] Pre-aggregated views named `v_{entities}_by_{parent}`
-- [ ] Arrow views named `av_{entity}` and are flat
-- [ ] Mutation functions return JSONB
-- [ ] All relevant columns indexed
+- [ ] Mutation functions return the standard JSON response
+- [ ] Relevant columns are indexed
 - [ ] JSONB fields use camelCase
-- [ ] No nullable JSONB (use {} or [])
+- [ ] No `pk_*` / `fk_*` inside `data`
+- [ ] No nullable JSONB (use `{}` or `[]`)
+
+---
+
+## See Also
+
+- [Naming Patterns](../reference/naming-patterns.md) — full identifier reference
+- [Scalars](../reference/scalars.md) — built-in GraphQL scalar types
+- [View Selection Guide](../architecture/database/view-selection-guide.md) — `v_` vs `tv_`
+- [tv_ Table Pattern](../architecture/database/tv-table-pattern.md) — table-backed projections
+- [Database-Centric Architecture](../foundation/03-database-centric-architecture.md) — the CQRS model
 
 ---
 


### PR DESCRIPTION
Phase 2 of the docs cleanup (follows #418–#422). Rewrites the **Reference** and **Specifications** nav pages, which were "FraiseQL v2" docs (alpha stamps, multi-DB type/operator matrices, capability manifests, "compiler developers" framing). All 5 rewritten to v1 reality, each verified against `src/`.

## Per-file summary

| File | Key v2→v1 changes |
|------|-------------------|
| `reference/README` | rebuilt as a v1 reference index linking only docs that exist; dropped removed v2/saga/compiler links |
| `reference/scalars` | document the **54 real** scalars from `fraiseql.types` (verified against `dir(fraiseql.types)`); drop invented ones; `FraiseQL.types`→`fraiseql.types`; remove v2 stamp + multi-DB type matrix |
| `reference/where-operators` | PostgreSQL operator reference (comparison/text/array + ltree/vector cross-links), verified against `src/fraiseql/sql/operators/`; remove the MySQL/SQLite/SQL Server matrix |
| `specs/schema-conventions` | keep the correct `tb_`/`v_`/`tv_`/`fn_`/trinity/`data`-JSONB conventions; remove Arrow plane (`va_`/`ta_`), Debezium/CDC, multi-DB, compiler framing; fix `pk_`/`fk_` to BIGINT |
| `specs/aggregation-operators` | reframe around v1's real runtime auto-aggregation (`_derive_auto_aggregation`; COUNT/SUM/AVG/MIN/MAX/STDDEV/VARIANCE; real `register_type_for_view` metadata keys); drop capability manifest + multi-DB targets + "v2 compiler" |

## Verification

- `grep`: **zero** v2 / `FraiseQL.` / capability-manifest / multi-DB / Arrow artifacts (the one "compiler" mention is an explicit negation).
- **Source-verified**: all 54 scalars against `dir(fraiseql.types)`; WHERE operators against `src/fraiseql/sql/operators/`; aggregation metadata keys (`measures`/`dimensions`/`native_dimensions`/`native_measures`/`native_dimension_mapping`) against `src/fraiseql/db.py`.
- All cross-links resolve; fences balanced; `mkdocs build` no new warnings.

Net: **+971 / −4249** lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)