### PR TITLE
docs(patterns): rewrite the application blueprints for v1 (Phase 2)

### DIFF
--- a/docs/patterns/README.md
+++ b/docs/patterns/README.md
@@ -1,297 +1,128 @@
-<!-- Skip to main content -->
 ---
-
 title: Real-World Application Patterns
-description: Complete architectural patterns and implementation guides for production FraiseQL applications.
-keywords: ["workflow", "saas", "realtime", "ecommerce", "analytics", "federation"]
-tags: ["documentation", "reference"]
+description: Application blueprints for production FraiseQL v1 services built on Python, PostgreSQL, and FastAPI.
+keywords: ["patterns", "saas", "realtime", "ecommerce", "analytics", "iot", "postgresql"]
+tags: ["documentation", "patterns"]
 ---
 
 # Real-World Application Patterns
 
-**Status:** ✅ Production Ready
+**Status:** Production Ready
 **Audience:** Architects, senior developers
-**Last Updated:** 2026-02-05
 
-Complete architectural patterns and implementation guides for production FraiseQL applications.
-
----
-
-## Overview
-
-This section contains production-tested patterns for building scalable applications with FraiseQL. Each pattern includes:
-
-- Complete schema design
-- Architecture diagrams
-- Database structure
-- Query optimization strategies
-- Security considerations
-- Scaling guidelines
+Application blueprints for building production services with FraiseQL v1. Each blueprint
+is a complete, opinionated design built on the same runtime foundation: Python decorators
+(`@fraiseql.type`, `@fraiseql.query`, `@fraiseql.mutation`, `@fraiseql.subscription`)
+served over FastAPI, with all data and write logic living in PostgreSQL.
 
 ---
 
-## SaaS & Multi-Tenancy
+## How these blueprints fit together
+
+Every pattern below follows FraiseQL's CQRS model:
+
+- **Reads** — `@query` resolvers call `db.find` / `db.find_one` on `v_` / `tv_` views.
+  The view's `data` JSONB is shaped to the requested GraphQL fields at runtime.
+- **Writes** — `@mutation` resolvers call PostgreSQL `fn_` functions via
+  `db.execute_function`. All write business logic and validation live in the database.
+- **Streams** — `@subscription` resolvers are async generators (often backed by
+  PostgreSQL `LISTEN/NOTIFY`) whose yielded values FraiseQL pushes over WebSocket.
+- **Identity** — the trinity pattern (`pk_` internal BIGINT, `id` public UUID,
+  optional `identifier` slug) keeps internal keys out of the API.
+
+The schema is assembled in memory at app startup. There is no build step and no
+generated artifact — `create_fraiseql_app(...)` (or `build_fraiseql_schema(...)`)
+wires your types, queries, and mutations into a running GraphQL service.
+
+---
+
+## The Blueprints
 
 ### [Multi-Tenant SaaS with Row-Level Security](./saas-multi-tenant.md)
 
-**Use Case:** Build a SaaS platform where customers are isolated at the database row level.
-
-**Architecture:**
-
-- Single PostgreSQL instance with tenant ID per row
-- Automatic tenant context injection from JWT claims
-- Row-level security policies in database
-- Billing integration with Stripe
-
-**Includes:**
-
-- Tenant isolation schema design
-- Dynamic data filtering at query time
-- Subscription management
-- Usage-based billing calculations
-- Audit logging per tenant
-
----
-
-## Analytics & Data Warehousing
+Build a B2B SaaS where tenants are isolated at the database row level. Each row carries
+a `tenant_id`; PostgreSQL Row-Level Security policies read `current_setting('app.tenant_id')`,
+and FraiseQL sets that session GUC per transaction from `info.context["tenant_id"]`.
 
 ### [Analytics Platform with OLAP](./analytics-olap-platform.md)
 
-**Use Case:** Build a BI/analytics dashboard querying large datasets efficiently.
-
-**Architecture:**
-
-- Fact tables for events (millions of rows)
-- Dimension tables for context
-- Materialized views for aggregations
-- Real-time and batch query support
-- Arrow Flight for bulk exports
-
-**Includes:**
-
-- Star schema design
-- Aggregation query patterns
-- Time-series data handling
-- Drill-down analytics queries
-- Performance optimization for large datasets
-- Export to Excel/CSV/Parquet
-
----
-
-## Database Federation
-
-### [Multi-Database Federation](./federation-patterns.md)
-
-**Use Case:** Query across multiple databases (PostgreSQL, MySQL, SQLite) as a unified GraphQL API.
-
-**Architecture:**
-
-- PostgreSQL as primary (customer data)
-- MySQL as secondary (historical data)
-- SQLite for local caching
-- Cross-database joins
-- Transaction coordination
-
-**Includes:**
-
-- Federation setup and configuration
-- Cross-database query execution
-- Consistency guarantees
-- Failover handling
-- Performance considerations
-
----
-
-## Real-Time Collaborative Apps
+Build a BI/analytics service over star-schema fact and dimension tables. Aggregations use
+FraiseQL's runtime auto-aggregation (COUNT, SUM, AVG, MIN, MAX, STDDEV, VARIANCE) and
+standard PostgreSQL `GROUP BY` / `HAVING` / `FILTER` inside your `v_` / `tv_` views.
 
 ### [Real-Time Collaboration with Subscriptions](./realtime-collaboration.md)
 
-**Use Case:** Build collaborative tools (document editor, project management) with real-time updates.
-
-**Architecture:**
-
-- WebSocket subscriptions for live updates
-- Operational transformation for conflict resolution
-- Event sourcing for audit trail
-- Presence tracking (who's online)
-- Optimistic concurrency control
-
-**Includes:**
-
-- Subscription patterns for live data
-- Conflict resolution strategies
-- Presence management
-- Activity feeds
-- Notification system
-
----
-
-## IoT & Time-Series Data
-
-### [IoT Platform with Time-Series Data](./iot-timeseries.md)
-
-**Use Case:** Collect and query IoT sensor data efficiently (millions of data points).
-
-**Architecture:**
-
-- Time-partitioned tables for sensor readings
-- Aggregation tables for rollups (hourly, daily)
-- Retention policies
-- Real-time alerts
-- Streaming ingestion
-
-**Includes:**
-
-- Schema design for high-cardinality data
-- Efficient time-range queries
-- Downsampling strategies
-- Alert query patterns
-- Scaling to billions of points
-
----
-
-## E-Commerce Platform
+Build collaborative tools (document editors, project boards) with live updates. Uses
+`@fraiseql.subscription` async generators over WebSocket, typically backed by PostgreSQL
+`LISTEN/NOTIFY`, plus presence tracking and activity feeds.
 
 ### [E-Commerce with Complex Workflows](./ecommerce-workflows.md)
 
-**Use Case:** Build e-commerce with orders, inventory, fulfillment workflows.
+Build an online store with product catalogs, an order state machine, inventory reservations,
+and fulfillment. Writes flow through `fn_` functions; reads come from `v_` / `tv_` views;
+order state transitions are enforced in the database.
 
-**Architecture:**
+### [IoT Platform with Time-Series Data](./iot-timeseries.md)
 
-- Product catalog with variants
-- Order management with state machine
-- Inventory tracking and reservations
-- Fulfillment pipeline
-- Returns and refunds
-
-**Includes:**
-
-- Schema for products/variants/SKUs
-- Order state machine design
-- Inventory allocation queries
-- Reporting dashboards
-- Integration with payment processors
-
----
-
-## Content Management System (CMS)
-
-### [Headless CMS with Versioning](../patterns/realtime-collaboration.md)
-
-**Use Case:** Build a headless CMS with content versioning, drafts, and publishing workflows.
-
-**Architecture:**
-
-- Content models (dynamic types)
-- Version history tracking
-- Draft/published states
-- Media management
-- Content relationship graphs
-
-**Includes:**
-
-- Polymorphic content types
-- Version control and rollback
-- Publication workflows
-- SEO metadata management
-- API-first design
-
----
-
-## Social Network Platform
-
-### [Social Network with Activity Feeds](../patterns/realtime-collaboration.md)
-
-**Use Case:** Build a social network with feeds, followers, messaging, and notifications.
-
-**Architecture:**
-
-- User graph with follower relationships
-- Activity feed generation
-- Real-time notifications
-- Messaging with threading
-- Privacy controls per post
-
-**Includes:**
-
-- Graph queries for friends/followers
-- Feed algorithms (chronological, algorithmic)
-- Notification delivery
-- Private messaging
-- Content visibility rules
-
----
-
-## Common Patterns Across All Applications
-
-### Data Validation
-
-- Pre-insert validation on mutation
-- Custom business rule validation
-- Referential integrity checks
-- Type coercion and sanitization
-
-### Error Handling
-
-- Validation error responses with field-level details
-- Business logic error codes
-- User-friendly error messages
-- Error tracking and monitoring
-
-### Performance Optimization
-
-- Query result caching strategies
-- N+1 query prevention
-- Pagination for large result sets
-- Connection pooling at backend
-- Database index strategy
-
-### Security
-
-- Authentication with JWT tokens
-- Authorization per object and field
-- SQL injection prevention (prepared statements)
-- Rate limiting per user/IP
-- Audit logging for sensitive operations
-
-### Monitoring & Observability
-
-- Query execution time tracking
-- Error rate monitoring
-- Database query metrics
-- Application performance monitoring (APM)
-- Distributed tracing
+Collect and query high-volume sensor data. Uses time-partitioned tables, rollup tables for
+hourly/daily aggregates refreshed by functions, retention policies, and time bucketing with
+`DATE_TRUNC` inside views.
 
 ---
 
 ## Pattern Selection Guide
 
-Choose a pattern based on your application needs:
-
 | Pattern | Best For | Scale |
 |---------|----------|-------|
-| **Multi-Tenant SaaS** | B2B SaaS platforms, white-label solutions | 10K-100K+ customers |
-| **Analytics OLAP** | BI dashboards, business intelligence, reporting | 100GB-100TB+ data |
-| **Database Federation** | Legacy system migration, data warehouse queries | Multiple data sources |
-| **Real-Time Collaboration** | Google Docs-like, Figma-like, project management | 100-10K+ concurrent users |
-| **IoT Time-Series** | Sensor networks, monitoring systems, metrics | Billions of data points |
-| **E-Commerce** | Online stores, marketplaces, product catalogs | 1M-100M+ products |
-| **Headless CMS** | Content platforms, publishing, websites | 10K-100K+ content items |
-| **Social Network** | User communities, social platforms, forums | 1M-1B+ users |
+| **Multi-Tenant SaaS** | B2B SaaS platforms, white-label products | 10K-100K+ tenants |
+| **Analytics OLAP** | BI dashboards, reporting, business intelligence | 100GB-100TB+ data |
+| **Real-Time Collaboration** | Document editors, boards, project management | 100-10K+ concurrent users |
+| **E-Commerce** | Online stores, marketplaces, catalogs | 1M-100M+ products |
+| **IoT Time-Series** | Sensor networks, monitoring, metrics | Billions of data points |
+
+---
+
+## Concerns Common to Every Blueprint
+
+### Data validation
+
+- Validation lives in PostgreSQL `fn_` functions, which return JSONB indicating success
+  or a structured error.
+- Referential integrity is enforced by foreign keys and constraints on `tb_` tables.
+- GraphQL input types coerce and type-check arguments before they reach the database.
+
+### Error handling
+
+- Mutations return a success-or-error union (`@fraiseql.success` / `@fraiseql.error`),
+  so clients receive field-level details and stable error codes.
+- Internal error details stay in the database/server logs, not in the API response.
+
+### Performance
+
+- Result caching with cascade invalidation via FraiseQL's PostgreSQL-backed cache
+  (`ResultCache`, `CachedRepository`, `cached_query`).
+- N+1 prevention with `@fraiseql.dataloader_field` and view-level joins.
+- Cursor-based pagination for large result sets; PostgreSQL indexes on read views.
+
+### Security
+
+- Authentication via JWT; authorization via an `Authorizer` passed to
+  `@fraiseql.query(authorizer=...)` / `@fraiseql.subscription(authorizer=...)` and/or
+  PostgreSQL RLS policies.
+- SQL injection prevention through parameterized queries everywhere.
+- Rate limiting and audit logging for sensitive operations.
 
 ---
 
 ## Common Challenges & Solutions
 
-### Challenge: N+1 Queries
+### Challenge: N+1 queries
 
-**Problem:** Fetching parent then iterating children causes excessive queries
-
-**Solution:** Use FraiseQL's nested query syntax or batch queries
+Fetching a parent then iterating its children issues one query per child. Request nested
+relationships in a single GraphQL query (FraiseQL resolves them from the view's JSONB) and
+use `@fraiseql.dataloader_field` for batched lookups.
 
 ```graphql
-<!-- Code example in GraphQL -->
-# ✅ Good: Single query with nested relationships
 query GetPostsWithAuthors {
   posts {
     id
@@ -308,17 +139,13 @@ query GetPostsWithAuthors {
     }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-### Challenge: Large Result Sets
+### Challenge: Large result sets
 
-**Problem:** Querying millions of rows causes memory issues
-
-**Solution:** Implement cursor-based pagination
+Querying millions of rows at once strains memory. Use cursor-based pagination.
 
 ```graphql
-<!-- Code example in GraphQL -->
 query GetPostsPaginated($first: Int!, $after: String) {
   posts(first: $first, after: $after) {
     edges {
@@ -334,71 +161,51 @@ query GetPostsPaginated($first: Int!, $after: String) {
     }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-### Challenge: Complex Authorization Rules
+### Challenge: Tenant and row-level authorization
 
-**Problem:** Some users can see only subset of data
+Some users may see only a subset of rows. Enforce visibility with PostgreSQL RLS policies
+that read session GUCs FraiseQL sets from the request context.
 
-**Solution:** Use row-level security in database + custom claims in JWT
+```sql
+-- RLS policy on a tenant-scoped table
+CREATE POLICY tenant_isolation ON tb_document
+  USING (
+    tenant_id = current_setting('app.tenant_id')::uuid
+    AND (is_public OR owner_id = current_setting('app.user_id')::uuid)
+  );
+```
 
-```text
-<!-- Code example in TEXT -->
-JWT Claims: { userId: "123", role: "admin", tenantId: "tenant_456" }
-              ↓
-Database RLS Policy: WHERE tenant_id = JWT.tenantId AND (is_public OR owner_id = JWT.userId)
-```text
-<!-- Code example in TEXT -->
+### Challenge: Real-time updates
 
-### Challenge: Real-Time Updates
-
-**Problem:** Need live data updates for subscriptions
-
-**Solution:** Use WebSocket subscriptions with intelligent filtering
+Clients need live data without polling. Stream changes with a WebSocket subscription whose
+async generator yields on PostgreSQL `LISTEN/NOTIFY` events.
 
 ```graphql
-<!-- Code example in GraphQL -->
-subscription OnUserOnline {
+subscription OnUserStatusChanged {
   userStatusChanged {
     userId
-    status  # online, idle, offline
+    status
     lastSeen
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
 ## See Also
 
-**Detailed Patterns:**
+**Detailed blueprints:**
 
 - [Multi-Tenant SaaS with RLS](./saas-multi-tenant.md)
 - [Analytics Platform with OLAP](./analytics-olap-platform.md)
-- [Database Federation](./federation-patterns.md)
 - [Real-Time Collaboration](./realtime-collaboration.md)
-- [IoT Time-Series Data](./iot-timeseries.md)
 - [E-Commerce Workflows](./ecommerce-workflows.md)
-- [Headless CMS](../patterns/realtime-collaboration.md)
-- [Social Network Platform](../patterns/realtime-collaboration.md)
+- [IoT Time-Series Data](./iot-timeseries.md)
 
-**Related Guides:**
+**Foundations:**
 
-- [Production Deployment](../guides/production-deployment.md)
-- [Performance Optimization](../guides/performance-optimization.md)
-- [Schema Design Best Practices](../guides/schema-design-best-practices.md)
-- [Security Checklist](../guides/production-security-checklist.md)
-
-**Full-Stack Examples:**
-
-- [Python + React Example](../tutorials/fullstack-python-react.md)
-- [TypeScript + Vue Example](../examples/fullstack-typescript-vue.md)
-- [Go + Flutter Example](../examples/fullstack-go-flutter.md)
-- [Java + Next.js Example](../examples/fullstack-java-nextjs.md)
-
----
-
-**Last Updated:** 2026-02-05
-**Version:** v2.0.0-alpha.1
+- [Documentation Home](../index.md)
+- [Core Concepts](../foundation/02-core-concepts.md)
+- [Quickstart](../getting-started/quickstart.md)

--- a/docs/patterns/analytics-olap-platform.md
+++ b/docs/patterns/analytics-olap-platform.md
@@ -1,834 +1,567 @@
-<!-- Skip to main content -->
 ---
-
 title: Analytics Platform with OLAP
-description: Complete guide to building a scalable analytics and business intelligence platform using FraiseQL with OLAP (Online Analytical Processing) patterns.
-keywords: ["workflow", "saas", "realtime", "ecommerce", "analytics", "federation"]
-tags: ["documentation", "reference"]
+description: Build a scalable analytics and business-intelligence platform with FraiseQL using PostgreSQL fact/dimension modelling, view-backed reads, and runtime auto-aggregation.
+keywords: ["analytics", "olap", "aggregation", "fact-table", "dimension", "postgresql"]
+tags: ["documentation", "patterns"]
 ---
 
 # Analytics Platform with OLAP
 
-**Status:** ✅ Production Ready
-**Complexity:** ⭐⭐⭐⭐ (Advanced)
+**Status:** Production Ready
+**Complexity:** Advanced
 **Audience:** Data engineers, analytics architects, BI developers
 **Reading Time:** 30-35 minutes
-**Last Updated:** 2026-02-05
 
-Complete guide to building a scalable analytics and business intelligence platform using FraiseQL with OLAP (Online Analytical Processing) patterns.
-
----
-
-## Architecture Overview
-
-**Diagram: Analytics Pattern** - Denormalized fact table design with JSONB dimensions
-
-```d2
-<!-- Code example in D2 Diagram -->
-direction: down
-
-Sources: "Data Sources" {
-  shape: box
-  style.fill: "#e3f2fd"
-  children: [
-    AppDB: "Application\nDatabases"
-    APIs: "APIs"
-    ThirdParty: "Third-Party\nServices"
-  ]
-}
-
-Warehouse: "Data Warehouse (PostgreSQL)" {
-  shape: box
-  style.fill: "#f3e5f5"
-  children: [
-    Fact: "Fact Tables\n(Events - billions of rows)"
-    Dim: "Dimension Tables\n(Reference data)"
-    Agg: "Aggregate Tables\n(Pre-computed)"
-  ]
-}
-
-Server: "FraiseQL Server (OLAP Mode)" {
-  shape: box
-  style.fill: "#fff3e0"
-  children: [
-    Exec: "Executes analytical queries"
-    Scale: "Handles aggregations at scale"
-    Export: "Supports Arrow Flight for bulk exports"
-  ]
-}
-
-Consumers: "Data Consumers" {
-  shape: box
-  style.fill: "#c8e6c9"
-  children: [
-    Dashboard: "📊 Dashboards\n(React)"
-    Reports: "📄 Reports\n(PDF)"
-    Exports: "📥 Exports\n(Excel)"
-    RealTime: "🔴 Real-time\n(WebSocket)"
-  ]
-}
-
-Sources -> Warehouse: "ETL/ELT"
-Warehouse -> Server: "GraphQL OLAP queries"
-Server -> Consumers: "Results"
-```text
-<!-- Code example in TEXT -->
+This guide shows how to build an OLAP-style analytics and business-intelligence
+platform on top of FraiseQL. Everything here is **PostgreSQL-only** and runs at
+**application runtime** — there is no compile step, no columnar engine, and no
+separate analytics server. You model your analytics in PostgreSQL (fact and
+dimension tables you maintain via ETL, plus `v_`/`tv_` read views), and FraiseQL
+serves them as a GraphQL API. When a query selects dimensions and measures,
+FraiseQL derives the `GROUP BY` + aggregate SQL automatically at runtime.
 
 ---
 
-## Schema Design: FraiseQL Fact Tables (Denormalized OLAP)
+## How FraiseQL Fits OLAP
 
-FraiseQL uses a **denormalized fact table pattern** optimized for fast analytics without expensive joins:
+| Concern | Where it lives |
+|---------|----------------|
+| Raw events / fact rows | PostgreSQL tables you load via ETL (e.g. `tb_event`) |
+| Reference / dimension data | PostgreSQL dimension tables (e.g. `tb_dim_product`) |
+| Read model exposed to GraphQL | `v_` views (logical) or `tv_` projection tables (pre-composed) |
+| Aggregation (`GROUP BY` + `SUM`/`AVG`/…) | Derived at **runtime** by FraiseQL from the selected fields |
+| Heavy pre-computed rollups | Aggregate tables / materialized views you refresh on a schedule |
 
-**Diagram: Analytics Pattern** - Denormalized fact table design with JSONB dimensions
-
-```d2
-<!-- Code example in D2 Diagram -->
-direction: right
-
-FactTable: "tf_events\n(Fact Table)" {
-  shape: box
-  style.fill: "#fff59d"
-  style.border: "3px solid #f57f17"
-  children: [
-    Measures: "Measures (SQL columns)\nrevenue, quantity, sessions"
-    Dimensions: "Dimensions (JSONB)\nuser, product, category, region"
-    Filters: "Filters (Indexed)\nuser_id, occurred_at"
-  ]
-}
-
-Benefits: "✅ No expensive joins\n✅ Flexible dimensions\n✅ Fast GROUP BY" {
-  shape: box
-  style.fill: "#c8e6c9"
-}
-
-FactTable -> Benefits
-```text
-<!-- Code example in TEXT -->
-
-**Why FraiseQL's Pattern?**
-
-| Aspect | Traditional Star Schema | FraiseQL Fact Tables |
-|--------|----------------------|-------------------|
-| **Structure** | Fact table + multiple dimension tables | Single denormalized fact table |
-| **Joins** | Multiple expensive joins per query | No joins needed |
-| **Dimensions** | Fixed schema columns | JSONB with flexible schema |
-| **Query Speed** | Slower (N joins) | Faster (no joins) |
-| **Schema Flexibility** | Hard to add dimensions | Easy (JSONB expansion) |
+FraiseQL's reads always go through a view (or `tv_` projection table) that exposes
+a public `id` column and a `data` JSONB column built with `jsonb_build_object(...)`.
+The internal `pk_*`/`fk_*` BIGINT keys used for fast joins are **never** exposed and
+**never** placed inside `data`.
 
 ---
 
-### Fact Tables (tf_events)
+## Runtime Auto-Aggregation
 
-FraiseQL fact tables follow a three-part structure:
+This is the core OLAP capability. When a GraphQL query against a view-backed type
+selects aggregate fields, FraiseQL builds the `GROUP BY` and the aggregate
+expressions for you at runtime — no compiler, no plan artifacts, no special
+decorator. The supported PostgreSQL aggregates are:
+
+`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, `STDDEV`, `VARIANCE`
+
+You declare which measures a view-backed type can aggregate, and which fields act
+as group-by dimensions, when you register the type for its view:
+
+```python
+import fraiseql
+from fraiseql.types import ID, Date
+
+@fraiseql.type(sql_source="v_event", jsonb_column="data")
+class Event:
+    """A single analytics event, read from v_event."""
+    id: ID
+    event_date: Date
+    product_id: str
+    category: str
+    region: str
+    source: str
+    device_type: str
+    revenue: float
+    quantity: int
+    sessions: int
+```
+
+```python
+from fraiseql import register_type_for_view
+
+# Declare the aggregations FraiseQL may derive at runtime for this view.
+register_type_for_view(
+    Event,
+    view_name="v_event",
+    aggregation={
+        "group_by": ["event_date", "product_id", "category", "region", "source"],
+        "measures": {
+            "revenue": ["SUM", "AVG", "MIN", "MAX"],
+            "quantity": ["SUM", "AVG"],
+            "sessions": ["SUM"],
+            "id": ["COUNT"],
+        },
+    },
+)
+```
+
+A GraphQL query then picks the dimensions and measures it wants, and FraiseQL
+derives the SQL:
+
+```graphql
+query RevenueByProduct($start: Date!, $end: Date!) {
+  events(
+    where: { eventDate: { gte: $start, lte: $end } }
+    groupBy: [PRODUCT_ID, CATEGORY]
+  ) {
+    productId
+    category
+    revenueSum
+    revenueAvg
+    quantitySum
+    count
+  }
+}
+```
+
+FraiseQL's repository (`_derive_auto_aggregation` / `_parse_aggregation_expr` in
+`db.py`) turns the selected dimensions into a `GROUP BY` clause and the selected
+measures into the matching aggregate expressions, then executes the query against
+`v_event`. The `where` clause maps to a parameterized `WHERE` on the view.
+
+> All aggregation is plain PostgreSQL. Anything you can express with `GROUP BY`,
+> `HAVING`, `FILTER (WHERE …)`, and window functions can be embedded in the view
+> SQL; FraiseQL's auto-aggregation handles the common dimension/measure rollups
+> on top of that.
+
+---
+
+## Schema Design: Fact and Dimension Tables
+
+The classic OLAP modelling pattern works directly in PostgreSQL. You maintain the
+fact and dimension tables through your own ETL/load process, and FraiseQL reads
+them through views.
+
+### Fact Table
+
+A fact table holds the numeric measures plus the foreign keys (or denormalized
+dimension values) needed to slice them.
 
 ```sql
-<!-- Code example in SQL -->
--- Fact table with measures, JSONB dimensions, and indexed filters
-CREATE TABLE tf_events (
-  -- Row identifier
-  event_id BIGSERIAL PRIMARY KEY,
+CREATE TABLE tb_event (
+    pk_event       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id             UUID NOT NULL DEFAULT gen_random_uuid(),
 
-  -- MEASURES: Numeric columns for fast aggregation
-  revenue DECIMAL(12, 2),
-  quantity INT,
-  cost DECIMAL(12, 2),
-  sessions INT,
+    -- Measures: numeric columns for fast aggregation
+    revenue        NUMERIC(12, 2),
+    quantity       INT,
+    cost           NUMERIC(12, 2),
+    sessions       INT,
 
-  -- DIMENSIONS: JSONB for flexible GROUP BY
-  -- Contains: user_category, product, region, country, utm_source, etc.
-  data JSONB NOT NULL,
+    -- Dimensions: foreign keys to dimension tables + flexible JSONB attributes
+    fk_product     BIGINT REFERENCES tb_dim_product (pk_product),
+    fk_user        BIGINT REFERENCES tb_dim_user (pk_user),
+    attributes     JSONB NOT NULL DEFAULT '{}'::jsonb,  -- utm_source, device, etc.
 
-  -- FILTERS: Indexed denormalized columns for fast WHERE
-  user_id UUID NOT NULL,
-  occurred_at TIMESTAMP NOT NULL,
-
-  -- Temporal partitioning
-  event_date DATE NOT NULL,  -- Partition key
-
-  -- Audit columns
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  -- Indexes for query performance
-  INDEX idx_event_date (event_date),
-  INDEX idx_user_id (user_id),
-  INDEX idx_occurred_at (occurred_at),
-  INDEX idx_data GIN (data)
+    -- Filters: indexed columns for fast WHERE / time-range scans
+    occurred_at    TIMESTAMPTZ NOT NULL,
+    event_date     DATE NOT NULL  -- partition key
 ) PARTITION BY RANGE (event_date);
 
--- Create monthly partitions
-CREATE TABLE tf_events_2024_01 PARTITION OF tf_events
-  FOR VALUES FROM ('2024-01-01') TO ('2024-02-01');
-CREATE TABLE tf_events_2024_02 PARTITION OF tf_events
-  FOR VALUES FROM ('2024-02-01') TO ('2024-03-01');
--- ... continue for each month
-```text
-<!-- Code example in TEXT -->
+CREATE TABLE tb_event_2026_01 PARTITION OF tb_event
+    FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+CREATE TABLE tb_event_2026_02 PARTITION OF tb_event
+    FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+-- ... one partition per period
 
-**Key components:**
+CREATE INDEX idx_event_date ON tb_event (event_date);
+CREATE INDEX idx_event_occurred_at ON tb_event (occurred_at);
+CREATE INDEX idx_event_attributes ON tb_event USING GIN (attributes);
+```
 
-1. **Measures** (numeric columns):
-   - `revenue`, `quantity`, `cost`, `sessions`
-   - Used in `SUM()`, `AVG()`, `COUNT()` aggregations
-   - Keep these as direct SQL columns for performance
+Notes on the columns:
 
-2. **Dimensions** (JSONB column):
-   - Single `data` JSONB column containing flexible schema
-   - Paths like `data->>'user_category'`, `data->>'product'`, `data->>'region'`
-   - Easy to add new dimensions without schema migration
-   - Query with operators: `->>` (text), `->` (JSON), `@>` (contains)
+1. **Measures** (`revenue`, `quantity`, `cost`, `sessions`): keep these as direct
+   numeric columns so `SUM`/`AVG`/`COUNT` stay fast.
+2. **Dimensions**: model stable, frequently-joined dimensions as foreign keys to
+   dimension tables; keep sparse or fast-evolving attributes in a `JSONB` column
+   so you can add slices without a schema migration.
+3. **Filters**: index the columns you filter on most (`event_date`,
+   `occurred_at`). Avoid hot WHERE predicates that have to dig into JSONB.
+4. **Partitioning**: range-partition by `event_date` so time-range queries only
+   scan the relevant partitions, and old partitions can be detached/archived.
 
-3. **Filters** (indexed columns):
-   - `user_id`, `occurred_at` - denormalized for fast WHERE
-   - Must be indexed: `INDEX idx_user_id (user_id)`
-   - Avoid searching these values in JSONB (slow)
-
-4. **Temporal structure**:
-   - Partition by `event_date` (monthly or daily)
-   - Improves query speed for time-range filters
-   - Enables archival of old partitions
-
-### Aggregate Tables (Pre-Computed)
+### Dimension Tables
 
 ```sql
-<!-- Code example in SQL -->
--- Daily aggregates (updated nightly)
-CREATE TABLE agg_daily_metrics (
-  date DATE NOT NULL,
-  product_id UUID NOT NULL,
-  country VARCHAR(2) NOT NULL,
-  metric_name VARCHAR(50) NOT NULL,
-  metric_value DECIMAL(15, 2),
-  event_count INT,
-  unique_users INT,
-  PRIMARY KEY (date, product_id, country, metric_name),
-
-  INDEX idx_date (date),
-  INDEX idx_product_id (product_id),
-  INDEX idx_country (country)
+CREATE TABLE tb_dim_product (
+    pk_product   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id           UUID NOT NULL DEFAULT gen_random_uuid(),
+    identifier   TEXT UNIQUE,            -- optional human-readable slug
+    product_name TEXT NOT NULL,
+    category     TEXT NOT NULL,
+    region       TEXT
 );
 
--- Hourly rolling aggregates (updated every hour)
-CREATE TABLE agg_hourly_metrics (
-  hour_timestamp TIMESTAMP NOT NULL,
-  product_id UUID NOT NULL,
-  source VARCHAR(100),
-  event_count INT,
-  revenue DECIMAL(12, 2),
-  unique_users INT,
-  PRIMARY KEY (hour_timestamp, product_id, source),
-
-  INDEX idx_timestamp (hour_timestamp),
-  INDEX idx_product_id (product_id)
+CREATE TABLE tb_dim_user (
+    pk_user      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id           UUID NOT NULL DEFAULT gen_random_uuid(),
+    signup_date  DATE NOT NULL,
+    country      VARCHAR(2)
 );
+```
 
--- Cohort Analysis Table
-CREATE TABLE agg_cohorts (
-  cohort_date DATE NOT NULL,
-  days_since_signup INT NOT NULL,
-  cohort_size INT,
-  retention_rate DECIMAL(5, 2),
-  revenue DECIMAL(12, 2),
-  PRIMARY KEY (cohort_date, days_since_signup)
+### Calendar / Date Dimension
+
+A date dimension is useful for fiscal periods, week numbers, and holiday flags.
+Compute the calendar attributes in your table or view SQL — they are a
+DBA/ETL responsibility, not something FraiseQL auto-detects.
+
+```sql
+CREATE TABLE tb_dim_date (
+    pk_date     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    date_value  DATE NOT NULL UNIQUE,
+    year        INT  NOT NULL,
+    quarter     INT  NOT NULL,
+    month       INT  NOT NULL,
+    week        INT  NOT NULL,
+    day_of_week INT  NOT NULL,
+    is_weekend  BOOLEAN NOT NULL,
+    is_holiday  BOOLEAN NOT NULL DEFAULT false
 );
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
-## FraiseQL OLAP Schema
+## Read Views
 
-FraiseQL uses a **fact table pattern** with measures (SQL columns) and dimensions (JSONB):
-
-```python
-<!-- Code example in Python -->
-# analytics_schema.py
-from FraiseQL import types
-from decimal import Decimal
-from datetime import datetime, date
-
-@types.fact_table(
-    table_name="tf_events",
-    measures=["revenue", "quantity", "sessions"],
-    dimension_column="data",
-    dimension_paths=[
-        {"name": "product_id", "json_path": "data->>'product_id'", "data_type": "text"},
-        {"name": "category", "json_path": "data->>'category'", "data_type": "text"},
-        {"name": "region", "json_path": "data->>'region'", "data_type": "text"},
-        {"name": "source", "json_path": "data->>'source'", "data_type": "text"},
-        {"name": "device_type", "json_path": "data->>'device_type'", "data_type": "text"},
-    ]
-)
-@types.object
-class Event:
-    """Event fact table - denormalized for fast analytics"""
-    event_id: UUID  # UUID v4 for GraphQL ID
-    event_date: date
-    event_timestamp: datetime
-
-    # MEASURES: Numeric columns for fast SUM/AVG/COUNT aggregation
-    revenue: Decimal | None              # NULL for non-purchase events
-    quantity: int | None                 # NULL for non-sale events
-    sessions: int | None                 # Session count
-
-    # DIMENSIONS: JSONB for flexible GROUP BY
-    # Includes: product_id, category, region, source, device_type
-    dimensions: dict                     # data JSONB column
-
-    # FILTERS: Indexed denormalized columns for fast WHERE clauses
-    user_id: str                         # Indexed for fast filtering
-    occurred_at: datetime                # Indexed for time-range queries
-```text
-<!-- Code example in TEXT -->
-
-**Schema mapping:**
-
-- `revenue`, `quantity`, `sessions` → **Measures** (direct columns, fast aggregation)
-- `dimensions` dict (JSONB column `data`) → **Dimensions** (flexible, no joins needed)
-- `user_id`, `occurred_at` → **Filters** (indexed for WHERE performance)
-
-```python
-<!-- Code example in Python -->
-@types.object
-class MetricResult:
-    """Metric aggregation result"""
-    dimension_value: str
-    event_count: int
-    revenue: Decimal
-    unique_users: int
-    conversion_rate: Decimal
-
-@types.object
-class CohortResult:
-    """Cohort analysis result"""
-    cohort_date: date
-    days_since_signup: int
-    cohort_size: int
-    retention_rate: Decimal
-    revenue: Decimal
-
-@types.object
-class Query:
-    # Time-series metrics
-    def daily_revenue(
-        self,
-        start_date: date,
-        end_date: date,
-        product_id: str | None = None,
-        country: str | None = None
-    ) -> list[dict]:
-        """Daily revenue over time period"""
-        pass
-
-    def hourly_events(
-        self,
-        date: date,
-        event_type: str | None = None
-    ) -> list[dict]:
-        """Hourly event breakdown for a day"""
-        pass
-
-    # Segmentation queries
-    def revenue_by_product(
-        self,
-        start_date: date,
-        end_date: date,
-        limit: int = 50
-    ) -> list[MetricResult]:
-        """Revenue segmented by product"""
-        pass
-
-    def conversion_by_source(
-        self,
-        start_date: date,
-        end_date: date
-    ) -> list[MetricResult]:
-        """Conversion rate by traffic source"""
-        pass
-
-    def customer_lifetime_value_distribution(
-        self,
-        country: str | None = None
-    ) -> list[dict]:
-        """Distribution of customer lifetime values"""
-        pass
-
-    # Cohort analysis
-    def retention_cohort(
-        self,
-        cohort_start: date,
-        cohort_end: date,
-        max_days: int = 90
-    ) -> list[CohortResult]:
-        """User retention by signup cohort"""
-        pass
-
-    # Funnel analysis
-    def conversion_funnel(
-        self,
-        start_date: date,
-        end_date: date,
-        steps: list[str]  # ['view', 'add_to_cart', 'purchase']
-    ) -> list[dict]:
-        """Funnel conversion analysis"""
-        pass
-
-    # Real-time metrics
-    def realtime_metrics(self) -> dict:
-        """Current real-time metrics (last 1 hour)"""
-        pass
-
-    # Drill-down queries
-    def product_details(
-        self,
-        product_id: str,
-        start_date: date,
-        end_date: date
-    ) -> dict:
-        """Deep-dive into single product performance"""
-        pass
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Complex OLAP Queries
-
-### Daily Revenue Trend
-
-```graphql
-<!-- Code example in GraphQL -->
-query DailyRevenue($startDate: Date!, $endDate: Date!, $productId: ID) {
-  dailyRevenue(startDate: $startDate, endDate: $endDate, productId: $productId) {
-    date
-    revenue
-    orders
-    average_order_value
-    unique_customers
-    returning_customer_percentage
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Corresponding SQL (generated by FraiseQL):**
+FraiseQL queries a `v_` view (or a `tv_` projection table), never the raw fact
+table directly. The view joins the dimensions you need and emits a `data` JSONB
+payload alongside the public `id`. Aggregations are derived on top of this view at
+runtime.
 
 ```sql
-<!-- Code example in SQL -->
+CREATE VIEW v_event AS
 SELECT
-  event_date as date,
-  SUM(revenue) as revenue,
-  COUNT(DISTINCT order_id) as orders,
-  AVG(revenue) as average_order_value,
-  COUNT(DISTINCT user_id) as unique_customers,
-  ROUND(
-    SUM(CASE WHEN is_returning THEN 1 ELSE 0 END)::NUMERIC / COUNT(DISTINCT user_id) * 100,
-    2
-  ) as returning_customer_percentage
-FROM events
-WHERE event_date BETWEEN $1 AND $2
-  AND event_type = 'purchase'
-  AND (product_id = $3 OR $3 IS NULL)
-GROUP BY event_date
-ORDER BY event_date DESC;
-```text
-<!-- Code example in TEXT -->
+    e.id,                               -- public UUID, required by FraiseQL
+    e.event_date,
+    e.occurred_at,
+    p.id          AS product_id,
+    p.category,
+    p.region,
+    e.attributes ->> 'source'      AS source,
+    e.attributes ->> 'device_type' AS device_type,
+    e.revenue,
+    e.quantity,
+    e.sessions,
+    jsonb_build_object(
+        'event_date',  e.event_date,
+        'product_id',  p.id,
+        'category',    p.category,
+        'region',      p.region,
+        'source',      e.attributes ->> 'source',
+        'device_type', e.attributes ->> 'device_type',
+        'revenue',     e.revenue,
+        'quantity',    e.quantity,
+        'sessions',    e.sessions
+    ) AS data
+FROM tb_event e
+LEFT JOIN tb_dim_product p ON p.pk_product = e.fk_product;
+```
 
-### Cohort Retention Analysis
+### `tv_` Projection Tables for Heavy Reads
 
-```graphql
-<!-- Code example in GraphQL -->
-query RetentionCohort($cohortStart: Date!, $cohortEnd: Date!, $maxDays: Int!) {
-  retentionCohort(cohortStart: $cohortStart, cohortEnd: $cohortEnd, maxDays: $maxDays) {
-    cohortDate
-    daysSinceSilgnup
-    cohortSize
-    retentionRate
-    revenue
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**SQL (complex multi-CTE query):**
+When a read is too expensive to compute per request — deep nesting, wide joins, or
+large rollups — materialize it into a `tv_` projection table: a real table holding
+pre-composed JSONB, refreshed by functions, triggers, or a schedule. FraiseQL
+queries a `tv_` table exactly like a `v_` view.
 
 ```sql
-<!-- Code example in SQL -->
+CREATE TABLE tv_daily_product_metrics (
+    id           UUID NOT NULL DEFAULT gen_random_uuid(),
+    metric_date  DATE NOT NULL,
+    product_id   UUID NOT NULL,
+    data         JSONB NOT NULL,        -- pre-composed payload
+    PRIMARY KEY (metric_date, product_id)
+);
+```
+
+---
+
+## Aggregation Patterns in View SQL
+
+Beyond the runtime auto-aggregation, the heavy lifting of OLAP lives in plain
+PostgreSQL that you embed in your `v_`/`tv_` views.
+
+### Time Bucketing with `DATE_TRUNC`
+
+```sql
+SELECT
+    DATE_TRUNC('day', e.occurred_at)::DATE AS bucket,
+    SUM(e.revenue)                          AS revenue,
+    COUNT(*)                                AS events,
+    AVG(e.revenue)                          AS avg_order_value
+FROM tb_event e
+WHERE e.event_date BETWEEN $1 AND $2
+GROUP BY DATE_TRUNC('day', e.occurred_at)
+ORDER BY bucket;
+```
+
+### Conditional Aggregates with `FILTER (WHERE …)`
+
+`FILTER` computes several conditional measures in a single scan — ideal for funnel
+and segmentation reporting.
+
+```sql
+SELECT
+    p.category,
+    COUNT(*) FILTER (WHERE e.attributes ->> 'step' = 'view')        AS views,
+    COUNT(*) FILTER (WHERE e.attributes ->> 'step' = 'add_to_cart') AS add_to_cart,
+    COUNT(*) FILTER (WHERE e.attributes ->> 'step' = 'purchase')    AS purchases,
+    SUM(e.revenue) FILTER (WHERE e.attributes ->> 'step' = 'purchase') AS revenue
+FROM tb_event e
+JOIN tb_dim_product p ON p.pk_product = e.fk_product
+WHERE e.event_date BETWEEN $1 AND $2
+GROUP BY p.category;
+```
+
+### Window Functions
+
+Window functions (`ROW_NUMBER`, `RANK`, `LAG`, `LEAD`, running totals over
+`OVER (PARTITION BY …)`) are standard PostgreSQL. Embed them in your view SQL when
+you need rankings, period-over-period deltas, or moving aggregates.
+
+```sql
+CREATE VIEW v_daily_revenue_trend AS
+SELECT
+    gen_random_uuid() AS id,
+    bucket            AS event_date,
+    revenue,
+    revenue - LAG(revenue) OVER (ORDER BY bucket)                 AS revenue_delta,
+    AVG(revenue) OVER (ORDER BY bucket ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)
+                                                                  AS revenue_7d_avg,
+    jsonb_build_object(
+        'event_date',     bucket,
+        'revenue',        revenue,
+        'revenue_delta',  revenue - LAG(revenue) OVER (ORDER BY bucket)
+    ) AS data
+FROM (
+    SELECT DATE_TRUNC('day', occurred_at)::DATE AS bucket, SUM(revenue) AS revenue
+    FROM tb_event
+    GROUP BY DATE_TRUNC('day', occurred_at)
+) daily;
+```
+
+### Cohort Retention
+
+Cohort analysis is a multi-CTE query you wrap in a view (or a `tv_` projection
+table if it is expensive):
+
+```sql
+CREATE VIEW v_retention_cohort AS
 WITH cohort_users AS (
-  SELECT
-    DATE_TRUNC('month', signup_date)::DATE as cohort_date,
-    user_id
-  FROM dim_users
-  WHERE signup_date BETWEEN $1 AND $2
+    SELECT DATE_TRUNC('month', u.signup_date)::DATE AS cohort_date, u.pk_user
+    FROM tb_dim_user u
 ),
-user_activities AS (
-  SELECT
-    cu.cohort_date,
-    cu.user_id,
-    EXTRACT(DAY FROM e.event_date - cu.cohort_date)::INT as days_since_signup,
-    SUM(e.revenue) as daily_revenue
-  FROM cohort_users cu
-  JOIN events e ON cu.user_id = e.user_id
-  WHERE e.event_date >= cu.cohort_date
-  GROUP BY cu.cohort_date, cu.user_id, EXTRACT(DAY FROM e.event_date - cu.cohort_date)
+activity AS (
+    SELECT
+        c.cohort_date,
+        c.pk_user,
+        (e.event_date - c.cohort_date)::INT AS days_since_signup
+    FROM cohort_users c
+    JOIN tb_event e ON e.fk_user = c.pk_user AND e.event_date >= c.cohort_date
 )
 SELECT
-  cohort_date,
-  days_since_signup,
-  COUNT(DISTINCT CASE WHEN days_since_signup = 0 THEN user_id END) as cohort_size,
-  ROUND(
-    COUNT(DISTINCT user_id)::NUMERIC /
-    COUNT(DISTINCT CASE WHEN days_since_signup = 0 THEN user_id END) * 100,
-    2
-  ) as retention_rate,
-  COALESCE(SUM(daily_revenue), 0) as revenue
-FROM user_activities
-WHERE days_since_signup BETWEEN 0 AND $3
-GROUP BY cohort_date, days_since_signup
-ORDER BY cohort_date, days_since_signup;
-```text
-<!-- Code example in TEXT -->
-
-### Funnel Conversion Analysis
-
-```graphql
-<!-- Code example in GraphQL -->
-query ConversionFunnel(
-  $startDate: Date!
-  $endDate: Date!
-  $steps: [String!]!
-) {
-  conversionFunnel(startDate: $startDate, endDate: $endDate, steps: $steps) {
-    step
-    users
-    dropoff
-    conversionRate
-  }
-}
-```text
-<!-- Code example in TEXT -->
+    gen_random_uuid() AS id,
+    cohort_date,
+    days_since_signup,
+    COUNT(DISTINCT pk_user) FILTER (WHERE days_since_signup = 0) AS cohort_size,
+    ROUND(
+        COUNT(DISTINCT pk_user)::NUMERIC
+        / NULLIF(COUNT(DISTINCT pk_user) FILTER (WHERE days_since_signup = 0), 0)
+        * 100, 2
+    ) AS retention_rate,
+    jsonb_build_object(
+        'cohort_date',       cohort_date,
+        'days_since_signup', days_since_signup
+    ) AS data
+FROM activity
+GROUP BY cohort_date, days_since_signup;
+```
 
 ---
 
-## Performance Optimization Strategies
+## Exposing the Analytics API
 
-### 1. Pre-Computed Aggregates
+Define the view-backed types and the queries that read them, then build the app.
+
+```python
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.types import ID, Date
+
+
+@fraiseql.type(sql_source="v_daily_revenue_trend", jsonb_column="data")
+class DailyRevenue:
+    id: ID
+    event_date: Date
+    revenue: float
+    revenue_delta: float | None
+
+
+@fraiseql.query
+async def daily_revenue(info, start: Date, end: Date) -> list[DailyRevenue]:
+    """Daily revenue trend over a date range."""
+    db = info.context["db"]
+    return await db.find(
+        "v_daily_revenue_trend",
+        where={"event_date": {"gte": start, "lte": end}},
+    )
+
+
+@fraiseql.query
+async def revenue_by_product(info, start: Date, end: Date) -> list[Event]:
+    """Revenue segmented by product, aggregated at runtime."""
+    db = info.context["db"]
+    return await db.find(
+        "v_event",
+        where={"event_date": {"gte": start, "lte": end}},
+    )
+
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/analytics",
+    types=[Event, DailyRevenue],
+    queries=[daily_revenue, revenue_by_product],
+    production=True,  # False enables the GraphQL playground
+)
+```
+
+Run it with any ASGI server:
+
+```bash
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+---
+
+## Performance Optimization
+
+### Pre-Computed Aggregate Tables
+
+For dashboards that hit the same rollups repeatedly, refresh an aggregate table on
+a schedule and expose it through a `tv_`/`v_` view.
 
 ```sql
-<!-- Code example in SQL -->
--- Refresh aggregates nightly
-CREATE OR REPLACE FUNCTION refresh_daily_aggregates()
+CREATE OR REPLACE FUNCTION fn_refresh_daily_aggregates()
 RETURNS void AS $$
 BEGIN
-  DELETE FROM agg_daily_metrics
-  WHERE date >= CURRENT_DATE - INTERVAL '1 day';
+    DELETE FROM tv_daily_product_metrics
+    WHERE metric_date >= CURRENT_DATE - INTERVAL '1 day';
 
-  INSERT INTO agg_daily_metrics
-  SELECT
-    event_date,
-    product_id,
-    country,
-    'revenue' as metric_name,
-    SUM(revenue) as metric_value,
-    COUNT(*) as event_count,
-    COUNT(DISTINCT user_id) as unique_users
-  FROM events
-  WHERE event_date >= CURRENT_DATE - INTERVAL '30 days'
-  GROUP BY event_date, product_id, country
-  UNION ALL
-  SELECT
-    event_date,
-    product_id,
-    country,
-    'events' as metric_name,
-    COUNT(*),
-    COUNT(*),
-    COUNT(DISTINCT user_id)
-  FROM events
-  WHERE event_date >= CURRENT_DATE - INTERVAL '30 days'
-  GROUP BY event_date, product_id, country;
+    INSERT INTO tv_daily_product_metrics (metric_date, product_id, data)
+    SELECT
+        e.event_date,
+        p.id,
+        jsonb_build_object(
+            'revenue',      SUM(e.revenue),
+            'event_count',  COUNT(*),
+            'unique_users', COUNT(DISTINCT e.fk_user)
+        )
+    FROM tb_event e
+    JOIN tb_dim_product p ON p.pk_product = e.fk_product
+    WHERE e.event_date >= CURRENT_DATE - INTERVAL '30 days'
+    GROUP BY e.event_date, p.id;
 END;
 $$ LANGUAGE plpgsql;
 
--- Schedule with cron (pg_cron extension)
-SELECT cron.schedule('refresh_daily_aggregates', '0 2 * * *', 'SELECT refresh_daily_aggregates()');
-```text
-<!-- Code example in TEXT -->
+-- Schedule nightly with pg_cron
+SELECT cron.schedule(
+    'refresh_daily_aggregates', '0 2 * * *',
+    'SELECT fn_refresh_daily_aggregates()'
+);
+```
 
-### 2. Partition Pruning
+### Partition Pruning
 
-Queries are automatically optimized by date:
-
-```sql
-<!-- Code example in SQL -->
--- Only scans relevant partitions
-SELECT * FROM events
-WHERE event_date BETWEEN '2024-06-01' AND '2024-06-30';
--- ↑ Only queries events_2024_06 partition
-```text
-<!-- Code example in TEXT -->
-
-### 3. Materialized Views
+Range-partitioning by `event_date` lets PostgreSQL skip irrelevant partitions:
 
 ```sql
-<!-- Code example in SQL -->
--- Fast views for common queries
+-- Only scans the January 2026 partition
+SELECT SUM(revenue) FROM tb_event
+WHERE event_date BETWEEN '2026-01-01' AND '2026-01-31';
+```
+
+### Materialized Views
+
+For expensive, slow-changing rollups, a materialized view refreshed
+concurrently keeps reads fast:
+
+```sql
 CREATE MATERIALIZED VIEW mv_top_products_by_revenue AS
 SELECT
-  p.product_id,
-  p.product_name,
-  SUM(e.revenue) as total_revenue,
-  COUNT(DISTINCT e.user_id) as unique_customers,
-  COUNT(*) as event_count
-FROM events e
-JOIN dim_products p ON e.product_id = p.product_id
+    p.id          AS product_id,
+    p.product_name,
+    SUM(e.revenue) AS total_revenue,
+    COUNT(DISTINCT e.fk_user) AS unique_customers
+FROM tb_event e
+JOIN tb_dim_product p ON p.pk_product = e.fk_product
 WHERE e.event_date >= CURRENT_DATE - INTERVAL '30 days'
-GROUP BY p.product_id, p.product_name
+GROUP BY p.id, p.product_name
 ORDER BY total_revenue DESC
 LIMIT 100;
 
--- Refresh hourly
-SELECT cron.schedule('refresh_mv_top_products', '0 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_top_products_by_revenue');
+CREATE UNIQUE INDEX idx_mv_top_products ON mv_top_products_by_revenue (product_id);
 
-CREATE INDEX idx_mv_top_products_revenue ON mv_top_products_by_revenue(total_revenue DESC);
-```text
-<!-- Code example in TEXT -->
+SELECT cron.schedule(
+    'refresh_mv_top_products', '0 * * * *',
+    'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_top_products_by_revenue'
+);
+```
 
-### 4. Columnar Storage (Citus/Timescale Extension)
+---
 
-For very large fact tables:
+## Real-Time Metrics with Subscriptions
+
+For a live dashboard, expose a subscription whose async-generator resolver yields
+the latest metrics. The generator can poll a recent-window aggregate or be driven
+by PostgreSQL `LISTEN/NOTIFY`; FraiseQL streams whatever it yields over WebSocket.
+
+```python
+import asyncio
+from collections.abc import AsyncGenerator
+
+import fraiseql
+
+
+@fraiseql.subscription
+async def realtime_metrics(info) -> AsyncGenerator[dict, None]:
+    """Stream rolling metrics for the last hour every 10 seconds."""
+    db = info.context["db"]
+    while True:
+        rows = await db.find("v_realtime_metrics")
+        yield rows[0] if rows else {}
+        await asyncio.sleep(10)
+```
+
+Back `v_realtime_metrics` with a view that aggregates the trailing window:
 
 ```sql
-<!-- Code example in SQL -->
--- Create hypertable (TimescaleDB)
-CREATE TABLE events (
-  event_timestamp TIMESTAMP NOT NULL,
-  user_id UUID,
-  event_type VARCHAR(50),
-  revenue DECIMAL(12, 2)
-) WITH (timescaledb.compress);
-
--- Compress old data automatically
-SELECT add_compression_policy('events', INTERVAL '7 days');
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Real-Time Subscriptions
-
-### Live Metrics Dashboard
-
-```graphql
-<!-- Code example in GraphQL -->
-subscription RealtimeMetrics {
-  realtimeMetrics {
-    timestamp
-    events_per_minute
-    revenue_per_minute
-    active_users
-    top_event_type
-    top_country
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Implementation:**
-
-```python
-<!-- Code example in Python -->
-@types.subscription
-class Subscription:
-    def realtime_metrics(self) -> dict:
-        """Stream updates every 10 seconds"""
-        # Queries the last 1-hour aggregates
-        # Emits when new data arrives
-        pass
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Export Capabilities
-
-### CSV Export
-
-```graphql
-<!-- Code example in GraphQL -->
-query ExportDailyRevenue($startDate: Date!, $endDate: Date!) {
-  exportDailyRevenue(startDate: $startDate, endDate: $endDate, format: CSV) {
-    url  # Pre-signed S3 URL
-    size_bytes
-    created_at
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-### Arrow Flight Export (Bulk Data)
-
-```graphql
-<!-- Code example in GraphQL -->
-query ExportArrowFlight($startDate: Date!, $endDate: Date!) {
-  exportArrowFlight(startDate: $startDate, endDate: $endDate) {
-    arrow_endpoint  # Arrow Flight server endpoint
-    query_id
-    row_count
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Client Usage:**
-
-```python
-<!-- Code example in Python -->
-import pyarrow.flight as flight
-import pandas as pd
-
-# Connect to Arrow Flight server
-client = flight.connect(('localhost', 5005))
-
-# Fetch large dataset
-flight_descriptor = flight.FlightDescriptor.for_command(
-    query_id.encode('utf-8')
-)
-reader = client.do_get(flight_descriptor)
-
-# Read into pandas
-table = reader.read_all()
-df = table.to_pandas()
-
-# Write to Parquet
-df.to_parquet('export.parquet')
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Dashboard Implementation (React)
-
-```typescript
-<!-- Code example in TypeScript -->
-import { useQuery, gql } from '@apollo/client';
-import { LineChart, PieChart } from 'recharts';
-
-const DAILY_REVENUE = gql`
-  query DailyRevenue($startDate: Date!, $endDate: Date!) {
-    dailyRevenue(startDate: $startDate, endDate: $endDate) {
-      date
-      revenue
-      orders
-    }
-  }
-`;
-
-export function AnalyticsDashboard() {
-  const [dateRange, setDateRange] = useState({
-    start: subDays(new Date(), 30),
-    end: new Date(),
-  });
-
-  const { data, loading } = useQuery(DAILY_REVENUE, {
-    variables: {
-      startDate: format(dateRange.start, 'yyyy-MM-dd'),
-      endDate: format(dateRange.end, 'yyyy-MM-dd'),
-    },
-    fetchPolicy: 'cache-and-network',
-  });
-
-  if (loading) return <div>Loading...</div>;
-
-  return (
-    <div className="dashboard">
-      <DateRangePicker onChange={setDateRange} />
-      <LineChart data={data?.dailyRevenue}>
-        <XAxis dataKey="date" />
-        <YAxis />
-        <Line type="monotone" dataKey="revenue" />
-      </LineChart>
-      <KPICards data={data} />
-    </div>
-  );
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Testing Analytical Queries
-
-```typescript
-<!-- Code example in TypeScript -->
-describe('Analytical Queries', () => {
-  it('should calculate daily revenue', async () => {
-    const result = await client.query(DAILY_REVENUE, {
-      variables: {
-        startDate: '2024-01-01',
-        endDate: '2024-01-31',
-      },
-    });
-
-    expect(result.data.dailyRevenue).toHaveLength(31);
-    expect(result.data.dailyRevenue[0]).toHaveProperty('revenue');
-    expect(result.data.dailyRevenue[0].revenue).toBeGreaterThan(0);
-  });
-
-  it('should handle date filtering', async () => {
-    const result = await client.query(DAILY_REVENUE, {
-      variables: {
-        startDate: '2024-06-15',
-        endDate: '2024-06-20',
-      },
-    });
-
-    expect(result.data.dailyRevenue.length).toBeLessThanOrEqual(6);
-    result.data.dailyRevenue.forEach((day: any) => {
-      expect(day.date).toBeGreaterThanOrEqual('2024-06-15');
-      expect(day.date).toBeLessThanOrEqual('2024-06-20');
-    });
-  });
-
-  it('should calculate cohort retention correctly', async () => {
-    const result = await client.query(RETENTION_COHORT, {
-      variables: {
-        cohortStart: '2024-01-01',
-        cohortEnd: '2024-02-01',
-        maxDays: 30,
-      },
-    });
-
-    // Retention rate should decrease over time
-    const rates = result.data.retentionCohort.map(c => c.retention_rate);
-    for (let i = 1; i < rates.length; i++) {
-      expect(rates[i]).toBeLessThanOrEqual(rates[i - 1]);
-    }
-  });
-});
-```text
-<!-- Code example in TEXT -->
+CREATE VIEW v_realtime_metrics AS
+SELECT
+    gen_random_uuid() AS id,
+    COUNT(*)          AS events_last_hour,
+    SUM(revenue)      AS revenue_last_hour,
+    COUNT(DISTINCT fk_user) AS active_users,
+    jsonb_build_object(
+        'events_last_hour',  COUNT(*),
+        'revenue_last_hour', SUM(revenue),
+        'active_users',      COUNT(DISTINCT fk_user)
+    ) AS data
+FROM tb_event
+WHERE occurred_at >= NOW() - INTERVAL '1 hour';
+```
 
 ---
 
 ## Monitoring Analytical Performance
 
+Use `pg_stat_statements` to find the slowest analytical queries and the views that
+need a `tv_` projection or an extra index:
+
 ```sql
-<!-- Code example in SQL -->
--- Track slow analytical queries
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
-SELECT
-  query,
-  calls,
-  mean_exec_time,
-  max_exec_time
+SELECT query, calls, mean_exec_time, max_exec_time
 FROM pg_stat_statements
-WHERE query LIKE '%events%'
+WHERE query ILIKE '%v_event%'
 ORDER BY mean_exec_time DESC
 LIMIT 20;
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -836,20 +569,18 @@ LIMIT 20;
 
 **Related Patterns:**
 
-- [Multi-Tenant SaaS](./saas-multi-tenant.md) - Per-tenant analytics
-- [IoT Time-Series](./iot-timeseries.md) - Specialized time-series
+- [Patterns Overview](./README.md)
+- [Multi-Tenant SaaS](./saas-multi-tenant.md) — per-tenant analytics with RLS
+- [IoT Time-Series](./iot-timeseries.md) — specialized time-series ingestion and bucketing
 
-**Performance Guides:**
+**Architecture:**
+
+- [Aggregation Model](../architecture/analytics/aggregation-model.md)
+- [Fact/Dimension Pattern](../architecture/analytics/fact-dimension-pattern.md)
+- [`tv_` Table Pattern](../architecture/database/tv-table-pattern.md)
+
+**Guides:**
 
 - [Performance Optimization](../guides/performance-optimization.md)
-- [Query Optimization](../guides/schema-design-best-practices.md)
-
-**Deployment:**
-
+- [Schema Design Best Practices](../guides/schema-design-best-practices.md)
 - [Production Deployment](../guides/production-deployment.md)
-- [Scaling Guidelines](../guides/monitoring.md)
-
----
-
-**Last Updated:** 2026-02-05
-**Version:** v2.0.0-alpha.1

--- a/docs/patterns/ecommerce-workflows.md
+++ b/docs/patterns/ecommerce-workflows.md
@@ -1,393 +1,553 @@
-<!-- Skip to main content -->
 ---
-
 title: E-Commerce Platform with Complex Workflows
-description: Complete guide to building a production e-commerce platform with order management, inventory tracking, and fulfillment workflows.
-keywords: ["workflow", "saas", "realtime", "ecommerce", "analytics", "federation"]
-tags: ["documentation", "reference"]
+description: Building a production e-commerce platform on FraiseQL v1 with order management, inventory tracking, and fulfillment workflows backed by PostgreSQL.
+keywords: ["workflow", "ecommerce", "orders", "inventory", "fulfillment", "postgresql"]
+tags: ["documentation", "patterns"]
 ---
 
 # E-Commerce Platform with Complex Workflows
 
-**Status:** ✅ Production Ready
-**Complexity:** ⭐⭐⭐⭐ (Advanced)
+**Status:** Production Ready
+**Complexity:** Advanced
 **Audience:** E-commerce architects, backend engineers
 **Reading Time:** 25-30 minutes
-**Last Updated:** 2026-02-05
 
-Complete guide to building a production e-commerce platform with order management, inventory tracking, and fulfillment workflows.
+A blueprint for a production e-commerce platform on FraiseQL v1: order
+management, inventory tracking, and fulfillment workflows. Everything is
+PostgreSQL — write tables (`tb_*`), read views (`v_*`/`tv_*`), and mutation
+logic in `fn_*` functions — served as a GraphQL API by a FastAPI app.
+
+## How multi-step workflows work in FraiseQL v1
+
+FraiseQL v1 has no saga framework and no built-in webhook/orchestration engine.
+Complex workflows are assembled from three PostgreSQL building blocks:
+
+1. **`fn_*` functions = transactional units.** Each mutation calls one
+   `fn_*` function that runs in a single transaction. Validation, the write,
+   inventory reservation, and status changes either all commit or all roll
+   back. This is your atomic step.
+2. **`status` columns = the state machine.** An order moves through
+   `pending → confirmed → processing → shipped → delivered` (or `cancelled`)
+   by updating a `status` column *inside* an `fn_*` function. A `BEFORE UPDATE`
+   trigger enforces legal transitions.
+3. **A transactional outbox = cross-system steps.** Anything that touches an
+   external system (charge a card, send an email, notify a carrier) is written
+   as a row into an outbox table *in the same transaction* as the order change.
+   A background worker you run polls the outbox, performs the side effect, and
+   marks the row done. This gives you exactly-once-ish delivery without a
+   distributed saga coordinator: if the transaction rolls back, the outbox row
+   never exists; if it commits, the worker will eventually drain it.
+
+The result is a reliable, observable workflow built entirely from PostgreSQL
+transactions plus one worker process — no external orchestration layer.
 
 ---
 
 ## Schema Design
 
-### Products & Inventory
+FraiseQL v1 separates the **write side** (`tb_*` normalized tables, the source
+of truth) from the **read side** (`v_*` / `tv_*` views that build a `data`
+JSONB payload for GraphQL). Mutations write through `fn_*` functions; queries
+read the views.
+
+### Products & Inventory (write tables)
 
 ```sql
-<!-- Code example in SQL -->
-CREATE TABLE products (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  sku VARCHAR(50) UNIQUE NOT NULL,
-  name VARCHAR(255) NOT NULL,
-  description TEXT,
-  category_id UUID NOT NULL,
-  brand VARCHAR(100),
-  price DECIMAL(12, 2) NOT NULL,
-  cost DECIMAL(12, 2),  -- For margin calculation
-  status VARCHAR(50) NOT NULL,  -- active, draft, discontinued
-  created_at TIMESTAMP DEFAULT NOW()
+CREATE TABLE tb_product (
+  pk_product       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- internal, hidden
+  id               UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),   -- public GraphQL id
+  sku              VARCHAR(50) UNIQUE NOT NULL,
+  name             VARCHAR(255) NOT NULL,
+  description      TEXT,
+  fk_category      BIGINT NOT NULL REFERENCES tb_category(pk_category),
+  brand            VARCHAR(100),
+  price            DECIMAL(12, 2) NOT NULL,
+  cost             DECIMAL(12, 2),                 -- for margin calculation
+  status           VARCHAR(50) NOT NULL DEFAULT 'draft',  -- active, draft, discontinued
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- Product variants (sizes, colors, etc.)
-CREATE TABLE product_variants (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  product_id UUID NOT NULL REFERENCES products(id) ON DELETE CASCADE,
-  sku VARCHAR(50) UNIQUE NOT NULL,
-  name VARCHAR(255),  -- e.g., "Red - Size M"
-  price_modifier DECIMAL(10, 2),  -- +$5 for premium variant
-  weight DECIMAL(8, 3),
-  dimensions JSONB,  -- { width: 10, height: 20, depth: 5 }
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_product_id (product_id)
+CREATE TABLE tb_product_variant (
+  pk_product_variant BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                 UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_product         BIGINT NOT NULL REFERENCES tb_product(pk_product) ON DELETE CASCADE,
+  sku                VARCHAR(50) UNIQUE NOT NULL,
+  name               VARCHAR(255),                 -- e.g. "Red - Size M"
+  price_modifier     DECIMAL(10, 2) DEFAULT 0,     -- +$5 for premium variant
+  weight             DECIMAL(8, 3),
+  dimensions         JSONB,                        -- {"width": 10, "height": 20, "depth": 5}
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+CREATE INDEX idx_variant_product ON tb_product_variant (fk_product);
 
 -- Inventory tracking (stock levels)
-CREATE TABLE inventory (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  variant_id UUID NOT NULL UNIQUE REFERENCES product_variants(id),
-  warehouse_id UUID NOT NULL,
-  quantity_on_hand INT NOT NULL DEFAULT 0,
-  quantity_reserved INT NOT NULL DEFAULT 0,
-  quantity_available INT GENERATED ALWAYS AS (quantity_on_hand - quantity_reserved) STORED,
-  reorder_point INT,
-  reorder_quantity INT,
-  last_stock_check TIMESTAMP,
-
-  INDEX idx_warehouse_id (warehouse_id),
-  INDEX idx_quantity_available (quantity_available)
+CREATE TABLE tb_inventory (
+  pk_inventory        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                  UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_product_variant  BIGINT NOT NULL REFERENCES tb_product_variant(pk_product_variant),
+  fk_warehouse        BIGINT NOT NULL REFERENCES tb_warehouse(pk_warehouse),
+  quantity_on_hand    INT NOT NULL DEFAULT 0,
+  quantity_reserved   INT NOT NULL DEFAULT 0,
+  quantity_available  INT GENERATED ALWAYS AS (quantity_on_hand - quantity_reserved) STORED,
+  reorder_point       INT,
+  reorder_quantity    INT,
+  last_stock_check    TIMESTAMPTZ,
+  UNIQUE (fk_product_variant, fk_warehouse)
 );
+CREATE INDEX idx_inventory_warehouse  ON tb_inventory (fk_warehouse);
+CREATE INDEX idx_inventory_available  ON tb_inventory (quantity_available);
 
 -- Stock movements (audit trail)
-CREATE TABLE stock_movements (
-  id BIGSERIAL PRIMARY KEY,
-  variant_id UUID NOT NULL REFERENCES product_variants(id),
-  warehouse_id UUID NOT NULL,
-  movement_type VARCHAR(50) NOT NULL,  -- purchase, return, adjustment, damage
-  quantity INT NOT NULL,
-  reference_id VARCHAR(50),  -- order_id, return_id
-  notes TEXT,
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_variant_id (variant_id),
-  INDEX idx_movement_type (movement_type)
+CREATE TABLE tb_stock_movement (
+  pk_stock_movement   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                  UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_product_variant  BIGINT NOT NULL REFERENCES tb_product_variant(pk_product_variant),
+  fk_warehouse        BIGINT NOT NULL REFERENCES tb_warehouse(pk_warehouse),
+  movement_type       VARCHAR(50) NOT NULL,        -- purchase, return, adjustment, damage
+  quantity            INT NOT NULL,
+  reference           VARCHAR(50),                 -- order id, return id
+  notes               TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_movement_variant ON tb_stock_movement (fk_product_variant);
+CREATE INDEX idx_movement_type    ON tb_stock_movement (movement_type);
+```
 
-### Orders & Fulfillment
+### Orders & Fulfillment (write tables)
 
 ```sql
-<!-- Code example in SQL -->
 -- Orders (customer purchases)
-CREATE TABLE orders (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  order_number VARCHAR(20) UNIQUE NOT NULL,  -- Public facing
-  customer_id UUID NOT NULL,
-  status VARCHAR(50) NOT NULL,  -- pending, confirmed, processing, shipped, delivered, cancelled
-  subtotal DECIMAL(12, 2),
-  tax DECIMAL(10, 2),
-  shipping_cost DECIMAL(10, 2),
-  discount_amount DECIMAL(10, 2),
-  total DECIMAL(12, 2) NOT NULL,
-  currency VARCHAR(3) NOT NULL,  -- USD, EUR, etc.
-  payment_status VARCHAR(50) NOT NULL,  -- pending, completed, failed, refunded
-  billing_address_id UUID NOT NULL,
-  shipping_address_id UUID NOT NULL,
-  created_at TIMESTAMP DEFAULT NOW(),
-  shipped_at TIMESTAMP,
-  delivered_at TIMESTAMP,
-  cancelled_at TIMESTAMP,
-
-  INDEX idx_customer_id (customer_id),
-  INDEX idx_status (status),
-  INDEX idx_payment_status (payment_status),
-  INDEX idx_created_at (created_at)
+CREATE TABLE tb_order (
+  pk_order            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                  UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  order_number        VARCHAR(20) UNIQUE NOT NULL,  -- public facing
+  fk_customer         BIGINT NOT NULL REFERENCES tb_customer(pk_customer),
+  status              VARCHAR(50) NOT NULL DEFAULT 'pending',
+                      -- pending, confirmed, processing, shipped, delivered, cancelled
+  subtotal            DECIMAL(12, 2),
+  tax                 DECIMAL(10, 2),
+  shipping_cost       DECIMAL(10, 2),
+  discount_amount     DECIMAL(10, 2),
+  total               DECIMAL(12, 2) NOT NULL,
+  currency            VARCHAR(3) NOT NULL,          -- USD, EUR, etc.
+  payment_status      VARCHAR(50) NOT NULL DEFAULT 'pending',  -- pending, completed, failed, refunded
+  fk_billing_address  BIGINT NOT NULL REFERENCES tb_address(pk_address),
+  fk_shipping_address BIGINT NOT NULL REFERENCES tb_address(pk_address),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  shipped_at          TIMESTAMPTZ,
+  delivered_at        TIMESTAMPTZ,
+  cancelled_at        TIMESTAMPTZ
 );
+CREATE INDEX idx_order_customer ON tb_order (fk_customer);
+CREATE INDEX idx_order_status   ON tb_order (status);
+CREATE INDEX idx_order_payment  ON tb_order (payment_status);
+CREATE INDEX idx_order_created  ON tb_order (created_at);
 
 -- Order line items
-CREATE TABLE order_items (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  order_id UUID NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
-  variant_id UUID NOT NULL,
-  quantity INT NOT NULL,
-  unit_price DECIMAL(12, 2) NOT NULL,
-  discount_amount DECIMAL(10, 2),
-  total DECIMAL(12, 2) NOT NULL,
-
-  INDEX idx_order_id (order_id)
+CREATE TABLE tb_order_item (
+  pk_order_item       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                  UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_order            BIGINT NOT NULL REFERENCES tb_order(pk_order) ON DELETE CASCADE,
+  fk_product_variant  BIGINT NOT NULL REFERENCES tb_product_variant(pk_product_variant),
+  quantity            INT NOT NULL,
+  unit_price          DECIMAL(12, 2) NOT NULL,
+  discount_amount     DECIMAL(10, 2) DEFAULT 0,
+  total               DECIMAL(12, 2) NOT NULL
 );
+CREATE INDEX idx_order_item_order ON tb_order_item (fk_order);
 
 -- Fulfillment operations
-CREATE TABLE fulfillments (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  order_id UUID NOT NULL REFERENCES orders(id),
-  status VARCHAR(50) NOT NULL,  -- pending, shipped, delivered, cancelled
-  tracking_number VARCHAR(100),
-  carrier VARCHAR(50),  -- FedEx, UPS, USPS
-  estimated_delivery DATE,
-  actual_delivery TIMESTAMP,
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_order_id (order_id),
-  INDEX idx_status (status)
+CREATE TABLE tb_fulfillment (
+  pk_fulfillment      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                  UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_order            BIGINT NOT NULL REFERENCES tb_order(pk_order),
+  status              VARCHAR(50) NOT NULL DEFAULT 'pending',  -- pending, shipped, delivered, cancelled
+  tracking_number     VARCHAR(100),
+  carrier             VARCHAR(50),                 -- FedEx, UPS, USPS
+  estimated_delivery  DATE,
+  actual_delivery     TIMESTAMPTZ,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+CREATE INDEX idx_fulfillment_order  ON tb_fulfillment (fk_order);
+CREATE INDEX idx_fulfillment_status ON tb_fulfillment (status);
 
 -- Fulfillment line items
-CREATE TABLE fulfillment_items (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  fulfillment_id UUID NOT NULL REFERENCES fulfillments(id) ON DELETE CASCADE,
-  order_item_id UUID NOT NULL REFERENCES order_items(id),
-  quantity INT NOT NULL,
-
-  INDEX idx_fulfillment_id (fulfillment_id)
+CREATE TABLE tb_fulfillment_item (
+  pk_fulfillment_item BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                  UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_fulfillment      BIGINT NOT NULL REFERENCES tb_fulfillment(pk_fulfillment) ON DELETE CASCADE,
+  fk_order_item       BIGINT NOT NULL REFERENCES tb_order_item(pk_order_item),
+  quantity            INT NOT NULL
 );
+CREATE INDEX idx_fulfillment_item_fulfillment ON tb_fulfillment_item (fk_fulfillment);
 
 -- Returns & Refunds
-CREATE TABLE returns (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  order_id UUID NOT NULL REFERENCES orders(id),
-  status VARCHAR(50) NOT NULL,  -- pending, approved, shipped, received, refunded
-  reason VARCHAR(255),
-  refund_amount DECIMAL(12, 2),
-  refund_status VARCHAR(50) NOT NULL,  -- pending, completed, failed
-  created_at TIMESTAMP DEFAULT NOW(),
-  refunded_at TIMESTAMP,
-
-  INDEX idx_order_id (order_id),
-  INDEX idx_status (status)
+CREATE TABLE tb_return (
+  pk_return           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                  UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_order            BIGINT NOT NULL REFERENCES tb_order(pk_order),
+  status              VARCHAR(50) NOT NULL DEFAULT 'pending',  -- pending, approved, shipped, received, refunded
+  reason              VARCHAR(255),
+  refund_amount       DECIMAL(12, 2),
+  refund_status       VARCHAR(50) NOT NULL DEFAULT 'pending',  -- pending, completed, failed
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  refunded_at         TIMESTAMPTZ
 );
+CREATE INDEX idx_return_order  ON tb_return (fk_order);
+CREATE INDEX idx_return_status ON tb_return (status);
 
 -- Return line items
-CREATE TABLE return_items (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  return_id UUID NOT NULL REFERENCES returns(id) ON DELETE CASCADE,
-  order_item_id UUID NOT NULL REFERENCES order_items(id),
-  quantity INT NOT NULL,
-  condition VARCHAR(50),  -- unopened, opened, defective
-
-  INDEX idx_return_id (return_id)
+CREATE TABLE tb_return_item (
+  pk_return_item      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                  UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_return           BIGINT NOT NULL REFERENCES tb_return(pk_return) ON DELETE CASCADE,
+  fk_order_item       BIGINT NOT NULL REFERENCES tb_order_item(pk_order_item),
+  quantity            INT NOT NULL,
+  condition           VARCHAR(50)                  -- unopened, opened, defective
 );
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_return_item_return ON tb_return_item (fk_return);
+```
 
-### Payments & Discounts
+### Payments & Discounts (write tables)
 
 ```sql
-<!-- Code example in SQL -->
-CREATE TABLE payments (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  order_id UUID NOT NULL REFERENCES orders(id),
-  amount DECIMAL(12, 2) NOT NULL,
-  status VARCHAR(50) NOT NULL,  -- pending, completed, failed, refunded
-  payment_method VARCHAR(50),  -- credit_card, paypal, stripe
-  transaction_id VARCHAR(100),
-  error_message TEXT,
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_order_id (order_id),
-  INDEX idx_status (status)
+CREATE TABLE tb_payment (
+  pk_payment      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id              UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  fk_order        BIGINT NOT NULL REFERENCES tb_order(pk_order),
+  amount          DECIMAL(12, 2) NOT NULL,
+  status          VARCHAR(50) NOT NULL DEFAULT 'pending',  -- pending, completed, failed, refunded
+  payment_method  VARCHAR(50),                     -- credit_card, paypal, stripe
+  transaction_id  VARCHAR(100),
+  error_message   TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+CREATE INDEX idx_payment_order  ON tb_payment (fk_order);
+CREATE INDEX idx_payment_status ON tb_payment (status);
 
-CREATE TABLE discounts (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  code VARCHAR(50) UNIQUE NOT NULL,
-  type VARCHAR(50) NOT NULL,  -- percentage, fixed_amount
-  value DECIMAL(10, 2) NOT NULL,
-  max_uses INT,
-  current_uses INT DEFAULT 0,
-  min_order_amount DECIMAL(10, 2),
-  valid_from DATE,
-  valid_until DATE,
-  is_active BOOLEAN DEFAULT TRUE,
-
-  INDEX idx_code (code),
-  INDEX idx_is_active (is_active)
+CREATE TABLE tb_discount (
+  pk_discount       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  code              VARCHAR(50) UNIQUE NOT NULL,
+  type              VARCHAR(50) NOT NULL,          -- percentage, fixed_amount
+  value             DECIMAL(10, 2) NOT NULL,
+  max_uses          INT,
+  current_uses      INT DEFAULT 0,
+  min_order_amount  DECIMAL(10, 2),
+  valid_from        DATE,
+  valid_until       DATE,
+  is_active         BOOLEAN DEFAULT TRUE
 );
+CREATE INDEX idx_discount_code   ON tb_discount (code);
+CREATE INDEX idx_discount_active ON tb_discount (is_active);
 
-CREATE TABLE order_discounts (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  order_id UUID NOT NULL REFERENCES orders(id),
-  discount_id UUID NOT NULL REFERENCES discounts(id),
-  discount_amount DECIMAL(10, 2),
-
-  UNIQUE(order_id, discount_id)
+CREATE TABLE tb_order_discount (
+  pk_order_discount BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  fk_order          BIGINT NOT NULL REFERENCES tb_order(pk_order),
+  fk_discount       BIGINT NOT NULL REFERENCES tb_discount(pk_discount),
+  discount_amount   DECIMAL(10, 2),
+  UNIQUE (fk_order, fk_discount)
 );
-```text
-<!-- Code example in TEXT -->
+```
+
+### The transactional outbox (cross-system steps)
+
+Cross-system side effects are recorded here in the same transaction as the
+business write, then drained by your worker.
+
+```sql
+CREATE TABLE tb_outbox (
+  pk_outbox     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id            UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  topic         VARCHAR(100) NOT NULL,             -- charge_payment, send_email, notify_carrier
+  payload       JSONB NOT NULL,
+  status        VARCHAR(20) NOT NULL DEFAULT 'pending',  -- pending, processing, done, failed
+  attempts      INT NOT NULL DEFAULT 0,
+  available_at  TIMESTAMPTZ NOT NULL DEFAULT now(),  -- for retry backoff
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  processed_at  TIMESTAMPTZ
+);
+CREATE INDEX idx_outbox_pending ON tb_outbox (available_at) WHERE status = 'pending';
+```
 
 ---
 
-## FraiseQL Schema
+## Read views
+
+GraphQL reads come from `v_*` views (or `tv_*` projection tables for heavy
+nested reads). Each view exposes the public `id` (UUID) and a `data` JSONB
+column built with `jsonb_build_object(...)`. Internal `pk_*` / `fk_*` columns
+never appear in `data`.
+
+```sql
+-- Product read view: id + data JSONB shaped for GraphQL
+CREATE VIEW v_product AS
+SELECT
+  p.id,                                            -- public id for WHERE id = $1
+  jsonb_build_object(
+    'id',           p.id,
+    'sku',          p.sku,
+    'name',         p.name,
+    'description',  p.description,
+    'price',        p.price,
+    'status',       p.status,
+    'inStock',      COALESCE(SUM(inv.quantity_available) > 0, false),
+    'rating',       COALESCE(AVG(r.rating), 0),
+    'variants', (
+      SELECT jsonb_agg(jsonb_build_object(
+        'id',                pv.id,
+        'name',              pv.name,
+        'sku',               pv.sku,
+        'price',             p.price + COALESCE(pv.price_modifier, 0),
+        'weight',            pv.weight,
+        'availableQuantity', COALESCE(vinv.quantity_available, 0)
+      ))
+      FROM tb_product_variant pv
+      LEFT JOIN tb_inventory vinv ON vinv.fk_product_variant = pv.pk_product_variant
+      WHERE pv.fk_product = p.pk_product
+    )
+  ) AS data
+FROM tb_product p
+LEFT JOIN tb_product_variant pv2 ON pv2.fk_product = p.pk_product
+LEFT JOIN tb_inventory inv       ON inv.fk_product_variant = pv2.pk_product_variant
+LEFT JOIN tb_review r            ON r.fk_product = p.pk_product
+GROUP BY p.pk_product, p.id, p.sku, p.name, p.description, p.price, p.status;
+
+-- Order read view
+CREATE VIEW v_order AS
+SELECT
+  o.id,
+  o.fk_customer,                                   -- kept for filtering / RLS, not in data
+  jsonb_build_object(
+    'id',             o.id,
+    'orderNumber',    o.order_number,
+    'status',         o.status,
+    'subtotal',       o.subtotal,
+    'tax',            o.tax,
+    'shippingCost',   o.shipping_cost,
+    'total',          o.total,
+    'currency',       o.currency,
+    'paymentStatus',  o.payment_status,
+    'createdAt',      o.created_at,
+    'shippedAt',      o.shipped_at,
+    'items', (
+      SELECT jsonb_agg(jsonb_build_object(
+        'id',        oi.id,
+        'quantity',  oi.quantity,
+        'unitPrice', oi.unit_price,
+        'total',     oi.total
+      ))
+      FROM tb_order_item oi
+      WHERE oi.fk_order = o.pk_order
+    )
+  ) AS data
+FROM tb_order o;
+```
+
+For order detail pages that fan out into items, fulfillments, and returns, a
+`tv_order` projection table (a real table holding pre-composed JSONB, refreshed
+by your `fn_*` functions or triggers) keeps heavy nested reads fast.
+
+---
+
+## FraiseQL types, queries, and mutations
+
+Define GraphQL types over the read views, queries over the views, and mutations
+over the `fn_*` functions. Mutations return a `success | error` union.
 
 ```python
-<!-- Code example in Python -->
 # ecommerce_schema.py
-from FraiseQL import types, authorize
+from datetime import date, datetime
 from decimal import Decimal
-from datetime import datetime, date
 
-@types.object
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.types import ID
+
+from .authz import customer_authorizer, admin_authorizer
+
+
+@fraiseql.type(sql_source="v_product", jsonb_column="data")
 class Product:
-    id: UUID  # UUID v4 for GraphQL ID
+    id: ID
     sku: str
     name: str
     price: Decimal
-    category: 'Category'
-    variants: list['ProductVariant']
-    inventory: list['Inventory']
-    reviews: list['Review']
-    rating: Decimal  # Average rating
+    rating: Decimal           # average rating, computed in the view
     in_stock: bool
+    variants: list["ProductVariant"]
 
-@types.object
+
+@fraiseql.type(sql_source="v_product_variant", jsonb_column="data")
 class ProductVariant:
-    id: UUID  # UUID v4 for GraphQL ID
-    product: Product
+    id: ID
     name: str
-    price: Decimal
     sku: str
+    price: Decimal
     weight: Decimal | None
     available_quantity: int
 
-@types.object
+
+@fraiseql.type(sql_source="v_order", jsonb_column="data")
 class Order:
-    id: UUID  # UUID v4 for GraphQL ID
+    id: ID
     order_number: str
-    customer: 'Customer'
     status: str
-    items: list['OrderItem']
+    items: list["OrderItem"]
     subtotal: Decimal
     tax: Decimal
     shipping_cost: Decimal
     total: Decimal
     payment_status: str
-    fulfillments: list['Fulfillment']
-    returns: list['Return']
     created_at: datetime
     shipped_at: datetime | None
 
-@types.object
+
+@fraiseql.type(sql_source="v_order_item", jsonb_column="data")
 class OrderItem:
-    id: UUID  # UUID v4 for GraphQL ID
-    variant: ProductVariant
+    id: ID
     quantity: int
     unit_price: Decimal
     total: Decimal
 
-@types.object
+
+@fraiseql.type(sql_source="v_fulfillment", jsonb_column="data")
 class Fulfillment:
-    id: UUID  # UUID v4 for GraphQL ID
-    order: Order
+    id: ID
     status: str
     tracking_number: str | None
     carrier: str | None
-    items: list['FulfillmentItem']
     estimated_delivery: date | None
 
-@types.object
+
+@fraiseql.type(sql_source="v_return", jsonb_column="data")
 class Return:
-    id: UUID  # UUID v4 for GraphQL ID
-    order: Order
+    id: ID
     status: str
-    items: list['ReturnItem']
     refund_amount: Decimal
     refund_status: str
     reason: str
+```
 
-@types.object
-class Query:
-    def product(self, id: str) -> Product:
-        """Get product details"""
-        pass
+### Inputs and result unions
 
-    def search_products(
-        self,
-        query: str,
-        category: str | None = None,
-        min_price: Decimal | None = None,
-        max_price: Decimal | None = None,
-        limit: int = 50
-    ) -> list[Product]:
-        """Search products"""
-        pass
+```python
+@fraiseql.input
+class OrderLineInput:
+    variant_id: ID
+    quantity: int
 
-    @authorize(roles=['customer', 'admin'])
-    def my_orders(self, limit: int = 20) -> list[Order]:
-        """Current user's orders"""
-        pass
 
-    @authorize(roles=['admin'])
-    def orders(
-        self,
-        status: str | None = None,
-        limit: int = 50
-    ) -> list[Order]:
-        """List orders (admin)"""
-        pass
+@fraiseql.input
+class CreateOrderInput:
+    lines: list[OrderLineInput]
+    shipping_address_id: ID
+    discount_code: str | None = None
 
-    @authorize(roles=['admin'])
-    def inventory_status(self) -> dict:
-        """Low stock alerts"""
-        pass
 
-@types.object
-class Mutation:
-    def add_to_cart(self, variant_id: str, quantity: int) -> 'CartItem':
-        """Add product to cart"""
-        pass
+@fraiseql.success
+class CreateOrderSuccess:
+    order: Order              # @success auto-injects status/message/id
 
-    @authorize(roles=['customer'])
-    def create_order(
-        self,
-        cart_items: list[dict],
-        shipping_address_id: str,
-        discount_code: str | None = None
-    ) -> Order:
-        """Create order from cart"""
-        pass
 
-    @authorize(roles=['customer'])
-    def cancel_order(self, order_id: str) -> Order:
-        """Cancel pending order"""
-        pass
+@fraiseql.error
+class CreateOrderError:
+    message: str
+    code: str = "ORDER_FAILED"
+```
 
-    @authorize(roles=['customer'])
-    def return_items(
-        self,
-        order_id: str,
-        items: list[dict]
-    ) -> Return:
-        """Initiate return"""
-        pass
+### Queries
 
-    @authorize(roles=['admin'])
-    def create_fulfillment(
-        self,
-        order_id: str,
-        items: list[dict],
-        carrier: str,
-        tracking_number: str
-    ) -> Fulfillment:
-        """Create shipment"""
-        pass
+Authorization is applied per operation with an `Authorizer` passed to the
+decorator — there is no `@authorize` decorator in v1. Row scoping (a customer
+sees only their own orders) is enforced by PostgreSQL Row-Level Security on the
+underlying tables, driven by the session GUCs FraiseQL sets from
+`info.context`. See [Multi-Tenant SaaS](./saas-multi-tenant.md) for the RLS
+pattern.
 
-    @authorize(roles=['admin'])
-    def process_payment(self, order_id: str) -> 'Payment':
-        """Process order payment"""
-        pass
-```text
-<!-- Code example in TEXT -->
+```python
+@fraiseql.query
+async def product(info, id: ID) -> Product | None:
+    db = info.context["db"]
+    return await db.find_one("v_product", id=id)
+
+
+@fraiseql.query
+async def search_products(
+    info,
+    query: str,
+    category: str | None = None,
+    min_price: Decimal | None = None,
+    max_price: Decimal | None = None,
+    limit: int = 50,
+) -> list[Product]:
+    db = info.context["db"]
+    return await db.find("v_product", search=query, limit=limit)
+
+
+@fraiseql.query(authorizer=customer_authorizer)
+async def my_orders(info, limit: int = 20) -> list[Order]:
+    """Current user's orders (scoped to the caller by RLS)."""
+    db = info.context["db"]
+    return await db.find("v_order", limit=limit)
+
+
+@fraiseql.query(authorizer=admin_authorizer)
+async def orders(info, status: str | None = None, limit: int = 50) -> list[Order]:
+    db = info.context["db"]
+    filters = {"status": status} if status else {}
+    return await db.find("v_order", limit=limit, **filters)
+```
+
+### Mutations
+
+Each mutation calls one `fn_*` function. The function runs in a transaction:
+it validates input, performs the write, reserves inventory, updates the
+`status` column, and (for cross-system steps) inserts outbox rows — all
+atomically. It returns a JSONB object with a `success` flag.
+
+```python
+@fraiseql.mutation(authorizer=customer_authorizer)
+async def create_order(
+    info, input: CreateOrderInput
+) -> CreateOrderSuccess | CreateOrderError:
+    db = info.context["db"]
+    result = await db.execute_function(
+        "fn_create_order",
+        {
+            "lines": [{"variant_id": str(l.variant_id), "quantity": l.quantity} for l in input.lines],
+            "shipping_address_id": str(input.shipping_address_id),
+            "discount_code": input.discount_code,
+        },
+    )
+    if not result.get("success"):
+        return CreateOrderError(
+            message=result.get("message", "Order creation failed"),
+            code=result.get("code", "ORDER_FAILED"),
+        )
+    return CreateOrderSuccess(order=Order(**result["order"]))
+
+
+@fraiseql.mutation(authorizer=customer_authorizer)
+async def cancel_order(info, order_id: ID) -> CreateOrderSuccess | CreateOrderError:
+    db = info.context["db"]
+    result = await db.execute_function("fn_cancel_order", {"order_id": str(order_id)})
+    if not result.get("success"):
+        return CreateOrderError(message=result.get("message", "Cancellation failed"))
+    return CreateOrderSuccess(order=Order(**result["order"]))
+
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/shop",
+    types=[Product, ProductVariant, Order, OrderItem, Fulfillment, Return],
+    queries=[product, search_products, my_orders, orders],
+    mutations=[create_order, cancel_order],
+    production=False,   # False enables the GraphQL playground
+)
+```
+
+Run it with `uvicorn ecommerce_schema:app`.
 
 ---
 
@@ -395,298 +555,411 @@ class Mutation:
 
 ### State Machine
 
-**Diagram:** System architecture visualization
+The order `status` column is the state machine. Transitions happen only inside
+`fn_*` functions, and a trigger rejects illegal jumps.
 
-```d2
-<!-- Code example in D2 Diagram -->
-direction: down
-
-Pending: "pending\n(awaiting payment)" {
-  shape: box
-  style.fill: "#fff9c4"
-}
-
-Confirmed: "confirmed\n(payment received)" {
-  shape: box
-  style.fill: "#fff3e0"
-}
-
-Processing: "processing\n(preparing shipment)" {
-  shape: box
-  style.fill: "#ffe0b2"
-}
-
-Shipped: "shipped\n(in transit)" {
-  shape: box
-  style.fill: "#ffccbc"
-}
-
-Delivered: "delivered\n(final destination)" {
-  shape: box
-  style.fill: "#c8e6c9"
-}
-
-Cancelled: "cancelled\n(at any point)" {
-  shape: box
-  style.fill: "#ffebee"
-}
-
-Pending -> Confirmed
-Confirmed -> Processing
-Processing -> Shipped
-Shipped -> Delivered
-Pending -> Cancelled
-Confirmed -> Cancelled
-Processing -> Cancelled
-Shipped -> Cancelled
 ```text
-<!-- Code example in TEXT -->
+pending  ──► confirmed ──► processing ──► shipped ──► delivered
+   │            │              │             │
+   └────────────┴──────────────┴─────────────┘
+                      ▼
+                  cancelled
+```
 
-### State Transitions
+| From         | Allowed next states          |
+|--------------|------------------------------|
+| `pending`    | `confirmed`, `cancelled`     |
+| `confirmed`  | `processing`, `cancelled`    |
+| `processing` | `shipped`, `cancelled`       |
+| `shipped`    | `delivered`, `cancelled`     |
+| `delivered`  | *(terminal)*                 |
+| `cancelled`  | *(terminal)*                 |
+
+### State transition guard
 
 ```sql
-<!-- Code example in SQL -->
--- Trigger to enforce state transitions
-CREATE OR REPLACE FUNCTION validate_order_transition()
+CREATE OR REPLACE FUNCTION fn_validate_order_transition()
 RETURNS TRIGGER AS $$
 BEGIN
-  -- Valid transitions
   CASE
-    WHEN OLD.status = 'pending' AND NEW.status NOT IN ('confirmed', 'cancelled') THEN
-      RAISE EXCEPTION 'Invalid transition from pending';
-    WHEN OLD.status = 'confirmed' AND NEW.status NOT IN ('processing', 'cancelled') THEN
-      RAISE EXCEPTION 'Invalid transition from confirmed';
-    WHEN OLD.status = 'shipped' AND NEW.status NOT IN ('delivered', 'cancelled') THEN
-      RAISE EXCEPTION 'Invalid transition from shipped';
+    WHEN OLD.status = 'pending'    AND NEW.status NOT IN ('confirmed', 'cancelled') THEN
+      RAISE EXCEPTION 'Invalid transition from pending to %', NEW.status;
+    WHEN OLD.status = 'confirmed'  AND NEW.status NOT IN ('processing', 'cancelled') THEN
+      RAISE EXCEPTION 'Invalid transition from confirmed to %', NEW.status;
+    WHEN OLD.status = 'processing' AND NEW.status NOT IN ('shipped', 'cancelled') THEN
+      RAISE EXCEPTION 'Invalid transition from processing to %', NEW.status;
+    WHEN OLD.status = 'shipped'    AND NEW.status NOT IN ('delivered', 'cancelled') THEN
+      RAISE EXCEPTION 'Invalid transition from shipped to %', NEW.status;
     WHEN OLD.status IN ('delivered', 'cancelled') THEN
-      RAISE EXCEPTION 'Cannot change delivered or cancelled orders';
+      RAISE EXCEPTION 'Cannot change a delivered or cancelled order';
+    ELSE
+      NULL;  -- transition allowed
   END CASE;
-
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER order_status_validation
-BEFORE UPDATE ON orders
+BEFORE UPDATE ON tb_order
 FOR EACH ROW
 WHEN (OLD.status IS DISTINCT FROM NEW.status)
-EXECUTE FUNCTION validate_order_transition();
-```text
-<!-- Code example in TEXT -->
+EXECUTE FUNCTION fn_validate_order_transition();
+```
+
+### The `fn_create_order` mutation function
+
+This is the transactional unit behind the `create_order` mutation: it creates
+the order, reserves inventory, sets the initial status, and enqueues the
+payment side effect — all in one transaction.
+
+```sql
+CREATE OR REPLACE FUNCTION fn_create_order(input JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_order_pk    BIGINT;
+  v_order_id    UUID;
+  v_line        JSONB;
+  v_variant_pk  BIGINT;
+  v_total       DECIMAL(12, 2) := 0;
+BEGIN
+  -- 1. Create the order shell (status defaults to 'pending')
+  INSERT INTO tb_order (order_number, fk_customer, total, currency,
+                        fk_billing_address, fk_shipping_address)
+  VALUES (
+    'ORD-' || to_char(now(), 'YYYYMMDD') || '-' || nextval('order_number_seq'),
+    current_setting('app.customer_pk')::BIGINT,
+    0, 'USD',
+    (input->>'shipping_address_id')::UUID::TEXT::BIGINT,  -- resolve via lookup in practice
+    (input->>'shipping_address_id')::UUID::TEXT::BIGINT
+  )
+  RETURNING pk_order, id INTO v_order_pk, v_order_id;
+
+  -- 2. Add line items and reserve inventory atomically
+  FOR v_line IN SELECT * FROM jsonb_array_elements(input->'lines')
+  LOOP
+    SELECT pk_product_variant INTO v_variant_pk
+    FROM tb_product_variant
+    WHERE id = (v_line->>'variant_id')::UUID;
+
+    UPDATE tb_inventory
+    SET quantity_reserved = quantity_reserved + (v_line->>'quantity')::INT
+    WHERE fk_product_variant = v_variant_pk
+      AND quantity_available >= (v_line->>'quantity')::INT;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'INSUFFICIENT_STOCK:%', v_line->>'variant_id';
+    END IF;
+
+    INSERT INTO tb_order_item (fk_order, fk_product_variant, quantity, unit_price, total)
+    SELECT v_order_pk, v_variant_pk, (v_line->>'quantity')::INT, p.price,
+           p.price * (v_line->>'quantity')::INT
+    FROM tb_product_variant pv
+    JOIN tb_product p ON p.pk_product = pv.fk_product
+    WHERE pv.pk_product_variant = v_variant_pk;
+  END LOOP;
+
+  -- 3. Recompute total
+  SELECT COALESCE(SUM(total), 0) INTO v_total
+  FROM tb_order_item WHERE fk_order = v_order_pk;
+  UPDATE tb_order SET total = v_total, subtotal = v_total WHERE pk_order = v_order_pk;
+
+  -- 4. Enqueue the cross-system payment step in the SAME transaction
+  INSERT INTO tb_outbox (topic, payload)
+  VALUES ('charge_payment',
+          jsonb_build_object('order_id', v_order_id, 'amount', v_total));
+
+  -- Everything above commits together, or nothing does.
+  RETURN jsonb_build_object(
+    'success', true,
+    'order', jsonb_build_object('id', v_order_id, 'status', 'pending', 'total', v_total)
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'message', SQLERRM,
+      'code', split_part(SQLERRM, ':', 1)
+    );
+END;
+$$;
+```
 
 ---
 
 ## Inventory Management
 
-### Reserve on Order Creation
+Inventory is reserved inside `fn_create_order` (above) and released inside the
+cancellation function. Keeping the reserve/release in the same transaction as
+the status change is what prevents overselling — there is no separate
+coordinator to keep in sync.
+
+### Release inventory on cancellation
 
 ```sql
-<!-- Code example in SQL -->
-CREATE OR REPLACE FUNCTION reserve_inventory()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION fn_cancel_order(input JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_order_pk BIGINT;
+  v_order_id UUID := (input->>'order_id')::UUID;
 BEGIN
-  -- Check available inventory
-  UPDATE inventory
-  SET quantity_reserved = quantity_reserved + NEW.quantity
-  WHERE variant_id = NEW.variant_id
-    AND quantity_available >= NEW.quantity;
-
-  IF NOT FOUND THEN
-    RAISE EXCEPTION 'Insufficient inventory for variant %', NEW.variant_id;
+  SELECT pk_order INTO v_order_pk FROM tb_order WHERE id = v_order_id;
+  IF v_order_pk IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'message', 'Order not found');
   END IF;
 
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER order_item_reserve
-BEFORE INSERT ON order_items
-FOR EACH ROW
-EXECUTE FUNCTION reserve_inventory();
-```text
-<!-- Code example in TEXT -->
-
-### Release on Cancellation
-
-```sql
-<!-- Code example in SQL -->
-CREATE OR REPLACE FUNCTION release_inventory()
-RETURNS TRIGGER AS $$
-BEGIN
-  UPDATE inventory
+  -- Release reserved stock for every line on the order
+  UPDATE tb_inventory inv
   SET quantity_reserved = quantity_reserved - oi.quantity
-  FROM order_items oi
-  WHERE inventory.variant_id = oi.variant_id
-    AND oi.order_id = NEW.id;
+  FROM tb_order_item oi
+  WHERE inv.fk_product_variant = oi.fk_product_variant
+    AND oi.fk_order = v_order_pk;
 
-  RETURN NEW;
+  -- Flip status (the BEFORE UPDATE trigger validates the transition)
+  UPDATE tb_order
+  SET status = 'cancelled', cancelled_at = now()
+  WHERE pk_order = v_order_pk;
+
+  -- Cross-system step: notify the customer
+  INSERT INTO tb_outbox (topic, payload)
+  VALUES ('send_email',
+          jsonb_build_object('template', 'order_cancelled', 'order_id', v_order_id));
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'order', jsonb_build_object('id', v_order_id, 'status', 'cancelled')
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object('success', false, 'message', SQLERRM);
 END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER order_cancel_release
-BEFORE UPDATE ON orders
-FOR EACH ROW
-WHEN (OLD.status != 'cancelled' AND NEW.status = 'cancelled')
-EXECUTE FUNCTION release_inventory();
-```text
-<!-- Code example in TEXT -->
+$$;
+```
 
 ---
 
-## Payment Processing
+## Cross-system steps: the outbox worker
 
-```typescript
-<!-- Code example in TypeScript -->
-const PROCESS_PAYMENT = gql`
-  mutation ProcessPayment($orderId: ID!, $paymentMethod: String!) {
-    processPayment(orderId: $orderId, paymentMethod: $paymentMethod) {
-      id
-      status
-      order {
-        id
-        payment_status
-      }
-    }
-  }
-`;
+The mutation transaction only ever touches PostgreSQL. External effects
+(charging a card via Stripe, sending email, notifying a carrier) are recorded
+in `tb_outbox` and performed *afterward* by a worker you run alongside the
+FastAPI app. This is the v1 substitute for a saga/webhook engine: there is no
+built-in orchestration, but the outbox gives you the same reliability
+guarantees with plain SQL.
 
-export async function processOrderPayment(
-  orderId: string,
-  token: string
-) {
-  try {
-    // Charge customer via Stripe/PayPal
-    const charge = await stripe.charges.create({
-      amount: order.total * 100, // Convert to cents
-      currency: order.currency.toLowerCase(),
-      source: token,
-      metadata: { orderId },
-    });
+```python
+# worker.py — run as a separate process: python -m worker
+import asyncio
+import json
 
-    // Record payment in database
-    const result = await client.mutation(PROCESS_PAYMENT, {
-      variables: {
-        orderId,
-        paymentMethod: 'stripe',
-      },
-    });
+import psycopg
 
-    // Update order status
-    if (result.data.processPayment.status === 'completed') {
-      await client.mutation(UPDATE_ORDER_STATUS, {
-        variables: {
-          orderId,
-          status: 'confirmed',
-        },
-      });
-    }
+import payments  # your Stripe/PayPal client
+import mailer    # your email client
 
-    return result;
-  } catch (error) {
-    // Handle payment failure
-    console.error('Payment failed:', error);
-    throw error;
-  }
-}
-```text
-<!-- Code example in TEXT -->
+
+async def drain_outbox(conn: psycopg.AsyncConnection) -> None:
+    # Claim one pending row with FOR UPDATE SKIP LOCKED so multiple
+    # workers never grab the same job.
+    async with conn.transaction():
+        row = await (await conn.execute(
+            """
+            SELECT pk_outbox, topic, payload
+            FROM tb_outbox
+            WHERE status = 'pending' AND available_at <= now()
+            ORDER BY available_at
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1
+            """
+        )).fetchone()
+        if row is None:
+            return
+
+        pk, topic, payload = row
+        try:
+            if topic == "charge_payment":
+                await payments.charge(payload["order_id"], payload["amount"])
+                # Confirm the order via its own fn_ function (its own transaction)
+                await conn.execute(
+                    "SELECT fn_mark_order_paid(%s)", (json.dumps(payload),)
+                )
+            elif topic == "send_email":
+                await mailer.send(payload)
+            elif topic == "notify_carrier":
+                await payments.notify_carrier(payload)  # illustrative
+
+            await conn.execute(
+                "UPDATE tb_outbox SET status = 'done', processed_at = now() WHERE pk_outbox = %s",
+                (pk,),
+            )
+        except Exception as exc:  # retry with backoff
+            await conn.execute(
+                """
+                UPDATE tb_outbox
+                SET attempts = attempts + 1,
+                    available_at = now() + (attempts + 1) * interval '30 seconds',
+                    status = CASE WHEN attempts + 1 >= 5 THEN 'failed' ELSE 'pending' END,
+                    error_message = %s
+                WHERE pk_outbox = %s
+                """,
+                (str(exc), pk),
+            )
+
+
+async def main() -> None:
+    async with await psycopg.AsyncConnection.connect("postgresql://localhost/shop") as conn:
+        while True:
+            await drain_outbox(conn)
+            await asyncio.sleep(0.5)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Key properties:
+
+- **Atomicity** — the outbox row and the order write share one transaction, so
+  you never charge a card for an order that rolled back.
+- **At-least-once delivery** — the worker retries with backoff; downstream
+  effects (payment confirmation via `fn_mark_order_paid`) are idempotent.
+- **Back-pressure & ordering** — `FOR UPDATE SKIP LOCKED` lets you scale to
+  several workers without double-processing.
 
 ---
 
 ## Reporting & Analytics
 
-```typescript
-<!-- Code example in TypeScript -->
-const ORDER_METRICS = gql`
-  query OrderMetrics($startDate: Date!, $endDate: Date!) {
-    orderMetrics(startDate: $startDate, endDate: $endDate) {
-      total_revenue
-      order_count
-      average_order_value
-      conversion_rate
-      top_products {
-        id
-        name
-        revenue
-        quantity_sold
-      }
-    }
+Sales reporting is plain PostgreSQL aggregation inside a view, served as a
+GraphQL type. FraiseQL v1 supports runtime auto-aggregation (COUNT, SUM, AVG,
+MIN, MAX, STDDEV, VARIANCE) over view-backed types, and you can also pre-shape
+metrics directly in the view with `DATE_TRUNC` time bucketing.
+
+```sql
+CREATE VIEW v_order_metrics AS
+SELECT
+  DATE_TRUNC('day', o.created_at)::DATE AS id,    -- bucket key, used as the view id
+  jsonb_build_object(
+    'day',               DATE_TRUNC('day', o.created_at)::DATE,
+    'totalRevenue',      SUM(o.total) FILTER (WHERE o.payment_status = 'completed'),
+    'orderCount',        COUNT(*),
+    'averageOrderValue', AVG(o.total),
+    'cancelledCount',    COUNT(*) FILTER (WHERE o.status = 'cancelled')
+  ) AS data
+FROM tb_order o
+GROUP BY DATE_TRUNC('day', o.created_at);
+```
+
+```python
+@fraiseql.type(sql_source="v_order_metrics", jsonb_column="data")
+class OrderMetrics:
+    day: date
+    total_revenue: Decimal
+    order_count: int
+    average_order_value: Decimal
+    cancelled_count: int
+
+
+@fraiseql.query(authorizer=admin_authorizer)
+async def order_metrics(info, start_date: date, end_date: date) -> list[OrderMetrics]:
+    db = info.context["db"]
+    return await db.find("v_order_metrics", day__gte=start_date, day__lte=end_date)
+```
+
+A client query:
+
+```graphql
+query OrderMetrics($start: Date!, $end: Date!) {
+  orderMetrics(startDate: $start, endDate: $end) {
+    day
+    totalRevenue
+    orderCount
+    averageOrderValue
   }
-`;
-
-export function RevenueReport() {
-  const [dateRange, setDateRange] = useState({
-    start: subDays(new Date(), 30),
-    end: new Date(),
-  });
-
-  const { data } = useQuery(ORDER_METRICS, {
-    variables: {
-      startDate: format(dateRange.start, 'yyyy-MM-dd'),
-      endDate: format(dateRange.end, 'yyyy-MM-dd'),
-    },
-  });
-
-  return (
-    <div className="report">
-      <h1>Revenue Report</h1>
-      <KPI label="Revenue" value={formatCurrency(data?.orderMetrics?.total_revenue)} />
-      <KPI label="Orders" value={data?.orderMetrics?.order_count} />
-      <KPI label="AOV" value={formatCurrency(data?.orderMetrics?.average_order_value)} />
-      <TopProducts products={data?.orderMetrics?.top_products} />
-    </div>
-  );
 }
-```text
-<!-- Code example in TEXT -->
+```
+
+For dedicated reporting workloads, materialize the metrics into a `tv_*`
+projection table refreshed on a schedule instead of computing the aggregate on
+every request.
 
 ---
 
 ## Testing Order Workflows
 
-```typescript
-<!-- Code example in TypeScript -->
-describe('Order Management', () => {
-  it('should create order and reserve inventory', async () => {
-    const variant = await createVariant();
-    const initialStock = 100;
-    await setInventory(variant.id, initialStock);
+Because all the workflow logic lives in `fn_*` functions, the highest-value
+tests are integration tests that run the mutation against a real PostgreSQL
+database and assert on the resulting state. FraiseQL v1 uses
+`pytest` + `pytest-asyncio`.
 
-    const order = await createOrder([
-      { variantId: variant.id, quantity: 10 }
-    ]);
+```python
+import pytest
 
-    const inventory = await getInventory(variant.id);
-    expect(inventory.quantityReserved).toBe(10);
-    expect(inventory.quantityAvailable).toBe(90);
-  });
 
-  it('should prevent overselling', async () => {
-    const variant = await createVariant();
-    await setInventory(variant.id, 5);
+@pytest.mark.asyncio
+async def test_create_order_reserves_inventory(db, seed_variant):
+    """Creating an order reserves stock atomically."""
+    variant_id = await seed_variant(quantity_on_hand=100)
 
-    const createOrder = async () => {
-      return await createOrder([
-        { variantId: variant.id, quantity: 10 }
-      ]);
-    };
+    result = await db.execute_function(
+        "fn_create_order",
+        {"lines": [{"variant_id": str(variant_id), "quantity": 10}],
+         "shipping_address_id": "addr-uuid"},
+    )
 
-    expect(createOrder()).rejects.toThrow('Insufficient inventory');
-  });
+    assert result["success"] is True
+    inv = await db.find_one("v_inventory", variant_id=variant_id)
+    assert inv["quantity_reserved"] == 10
+    assert inv["quantity_available"] == 90
 
-  it('should release inventory on cancellation', async () => {
-    const order = await createOrder([...]);
-    const inventory = await getInventory(variant.id);
-    const reserved = inventory.quantityReserved;
 
-    await cancelOrder(order.id);
+@pytest.mark.asyncio
+async def test_create_order_prevents_overselling(db, seed_variant):
+    """Ordering more than is available fails and reserves nothing."""
+    variant_id = await seed_variant(quantity_on_hand=5)
 
-    const updatedInventory = await getInventory(variant.id);
-    expect(updatedInventory.quantityReserved).toBe(reserved - 10);
-  });
-});
-```text
-<!-- Code example in TEXT -->
+    result = await db.execute_function(
+        "fn_create_order",
+        {"lines": [{"variant_id": str(variant_id), "quantity": 10}],
+         "shipping_address_id": "addr-uuid"},
+    )
+
+    assert result["success"] is False
+    assert "INSUFFICIENT_STOCK" in result["message"]
+    inv = await db.find_one("v_inventory", variant_id=variant_id)
+    assert inv["quantity_reserved"] == 0   # transaction rolled back
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_releases_inventory(db, seeded_order):
+    """Cancelling an order releases its reserved stock."""
+    order_id, variant_id = seeded_order
+    before = await db.find_one("v_inventory", variant_id=variant_id)
+
+    result = await db.execute_function("fn_cancel_order", {"order_id": str(order_id)})
+
+    assert result["success"] is True
+    after = await db.find_one("v_inventory", variant_id=variant_id)
+    assert after["quantity_reserved"] == before["quantity_reserved"] - 10
+
+
+@pytest.mark.asyncio
+async def test_outbox_row_enqueued_on_order(db, seed_variant):
+    """The payment side effect is recorded in the outbox, not executed inline."""
+    variant_id = await seed_variant(quantity_on_hand=50)
+
+    result = await db.execute_function(
+        "fn_create_order",
+        {"lines": [{"variant_id": str(variant_id), "quantity": 1}],
+         "shipping_address_id": "addr-uuid"},
+    )
+
+    rows = await db.find("v_outbox", topic="charge_payment", status="pending")
+    assert any(r["payload"]["order_id"] == result["order"]["id"] for r in rows)
+```
 
 ---
 
@@ -694,15 +967,11 @@ describe('Order Management', () => {
 
 **Related Patterns:**
 
-- [Multi-Tenant SaaS](./saas-multi-tenant.md) - Multi-vendor marketplaces
-- [Analytics Platform](./analytics-olap-platform.md) - Sales reporting
+- [Patterns overview](./README.md) - Index of application blueprints
+- [Multi-Tenant SaaS](./saas-multi-tenant.md) - RLS-based tenant and role isolation
+- [Analytics Platform](./analytics-olap-platform.md) - Sales reporting and OLAP
 
 **Guides:**
 
-- [Production Deployment](../guides/production-deployment.md)
-- [Schema Design Best Practices](../guides/schema-design-best-practices.md)
-
----
-
-**Last Updated:** 2026-02-05
-**Version:** v2.0.0-alpha.1
+- [Integration Patterns](../architecture/integration/integration-patterns.md) - FastAPI integration, FDW, `fn_*` functions
+- [Error Handling & Validation](../foundation/10-error-handling-validation.md) - Success/error unions and mutation results

--- a/docs/patterns/iot-timeseries.md
+++ b/docs/patterns/iot-timeseries.md
@@ -1,459 +1,603 @@
-<!-- Skip to main content -->
 ---
-
 title: IoT Platform with Time-Series Data
-description: Complete guide to building a scalable IoT platform for collecting and querying sensor data efficiently.
-keywords: ["workflow", "saas", "realtime", "ecommerce", "analytics", "federation"]
-tags: ["documentation", "reference"]
+description: Build a scalable IoT platform on FraiseQL and PostgreSQL — collect sensor readings, bucket and roll them up with views, and serve them over GraphQL.
+keywords: ["iot", "time-series", "sensors", "aggregation", "postgresql"]
+tags: ["documentation", "patterns"]
 ---
 
 # IoT Platform with Time-Series Data
 
-**Status:** ✅ Production Ready
-**Complexity:** ⭐⭐⭐⭐ (Advanced)
+**Status:** Production Ready
+**Complexity:** Advanced
 **Audience:** IoT architects, DevOps engineers, data engineers
 **Reading Time:** 25-30 minutes
-**Last Updated:** 2026-02-05
 
-Complete guide to building a scalable IoT platform for collecting and querying sensor data efficiently.
+A blueprint for building an IoT platform on FraiseQL v1. Readings land in normalized
+`tb_` tables (optionally partitioned by time range), `v_`/`tv_` views bucket and roll
+them up with `DATE_TRUNC` and PostgreSQL aggregates, and `@fraiseql.query` resolvers serve
+the views over GraphQL. FraiseQL is a Python runtime GraphQL framework for **PostgreSQL
+only** — there is no compile step and no separate database engine. Everything below runs at
+app startup against your PostgreSQL database.
 
 ---
 
 ## Architecture Overview
 
 ```text
-<!-- Code example in TEXT -->
 ┌──────────────┬──────────────┬──────────────┐
 │   Devices    │   Devices    │   Devices    │
-│  (millions)  │  (millions)  │  (millions)  │
+│  (sensors)   │  (sensors)   │  (sensors)   │
 └──────────┬───┴──────┬───────┴──────┬───────┘
-           │          │               │
-           └──────────┼───────────────┘
-                      ↓ (MQTT/HTTP)
-         ┌────────────────────────┐
-         │  Message Broker        │
-         │  (Kafka/MQTT/Redis)    │
-         └────────────┬───────────┘
+           │          │              │
+           └──────────┼──────────────┘
+                      ↓ (HTTP / MQTT bridge)
+         ┌────────────────────────────┐
+         │  Ingestion                 │
+         │  fn_record_reading()       │
+         │  or COPY (bulk)            │
+         └────────────┬───────────────┘
                       ↓
-         ┌────────────────────────┐
-         │  Stream Processor      │
-         │  (Validation,          │
-         │   Aggregation)         │
-         └────────────┬───────────┘
-                      ↓
-         ┌────────────────────────┐
-         │  Time-Series Database  │
-         │  (PostgreSQL +         │
-         │   TimescaleDB)         │
-         └────────────┬───────────┘
-                      ↓
-         ┌────────────────────────┐
-         │  FraiseQL GraphQL      │
-         │  (Query Layer)         │
-         └────────────────────────┘
-```text
-<!-- Code example in TEXT -->
+         ┌────────────────────────────┐
+         │  PostgreSQL                │
+         │  tb_sensor_reading         │
+         │  (PARTITION BY RANGE time) │
+         │  tv_reading_1h / _1d       │
+         │  (pre-aggregated rollups)  │
+         └────────────┬───────────────┘
+                      ↓  v_/tv_ views
+         ┌────────────────────────────┐
+         │  FraiseQL (FastAPI)        │
+         │  @fraiseql.query / runtime │
+         │  auto-aggregation          │
+         └────────────────────────────┘
+```
+
+The message broker (MQTT/Kafka) and any stream processor live *outside* FraiseQL. They are
+optional plumbing that lands readings into PostgreSQL. FraiseQL's job is the read/write path
+against PostgreSQL: queries read `v_`/`tv_` views, mutations call `fn_` functions.
 
 ---
 
 ## Schema Design
 
+FraiseQL follows a CQRS layout: normalized `tb_` write tables are the source of truth,
+`v_`/`tv_` read views expose a `data` JSONB column for GraphQL, and `fn_` functions hold
+write logic. Each public row carries a `pk_` internal BIGINT (hidden), a public `id` UUID,
+and an optional human-readable `identifier`.
+
 ### Devices & Metadata
 
 ```sql
-<!-- Code example in SQL -->
--- Device registry
-CREATE TABLE devices (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  device_id VARCHAR(100) UNIQUE NOT NULL,  -- External ID (MAC, serial)
-  name VARCHAR(255) NOT NULL,
-  device_type VARCHAR(50) NOT NULL,  -- temperature_sensor, humidity_sensor, etc.
-  location VARCHAR(255),  -- Building/Room
-  latitude NUMERIC(10, 8),
-  longitude NUMERIC(11, 8),
-  owner_id UUID NOT NULL,
-  status VARCHAR(50) NOT NULL,  -- active, inactive, error
-  last_heartbeat TIMESTAMP,
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_device_id (device_id),
-  INDEX idx_owner_id (owner_id),
-  INDEX idx_status (status),
-  INDEX idx_device_type (device_type)
+-- Device registry (write table)
+CREATE TABLE tb_device (
+    pk_device       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id              UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    identifier      TEXT UNIQUE,              -- external slug (MAC, serial)
+    name            TEXT NOT NULL,
+    device_type     TEXT NOT NULL,           -- temperature_sensor, humidity_sensor, ...
+    location        TEXT,
+    latitude        NUMERIC(10, 8),
+    longitude       NUMERIC(11, 8),
+    fk_owner        BIGINT NOT NULL REFERENCES tb_owner (pk_owner),
+    status          TEXT NOT NULL DEFAULT 'active',  -- active, inactive, error
+    last_heartbeat  TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Device configuration
-CREATE TABLE device_config (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  device_id UUID NOT NULL UNIQUE REFERENCES devices(id) ON DELETE CASCADE,
-  read_interval INT NOT NULL,  -- Seconds between readings
-  alert_threshold JSONB,  -- { temperature: { min: 0, max: 100 } }
-  data_retention_days INT DEFAULT 365,
-  custom_fields JSONB,  -- Any device-specific config
-  updated_at TIMESTAMP DEFAULT NOW(),
+CREATE INDEX idx_device_status      ON tb_device (status);
+CREATE INDEX idx_device_type        ON tb_device (device_type);
+CREATE INDEX idx_device_owner       ON tb_device (fk_owner);
 
-  INDEX idx_device_id (device_id)
+-- Per-device configuration
+CREATE TABLE tb_device_config (
+    pk_device_config    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    fk_device           BIGINT NOT NULL UNIQUE REFERENCES tb_device (pk_device) ON DELETE CASCADE,
+    read_interval_s     INT NOT NULL,                -- seconds between readings
+    alert_threshold     JSONB,                       -- {"temperature": {"min": 0, "max": 100}}
+    data_retention_days INT NOT NULL DEFAULT 365,
+    custom_fields       JSONB,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- Sensor metadata (what each device measures)
-CREATE TABLE sensors (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  device_id UUID NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
-  sensor_name VARCHAR(100) NOT NULL,  -- temperature, humidity, pressure
-  unit VARCHAR(20),  -- Celsius, %, hPa
-  sensor_type VARCHAR(50),  -- analog, digital, counter
-  accuracy DECIMAL(5, 2),
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  UNIQUE(device_id, sensor_name),
-  INDEX idx_device_id (device_id)
+CREATE TABLE tb_sensor (
+    pk_sensor   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id          UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    fk_device   BIGINT NOT NULL REFERENCES tb_device (pk_device) ON DELETE CASCADE,
+    sensor_name TEXT NOT NULL,                -- temperature, humidity, pressure
+    unit        TEXT,                         -- Celsius, %, hPa
+    sensor_type TEXT,                         -- analog, digital, counter
+    accuracy    NUMERIC(5, 2),
+    UNIQUE (fk_device, sensor_name)
 );
-```text
-<!-- Code example in TEXT -->
 
-### Time-Series Data
+CREATE INDEX idx_sensor_device ON tb_sensor (fk_device);
+```
+
+### Time-Series Readings (Native Partitioning)
+
+Raw readings are high-volume and append-only, which makes them a natural fit for
+PostgreSQL **native range partitioning** by time. Partitioning keeps indexes small,
+makes retention a metadata operation (`DROP`/`DETACH PARTITION` instead of a slow
+`DELETE`), and lets the planner prune to the partitions a query touches.
 
 ```sql
-<!-- Code example in SQL -->
--- Raw sensor readings (hypertable with TimescaleDB)
-CREATE TABLE sensor_readings (
-  time TIMESTAMP NOT NULL,
-  device_id UUID NOT NULL,
-  sensor_name VARCHAR(100) NOT NULL,
-  value NUMERIC(10, 4) NOT NULL,
-  unit VARCHAR(20),
-  quality VARCHAR(50),  -- good, poor, unknown
-  FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
-);
+-- Raw sensor readings, partitioned by month
+CREATE TABLE tb_sensor_reading (
+    "time"      TIMESTAMPTZ NOT NULL,
+    fk_device   BIGINT NOT NULL REFERENCES tb_device (pk_device) ON DELETE CASCADE,
+    sensor_name TEXT NOT NULL,
+    value       NUMERIC(12, 4) NOT NULL,
+    unit        TEXT,
+    quality     TEXT                          -- good, poor, unknown
+) PARTITION BY RANGE ("time");
 
--- Create hypertable (TimescaleDB extension)
-SELECT create_hypertable('sensor_readings', 'time');
+-- One partition per month (create ahead of time, e.g. via cron)
+CREATE TABLE tb_sensor_reading_2026_06
+    PARTITION OF tb_sensor_reading
+    FOR VALUES FROM ('2026-06-01') TO ('2026-07-01');
 
--- Automatic compression of old data
-SELECT add_compression_policy('sensor_readings', INTERVAL '7 days');
+CREATE TABLE tb_sensor_reading_2026_07
+    PARTITION OF tb_sensor_reading
+    FOR VALUES FROM ('2026-07-01') TO ('2026-08-01');
 
--- Automatic retention (delete data older than 1 year)
-SELECT add_retention_policy('sensor_readings', INTERVAL '1 year');
+-- Indexes are created on the parent and inherited by every partition
+CREATE INDEX idx_reading_device_time ON tb_sensor_reading (fk_device, "time" DESC);
+CREATE INDEX idx_reading_sensor_time ON tb_sensor_reading (sensor_name, "time" DESC);
+```
 
--- Indexes for common queries
-CREATE INDEX idx_device_time ON sensor_readings (device_id, time DESC);
-CREATE INDEX idx_sensor_time ON sensor_readings (sensor_name, time DESC);
-```text
-<!-- Code example in TEXT -->
-
-### Aggregated Data (Pre-Computed)
+Retention then becomes cheap — drop the partition once it ages out:
 
 ```sql
-<!-- Code example in SQL -->
--- Hourly aggregates (faster for dashboards)
-CREATE TABLE sensor_readings_1h (
-  time TIMESTAMP NOT NULL,
-  device_id UUID NOT NULL,
-  sensor_name VARCHAR(100) NOT NULL,
-  avg_value NUMERIC(10, 4),
-  min_value NUMERIC(10, 4),
-  max_value NUMERIC(10, 4),
-  reading_count INT,
-  FOREIGN KEY (device_id) REFERENCES devices(id)
+-- Retire June once it is older than the retention window
+DROP TABLE tb_sensor_reading_2026_06;
+-- or keep it queryable but off the hot path:
+-- ALTER TABLE tb_sensor_reading DETACH PARTITION tb_sensor_reading_2026_06;
+```
+
+### Pre-Aggregated Rollups (`tv_` projection tables)
+
+For dashboards you don't want to scan raw readings on every request. A `tv_` table holds
+**pre-aggregated** rollups: a real table populated by a function (run from a trigger or a
+cron job) that FraiseQL queries directly. This is the standard v1 way to serve heavy reads
+fast — see [tv-table pattern](../architecture/database/tv-table-pattern.md).
+
+```sql
+-- Hourly rollup table (a real table, refreshed incrementally)
+CREATE TABLE tv_reading_1h (
+    bucket        TIMESTAMPTZ NOT NULL,
+    fk_device     BIGINT NOT NULL,
+    sensor_name   TEXT NOT NULL,
+    data          JSONB NOT NULL,          -- pre-composed payload FraiseQL returns
+    PRIMARY KEY (bucket, fk_device, sensor_name)
 );
 
--- Create hypertable
-SELECT create_hypertable('sensor_readings_1h', 'time');
+-- Refresh one window (call from cron, or from a trigger on tb_sensor_reading)
+CREATE OR REPLACE FUNCTION fn_refresh_reading_1h(p_from TIMESTAMPTZ, p_to TIMESTAMPTZ)
+RETURNS void
+LANGUAGE sql
+AS $$
+    INSERT INTO tv_reading_1h (bucket, fk_device, sensor_name, data)
+    SELECT
+        DATE_TRUNC('hour', r."time")               AS bucket,
+        r.fk_device,
+        r.sensor_name,
+        jsonb_build_object(
+            'avgValue',     AVG(r.value),
+            'minValue',     MIN(r.value),
+            'maxValue',     MAX(r.value),
+            'stddevValue',  STDDEV(r.value),
+            'readingCount', COUNT(*)
+        )                                          AS data
+    FROM tb_sensor_reading r
+    WHERE r."time" >= p_from AND r."time" < p_to
+    GROUP BY DATE_TRUNC('hour', r."time"), r.fk_device, r.sensor_name
+    ON CONFLICT (bucket, fk_device, sensor_name)
+    DO UPDATE SET data = EXCLUDED.data;
+$$;
+```
 
--- Continuous aggregate (automatically updated)
-CREATE MATERIALIZED VIEW sensor_readings_1h AS
-SELECT
-  time_bucket('1 hour', time) as time,
-  device_id,
-  sensor_name,
-  AVG(value) as avg_value,
-  MIN(value) as min_value,
-  MAX(value) as max_value,
-  COUNT(*) as reading_count
-FROM sensor_readings
-GROUP BY time_bucket('1 hour', time), device_id, sensor_name;
+A daily `tv_reading_1d` table follows the same shape with `DATE_TRUNC('day', ...)`.
+For details on automatic `GROUP BY` derivation, see the
+[aggregation model](../architecture/analytics/aggregation-model.md).
 
--- Same for daily
-CREATE MATERIALIZED VIEW sensor_readings_1d AS
+### Read Views
+
+Read views always expose an `id` (for `WHERE id = $1`) plus a `data` JSONB column built
+with `jsonb_build_object(...)`. `pk_`/`fk_` columns stay out of `data`.
+
+```sql
+-- Device read view
+CREATE VIEW v_device AS
 SELECT
-  time_bucket('1 day', time) as time,
-  device_id,
-  sensor_name,
-  AVG(value) as avg_value,
-  MIN(value) as min_value,
-  MAX(value) as max_value,
-  COUNT(*) as reading_count
-FROM sensor_readings
-WHERE time >= NOW() - INTERVAL '1 year'
-GROUP BY time_bucket('1 day', time), device_id, sensor_name;
-```text
-<!-- Code example in TEXT -->
+    d.id,
+    jsonb_build_object(
+        'id',           d.id,
+        'identifier',   d.identifier,
+        'name',         d.name,
+        'deviceType',   d.device_type,
+        'location',     d.location,
+        'latitude',     d.latitude,
+        'longitude',    d.longitude,
+        'status',       d.status,
+        'lastHeartbeat', d.last_heartbeat
+    ) AS data
+FROM tb_device d;
+
+-- Hourly metric view over the rollup table
+CREATE VIEW v_reading_1h AS
+SELECT
+    t.bucket,
+    dev.id AS device_id,
+    t.sensor_name,
+    jsonb_build_object(
+        'bucket',       t.bucket,
+        'sensorName',   t.sensor_name,
+        'avgValue',     t.data ->> 'avgValue',
+        'minValue',     t.data ->> 'minValue',
+        'maxValue',     t.data ->> 'maxValue',
+        'stddevValue',  t.data ->> 'stddevValue',
+        'readingCount', t.data ->> 'readingCount'
+    ) AS data
+FROM tv_reading_1h t
+JOIN tb_device dev ON dev.pk_device = t.fk_device;
+```
+
+### Moving Averages with Window Functions
+
+Moving averages and rate-of-change are plain PostgreSQL **window functions** embedded in a
+view — not a FraiseQL API. FraiseQL serves whatever the view returns. See
+[window functions](../architecture/analytics/window-functions.md).
+
+```sql
+-- 3-bucket moving average of hourly readings
+CREATE VIEW v_reading_1h_smoothed AS
+SELECT
+    dev.id AS device_id,
+    t.sensor_name,
+    jsonb_build_object(
+        'bucket',     t.bucket,
+        'sensorName', t.sensor_name,
+        'avgValue',   (t.data ->> 'avgValue')::numeric,
+        'movingAvg3', AVG((t.data ->> 'avgValue')::numeric) OVER (
+            PARTITION BY t.fk_device, t.sensor_name
+            ORDER BY t.bucket
+            ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+        )
+    ) AS data
+FROM tv_reading_1h t
+JOIN tb_device dev ON dev.pk_device = t.fk_device;
+```
 
 ### Alerts & Events
 
 ```sql
-<!-- Code example in SQL -->
-CREATE TABLE device_alerts (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  device_id UUID NOT NULL REFERENCES devices(id),
-  alert_type VARCHAR(50) NOT NULL,  -- threshold_exceeded, device_offline, low_battery
-  severity VARCHAR(50) NOT NULL,  -- info, warning, critical
-  value NUMERIC(10, 4),
-  threshold NUMERIC(10, 4),
-  acknowledged BOOLEAN DEFAULT FALSE,
-  acknowledged_by UUID,
-  acknowledged_at TIMESTAMP,
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_device_id (device_id),
-  INDEX idx_severity (severity),
-  INDEX idx_acknowledged (acknowledged),
-  INDEX idx_created_at (created_at)
+CREATE TABLE tb_device_alert (
+    pk_device_alert  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id               UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    fk_device        BIGINT NOT NULL REFERENCES tb_device (pk_device),
+    alert_type       TEXT NOT NULL,           -- threshold_exceeded, device_offline, low_battery
+    severity         TEXT NOT NULL,           -- info, warning, critical
+    value            NUMERIC(12, 4),
+    threshold        NUMERIC(12, 4),
+    acknowledged     BOOLEAN NOT NULL DEFAULT FALSE,
+    fk_acknowledged_by BIGINT REFERENCES tb_user (pk_user),
+    acknowledged_at  TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-```text
-<!-- Code example in TEXT -->
+
+CREATE INDEX idx_alert_device       ON tb_device_alert (fk_device);
+CREATE INDEX idx_alert_severity     ON tb_device_alert (severity);
+CREATE INDEX idx_alert_open         ON tb_device_alert (acknowledged) WHERE NOT acknowledged;
+
+CREATE VIEW v_alert AS
+SELECT
+    a.id,
+    jsonb_build_object(
+        'id',           a.id,
+        'alertType',    a.alert_type,
+        'severity',     a.severity,
+        'value',        a.value,
+        'threshold',    a.threshold,
+        'acknowledged', a.acknowledged,
+        'createdAt',    a.created_at
+    ) AS data
+FROM tb_device_alert a;
+```
 
 ---
 
 ## FraiseQL Schema
 
+Types bind to a read view via `sql_source`; FraiseQL reads the view's `data` JSONB and
+shapes it to the requested GraphQL fields. Queries call `db.find`/`db.find_one`; mutations
+call `fn_` functions via `db.execute_function`.
+
 ```python
-<!-- Code example in Python -->
 # iot_schema.py
-from FraiseQL import types
-from datetime import datetime
+import fraiseql
+from fraiseql.types import ID, DateTime
 from decimal import Decimal
 
-@types.object
+
+@fraiseql.type(sql_source="v_device", jsonb_column="data")
 class Device:
-    id: UUID  # UUID v4 for GraphQL ID
-    device_id: UUID  # UUID v4 for GraphQL ID
+    id: ID
+    identifier: str | None
     name: str
     device_type: str
     location: str | None
     latitude: Decimal | None
     longitude: Decimal | None
-    status: str  # active, inactive, error
-    last_heartbeat: datetime | None
-    sensors: list['Sensor']
-    current_readings: list['SensorReading']
-    alerts: list['Alert']
+    status: str                       # active, inactive, error
+    last_heartbeat: DateTime | None
 
-@types.object
+
+@fraiseql.type(sql_source="v_sensor", jsonb_column="data")
 class Sensor:
-    id: UUID  # UUID v4 for GraphQL ID
-    device: Device
+    id: ID
     sensor_name: str
-    unit: str
-    accuracy: Decimal
+    unit: str | None
+    accuracy: Decimal | None
 
-@types.object
-class SensorReading:
-    time: datetime
-    device: Device
-    sensor_name: str
-    value: Decimal
-    unit: str
-    quality: str
 
-@types.object
+@fraiseql.type(sql_source="v_reading_1h", jsonb_column="data")
 class SensorMetric:
-    """Aggregated metric"""
-    time: datetime
-    avg_value: Decimal
-    min_value: Decimal
-    max_value: Decimal
+    """Pre-aggregated hourly metric from tv_reading_1h."""
+    bucket: DateTime
+    sensor_name: str
+    avg_value: Decimal | None
+    min_value: Decimal | None
+    max_value: Decimal | None
+    stddev_value: Decimal | None
     reading_count: int
 
-@types.object
+
+@fraiseql.type(sql_source="v_alert", jsonb_column="data")
 class Alert:
-    id: UUID  # UUID v4 for GraphQL ID
-    device: Device
+    id: ID
     alert_type: str
-    severity: str  # info, warning, critical
+    severity: str                     # info, warning, critical
     value: Decimal | None
     threshold: Decimal | None
     acknowledged: bool
-    created_at: datetime
+    created_at: DateTime
 
-@types.object
-class Query:
-    def device(self, id: str) -> Device:
-        """Get device details"""
-        pass
 
-    def devices(self, device_type: str | None = None) -> list[Device]:
-        """List all devices"""
-        pass
+@fraiseql.input
+class RecordReadingInput:
+    device_id: ID
+    sensor_name: str
+    value: Decimal
+    timestamp: DateTime | None = None
 
-    def sensor_readings(
-        self,
-        device_id: str,
-        sensor_name: str,
-        start_time: str,
-        end_time: str,
-        limit: int = 1000
-    ) -> list[SensorReading]:
-        """Get raw sensor readings"""
-        pass
 
-    def sensor_metrics(
-        self,
-        device_id: str,
-        sensor_name: str,
-        start_time: str,
-        end_time: str,
-        granularity: str = '1h'  # 1h, 1d, 1w
-    ) -> list[SensorMetric]:
-        """Get aggregated metrics (faster)"""
-        pass
+@fraiseql.success
+class RecordReadingSuccess:
+    device_id: ID
+    sensor_name: str
 
-    def active_alerts(self) -> list[Alert]:
-        """Unacknowledged alerts"""
-        pass
 
-    def device_status_summary(self) -> dict:
-        """Status summary (active, offline, error counts)"""
-        pass
+@fraiseql.error
+class RecordReadingError:
+    message: str
+    code: str = "INGEST_ERROR"
 
-@types.object
-class Mutation:
-    def create_device(
-        self,
-        device_id: str,
-        name: str,
-        device_type: str
-    ) -> Device:
-        """Register new device"""
-        pass
 
-    def record_reading(
-        self,
-        device_id: str,
-        sensor_name: str,
-        value: Decimal,
-        timestamp: str
-    ) -> SensorReading:
-        """Record sensor reading"""
-        pass
+@fraiseql.input
+class AcknowledgeAlertInput:
+    alert_id: ID
 
-    def acknowledge_alert(self, alert_id: str) -> Alert:
-        """Mark alert as acknowledged"""
-        pass
 
-@types.subscription
-class Subscription:
-    def device_status(self, device_id: str) -> dict:
-        """Real-time device status updates"""
-        pass
+@fraiseql.success
+class AcknowledgeAlertSuccess:
+    alert: Alert
 
-    def alerts(self) -> Alert:
-        """Real-time alert stream"""
-        pass
 
-    def metrics(self, device_id: str) -> SensorMetric:
-        """Real-time metric updates"""
-        pass
-```text
-<!-- Code example in TEXT -->
+@fraiseql.error
+class AcknowledgeAlertError:
+    message: str
+    code: str = "NOT_FOUND"
+```
+
+### Queries
+
+```python
+@fraiseql.query
+async def devices(info, device_type: str | None = None) -> list[Device]:
+    """List devices, optionally filtered by type."""
+    db = info.context["db"]
+    filters = {"device_type": device_type} if device_type else {}
+    return await db.find("v_device", **filters)
+
+
+@fraiseql.query
+async def device(info, id: ID) -> Device | None:
+    """Get one device by id."""
+    db = info.context["db"]
+    return await db.find_one("v_device", id=id)
+
+
+@fraiseql.query
+async def sensor_metrics(
+    info,
+    device_id: ID,
+    sensor_name: str,
+    start_time: DateTime,
+    end_time: DateTime,
+) -> list[SensorMetric]:
+    """Pre-aggregated hourly metrics from tv_reading_1h (fast for dashboards)."""
+    db = info.context["db"]
+    return await db.find(
+        "v_reading_1h",
+        device_id=device_id,
+        sensor_name=sensor_name,
+        bucket__gte=start_time,
+        bucket__lte=end_time,
+    )
+
+
+@fraiseql.query
+async def active_alerts(info) -> list[Alert]:
+    """Unacknowledged alerts."""
+    db = info.context["db"]
+    return await db.find("v_alert", acknowledged=False)
+```
+
+`start_time`/`end_time` map to the WHERE operators `bucket__gte` / `bucket__lte`, which
+FraiseQL translates into a partition-prunable `BETWEEN` against the view. When a query
+selects only aggregate fields, FraiseQL's **runtime auto-aggregation** derives the
+`GROUP BY` and the COUNT/SUM/AVG/MIN/MAX/STDDEV/VARIANCE SQL for you against the view — so
+you can aggregate `v_reading_1h` further without writing a second view. See the
+[aggregation model](../architecture/analytics/aggregation-model.md).
+
+### Mutations
+
+```python
+@fraiseql.mutation
+async def record_reading(
+    info, input: RecordReadingInput
+) -> RecordReadingSuccess | RecordReadingError:
+    """Ingest a single reading and run threshold checks (in PostgreSQL)."""
+    db = info.context["db"]
+    result = await db.execute_function(
+        "fn_record_reading",
+        {
+            "device_id": str(input.device_id),
+            "sensor_name": input.sensor_name,
+            "value": str(input.value),
+            "ts": input.timestamp,
+        },
+    )
+    if not result.get("success"):
+        return RecordReadingError(message=result.get("message", "ingest failed"))
+    return RecordReadingSuccess(
+        device_id=input.device_id, sensor_name=input.sensor_name
+    )
+
+
+@fraiseql.mutation
+async def acknowledge_alert(
+    info, input: AcknowledgeAlertInput
+) -> AcknowledgeAlertSuccess | AcknowledgeAlertError:
+    db = info.context["db"]
+    result = await db.execute_function(
+        "fn_acknowledge_alert", {"alert_id": str(input.alert_id)}
+    )
+    if not result.get("success"):
+        return AcknowledgeAlertError(message=result.get("message", "not found"))
+    return AcknowledgeAlertSuccess(alert=Alert(**result["alert"]))
+```
+
+### Real-Time Push (Subscriptions)
+
+FraiseQL exposes GraphQL subscriptions over WebSocket. A `@fraiseql.subscription` decorates
+an **async generator** — you write the event source, FraiseQL streams what you yield. Back
+it with PostgreSQL `LISTEN/NOTIFY` (e.g. a trigger on `tb_device_alert` that runs
+`pg_notify('alert', ...)`), polling, or any external stream.
+
+```python
+from collections.abc import AsyncGenerator
+
+
+@fraiseql.subscription
+async def alerts(info) -> AsyncGenerator[Alert, None]:
+    """Stream new alerts to dashboards as they are created."""
+    async for alert in watch_alerts(info.context["db"]):   # your LISTEN/NOTIFY loop
+        yield alert
+```
+
+### Mounting the App
+
+```python
+from fraiseql.fastapi import create_fraiseql_app
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/iot",
+    types=[Device, Sensor, SensorMetric, Alert],
+    queries=[devices, device, sensor_metrics, active_alerts],
+    mutations=[record_reading, acknowledge_alert],
+    subscriptions=[alerts],
+    production=False,        # False enables the GraphQL playground
+)
+```
+
+Run it with `uvicorn app:app`.
 
 ---
 
-## MQTT Ingestion
+## Ingestion
 
-### Stream Processor
+All write logic lives in PostgreSQL. The `fn_record_reading` function validates the device,
+inserts the reading, and evaluates thresholds in one transaction.
+
+```sql
+CREATE OR REPLACE FUNCTION fn_record_reading(
+    device_id   UUID,
+    sensor_name TEXT,
+    value       NUMERIC,
+    ts          TIMESTAMPTZ DEFAULT now()
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_pk_device BIGINT;
+    v_threshold NUMERIC;
+BEGIN
+    SELECT pk_device INTO v_pk_device FROM tb_device WHERE id = device_id;
+    IF v_pk_device IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'message', 'unknown device');
+    END IF;
+
+    INSERT INTO tb_sensor_reading ("time", fk_device, sensor_name, value)
+    VALUES (ts, v_pk_device, sensor_name, value);
+
+    -- Threshold check
+    SELECT (alert_threshold -> sensor_name ->> 'max')::numeric
+      INTO v_threshold
+      FROM tb_device_config WHERE fk_device = v_pk_device;
+
+    IF v_threshold IS NOT NULL AND value > v_threshold THEN
+        INSERT INTO tb_device_alert (fk_device, alert_type, severity, value, threshold)
+        VALUES (v_pk_device, 'threshold_exceeded', 'warning', value, v_threshold);
+        PERFORM pg_notify('alert', jsonb_build_object(
+            'device', device_id, 'sensor', sensor_name, 'value', value
+        )::text);
+    END IF;
+
+    RETURN jsonb_build_object('success', true);
+END;
+$$;
+```
+
+### Bulk Ingestion with COPY
+
+For backfills or high-throughput ingestion, bypass per-row mutations and stream straight
+into the partitioned table with `COPY` — the fastest path PostgreSQL offers. An MQTT/Kafka
+bridge can batch readings and pipe them in:
+
+```sql
+COPY tb_sensor_reading ("time", fk_device, sensor_name, value, unit)
+FROM STDIN WITH (FORMAT csv);
+```
 
 ```python
-<!-- Code example in Python -->
-import asyncio
-import aiomqtt
-from datetime import datetime
+# Async bulk load via psycopg copy (run outside FraiseQL, in your ingestion worker)
+async with pool.connection() as conn:
+    async with conn.cursor().copy(
+        "COPY tb_sensor_reading (\"time\", fk_device, sensor_name, value) FROM STDIN"
+    ) as copy:
+        for row in batch:
+            await copy.write_row(row)
+```
 
-class MQTTIngestionService:
-    def __init__(self, db_client, kafka_producer):
-        self.db = db_client
-        self.kafka = kafka_producer
+After a bulk load, refresh the affected rollup windows by calling
+`fn_refresh_reading_1h(p_from, p_to)`.
 
-    async def start(self):
-        async with aiomqtt.Client('mqtt.broker.local') as client:
-            async with client.messages() as messages:
-                async for message in messages:
-                    await self.process_message(message)
-
-    async def process_message(self, message):
-        """
-        Expected MQTT topic: sensors/{device_id}/{sensor_name}
-        Expected payload: { value: 23.5, timestamp: ISO8601 }
-        """
-        try:
-            # Parse topic
-            parts = message.topic.split('/')
-            if len(parts) < 3:
-                return
-
-            device_id = parts[1]
-            sensor_name = parts[2]
-            payload = json.loads(message.payload.decode())
-
-            # Validate device exists
-            device = await self.db.fetchrow(
-                'SELECT id FROM devices WHERE device_id = $1',
-                device_id
-            )
-            if not device:
-                print(f'Unknown device: {device_id}')
-                return
-
-            # Insert reading
-            await self.db.execute("""
-                INSERT INTO sensor_readings
-                (time, device_id, sensor_name, value)
-                VALUES ($1, $2, $3, $4)
-            """, (
-                datetime.fromisoformat(payload.get('timestamp', datetime.now().isoformat())),
-                device['id'],
-                sensor_name,
-                payload['value']
-            ))
-
-            # Check for alerts
-            await self.check_alerts(device['id'], sensor_name, payload['value'])
-
-            # Publish to Kafka for other consumers
-            self.kafka.send('sensor-readings', {
-                'device_id': device_id,
-                'sensor_name': sensor_name,
-                'value': payload['value'],
-                'timestamp': datetime.now().isoformat()
-            })
-
-        except Exception as e:
-            print(f'Error processing message: {e}')
-
-    async def check_alerts(self, device_id, sensor_name, value):
-        """Check if value exceeds threshold"""
-        config = await self.db.fetchrow("""
-            SELECT alert_threshold FROM device_config WHERE device_id = $1
-        """, device_id)
-
-        if not config:
-            return
-
-        thresholds = config.get('alert_threshold', {})
-        sensor_threshold = thresholds.get(sensor_name)
-
-        if not sensor_threshold:
-            return
-
-        # Check if value exceeds
-        if value > sensor_threshold.get('max'):
-            await self.db.execute("""
-                INSERT INTO device_alerts
-                (device_id, alert_type, severity, value, threshold)
-                VALUES ($1, 'threshold_exceeded', 'warning', $2, $3)
-            """, (device_id, value, sensor_threshold['max']))
-```text
-<!-- Code example in TEXT -->
+> **Brokers are external.** Kafka, MQTT, and stream processors are separate systems that
+> feed PostgreSQL. Dedicated time-series stores (e.g. ClickHouse, InfluxDB) are also separate
+> systems — FraiseQL itself targets PostgreSQL only. Pick whichever ingestion plumbing you
+> like; FraiseQL reads from the PostgreSQL tables and views.
 
 ---
 
@@ -462,53 +606,43 @@ class MQTTIngestionService:
 ### Real-Time Dashboard
 
 ```graphql
-<!-- Code example in GraphQL -->
 query DeviceDashboard($deviceId: ID!) {
   device(id: $deviceId) {
     id
     name
     status
-    current_readings {
-      sensor_name
-      value
-      unit
-      time
-    }
-    alerts {
-      id
-      alert_type
-      severity
-      value
-    }
+    lastHeartbeat
+  }
+  activeAlerts {
+    id
+    alertType
+    severity
+    value
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-### Time-Series Analysis
+### Time-Series Trend
 
 ```graphql
-<!-- Code example in GraphQL -->
 query TemperatureTrend(
   $deviceId: ID!
-  $startTime: String!
-  $endTime: String!
+  $startTime: DateTime!
+  $endTime: DateTime!
 ) {
   sensorMetrics(
     deviceId: $deviceId
     sensorName: "temperature"
     startTime: $startTime
     endTime: $endTime
-    granularity: "1h"
   ) {
-    time
-    avg_value
-    min_value
-    max_value
+    bucket
+    avgValue
+    minValue
+    maxValue
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -516,187 +650,141 @@ query TemperatureTrend(
 
 ### Time-Based Partitioning
 
-```sql
-<!-- Code example in SQL -->
--- Automatic partitioning by date with TimescaleDB
-SELECT set_integer_now_func('sensor_readings', 'pg_catalog.extract_epoch(now())::bigint'::regprocedure);
+Native range partitioning (above) is the core scaling lever. Pre-create partitions ahead of
+time with a small cron job so writes never hit a missing partition:
 
--- Chunks are automatically created
-SELECT show_chunks('sensor_readings');
-```text
-<!-- Code example in TEXT -->
+```sql
+-- Create next month's partition (run monthly)
+CREATE TABLE IF NOT EXISTS tb_sensor_reading_2026_08
+    PARTITION OF tb_sensor_reading
+    FOR VALUES FROM ('2026-08-01') TO ('2026-09-01');
+```
 
 ### Data Retention
 
+Drop or detach aged partitions — a metadata operation, far cheaper than a bulk `DELETE`:
+
 ```sql
-<!-- Code example in SQL -->
--- Automatically delete old data
-SELECT add_retention_policy('sensor_readings', INTERVAL '1 year');
-
--- Or manually archive to cold storage
-INSERT INTO sensor_readings_archive
-SELECT * FROM sensor_readings
-WHERE time < NOW() - INTERVAL '1 year';
-
-DELETE FROM sensor_readings
-WHERE time < NOW() - INTERVAL '1 year';
-```text
-<!-- Code example in TEXT -->
+-- Archive then drop the oldest partition
+ALTER TABLE tb_sensor_reading DETACH PARTITION tb_sensor_reading_2026_06;
+-- Optionally move the detached table to cheaper storage, then:
+DROP TABLE tb_sensor_reading_2026_06;
+```
 
 ### Downsampling
 
+For long-term storage, keep only the daily rollup and let raw partitions expire. The
+`tv_reading_1d` table (refreshed like `tv_reading_1h`) becomes the system of record for
+historical trends, served through `v_reading_1d`.
+
 ```sql
-<!-- Code example in SQL -->
--- For very long-term storage, downsample to daily
-CREATE MATERIALIZED VIEW sensor_summary_long_term AS
-SELECT
-  DATE(time) as date,
-  device_id,
-  sensor_name,
-  AVG(value) as avg_value,
-  MIN(value) as min_value,
-  MAX(value) as max_value
-FROM sensor_readings
-WHERE time < NOW() - INTERVAL '90 days'
-GROUP BY DATE(time), device_id, sensor_name;
-```text
-<!-- Code example in TEXT -->
+-- Daily rollup window refresh
+SELECT fn_refresh_reading_1d(DATE_TRUNC('day', now() - INTERVAL '1 day'),
+                             DATE_TRUNC('day', now()));
+```
 
 ---
 
 ## Alerting
 
-### Rule Engine
+Threshold alerts are evaluated inside `fn_record_reading` (above) so every write is checked
+in the same transaction. For time-window rules (device offline, sustained anomalies) run a
+periodic job that calls an `fn_` function:
 
-```python
-<!-- Code example in Python -->
-# Define alert rules
-ALERT_RULES = [
-    {
-        'id': 'high_temp',
-        'condition': 'sensor_name == "temperature" AND value > 100',
-        'severity': 'critical',
-        'message': 'High temperature detected'
-    },
-    {
-        'id': 'device_offline',
-        'condition': 'last_heartbeat < NOW() - INTERVAL 5 minutes',
-        'severity': 'warning',
-        'message': 'Device offline for 5+ minutes'
-    },
-    {
-        'id': 'low_battery',
-        'condition': 'sensor_name == "battery_level" AND value < 10',
-        'severity': 'warning',
-        'message': 'Battery level low'
-    }
-]
+```sql
+-- Flag devices that haven't reported in 5 minutes (run from cron)
+CREATE OR REPLACE FUNCTION fn_flag_offline_devices()
+RETURNS void
+LANGUAGE sql
+AS $$
+    INSERT INTO tb_device_alert (fk_device, alert_type, severity)
+    SELECT d.pk_device, 'device_offline', 'warning'
+    FROM tb_device d
+    WHERE d.last_heartbeat < now() - INTERVAL '5 minutes'
+      AND d.status = 'active'
+      AND NOT EXISTS (
+          SELECT 1 FROM tb_device_alert a
+          WHERE a.fk_device = d.pk_device
+            AND a.alert_type = 'device_offline'
+            AND NOT a.acknowledged
+      );
+$$;
+```
 
-# Evaluate rules periodically
-async def evaluate_alert_rules():
-    for rule in ALERT_RULES:
-        results = await db.fetch(f"""
-            SELECT * FROM sensor_readings
-            WHERE {rule['condition']}
-            AND time > NOW() - INTERVAL '1 minute'
-        """)
-
-        for reading in results:
-            await create_alert(
-                device_id=reading['device_id'],
-                alert_type=rule['id'],
-                severity=rule['severity'],
-                message=rule['message']
-            )
-```text
-<!-- Code example in TEXT -->
+Subscribers receive new alerts in real time via the `alerts` subscription, backed by the
+`pg_notify('alert', ...)` call in `fn_record_reading`.
 
 ---
 
 ## Testing
 
-```typescript
-<!-- Code example in TypeScript -->
-describe('IoT Platform', () => {
-  it('should ingest sensor readings', async () => {
-    const deviceId = 'device_123';
-    const reading = {
-      sensorName: 'temperature',
-      value: 23.5,
-      timestamp: new Date().toISOString(),
-    };
+Integration tests run GraphQL operations against a real PostgreSQL database.
 
-    await recordReading(deviceId, reading);
+```python
+import pytest
 
-    const result = await client.query(GET_READINGS, {
-      variables: {
-        deviceId,
-        sensorName: 'temperature',
-        startTime: readingTime,
-        endTime: new Date().toISOString(),
-      },
-    });
 
-    expect(result.data.sensorReadings).toHaveLength(1);
-    expect(result.data.sensorReadings[0].value).toBe(23.5);
-  });
+@pytest.mark.asyncio
+async def test_record_reading_ingests(schema, db):
+    """A reading is persisted and queryable."""
+    result = await schema.execute(
+        """
+        mutation Ingest($input: RecordReadingInput!) {
+          recordReading(input: $input) {
+            ... on RecordReadingSuccess { deviceId sensorName }
+            ... on RecordReadingError { message }
+          }
+        }
+        """,
+        variable_values={
+            "input": {
+                "deviceId": str(device_id),
+                "sensorName": "temperature",
+                "value": "23.5",
+            }
+        },
+        context_value={"db": db},
+    )
+    assert result.errors is None
+    assert result.data["recordReading"]["sensorName"] == "temperature"
 
-  it('should trigger alert on threshold', async () => {
-    const device = await createDevice({
-      alertThreshold: { temperature: { max: 30 } }
-    });
 
-    await recordReading(device.id, {
-      sensorName: 'temperature',
-      value: 35,  // Exceeds 30
-    });
-
-    const alerts = await getAlerts(device.id);
-    expect(alerts).toHaveLength(1);
-    expect(alerts[0].severity).toBe('warning');
-  });
-
-  it('should aggregate data correctly', async () => {
-    const times = [1, 2, 3, 4, 5].map(i => new Date(Date.now() - i * 60000));
-    const values = [20, 22, 21, 23, 24];
-
-    for (let i = 0; i < 5; i++) {
-      await recordReading(deviceId, {
-        sensorName: 'temperature',
-        value: values[i],
-        timestamp: times[i],
-      });
-    }
-
-    const metrics = await getMetrics(deviceId, 'temperature');
-
-    expect(metrics[0].avg_value).toBe(22);  // (20+22+21+23+24)/5
-    expect(metrics[0].min_value).toBe(20);
-    expect(metrics[0].max_value).toBe(24);
-  });
-});
-```text
-<!-- Code example in TEXT -->
+@pytest.mark.asyncio
+async def test_threshold_triggers_alert(schema, db):
+    """A reading above the configured max raises an alert."""
+    await schema.execute(
+        "mutation { recordReading(input: "
+        '{ deviceId: "%s", sensorName: "temperature", value: "120" }) '
+        "{ ... on RecordReadingSuccess { sensorName } } }" % device_id,
+        context_value={"db": db},
+    )
+    alerts = await db.find("v_alert", acknowledged=False)
+    assert any(a["data"]["severity"] == "warning" for a in alerts)
+```
 
 ---
 
 ## Monitoring
 
+A status-summary view aggregates device health for an operations dashboard. Build it as a
+view and let runtime auto-aggregation count the buckets, or precompute it in a `tv_` table.
+
 ```graphql
-<!-- Code example in GraphQL -->
-query ClusterHealth {
-  deviceStatusSummary {
-    total_devices
-    active_devices
-    offline_devices
-    error_devices
-    average_response_time_ms
-    critical_alerts_count
-    readings_per_second
+query FleetHealth {
+  devices {
+    id
+    status
+    lastHeartbeat
+  }
+  activeAlerts {
+    severity
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
+
+For production deployment and observability practices, see
+[Production Deployment](../guides/production-deployment.md) and
+[Observability & Monitoring](../guides/observability.md).
 
 ---
 
@@ -704,19 +792,12 @@ query ClusterHealth {
 
 **Related Patterns:**
 
-- [Analytics Platform](./analytics-olap-platform.md) - OLAP for metrics
-- [Real-Time Collaboration](./realtime-collaboration.md) - Real-time updates
+- [Patterns Index](./README.md)
+- [Analytics / OLAP Platform](./analytics-olap-platform.md) — views + runtime aggregation for metrics
+- [Real-Time Collaboration](./realtime-collaboration.md) — subscriptions over WebSocket
 
-**Deployment:**
+**Architecture:**
 
-- [Production Deployment](../guides/production-deployment.md)
-- [Kubernetes Scaling](../guides/production-deployment.md)
-
-**Monitoring:**
-
-- [Observability & Monitoring](../guides/observability.md)
-
----
-
-**Last Updated:** 2026-02-05
-**Version:** v2.0.0-alpha.1
+- [Aggregation Model](../architecture/analytics/aggregation-model.md) — runtime auto-aggregation
+- [Window Functions](../architecture/analytics/window-functions.md) — moving averages in views
+- [tv-table Pattern](../architecture/database/tv-table-pattern.md) — pre-aggregated projection tables

--- a/docs/patterns/realtime-collaboration.md
+++ b/docs/patterns/realtime-collaboration.md
@@ -1,391 +1,762 @@
-<!-- Skip to main content -->
 ---
-
 title: Real-Time Collaboration with Subscriptions
-description: Complete guide to building collaborative tools (like Google Docs, Figma, Notion) with real-time synchronization using FraiseQL subscriptions.
-keywords: ["workflow", "saas", "realtime", "ecommerce", "analytics", "federation"]
-tags: ["documentation", "reference"]
+description: Blueprint for building collaborative tools (like Google Docs, Figma, Notion) with real-time synchronization using FraiseQL subscriptions backed by PostgreSQL LISTEN/NOTIFY.
+keywords: ["realtime", "collaboration", "subscriptions", "websocket", "postgresql", "listen-notify"]
+tags: ["documentation", "patterns"]
 ---
 
 # Real-Time Collaboration with Subscriptions
 
-**Status:** ✅ Production Ready
-**Complexity:** ⭐⭐⭐⭐ (Advanced)
+**Status:** Production Ready
+**Complexity:** Advanced
 **Audience:** Frontend architects, real-time systems engineers
 **Reading Time:** 25-30 minutes
-**Last Updated:** 2026-02-05
 
-Complete guide to building collaborative tools (like Google Docs, Figma, Notion) with real-time synchronization using FraiseQL subscriptions.
+Blueprint for building collaborative tools (like Google Docs, Figma, Notion) with
+real-time synchronization using FraiseQL subscriptions.
+
+In FraiseQL v1 a subscription is an **async-generator resolver** served over a
+GraphQL WebSocket connection. You write the generator; FraiseQL streams whatever it
+yields to the subscribed client. The natural event source for collaboration is
+PostgreSQL **`LISTEN`/`NOTIFY`**: a trigger on a write table emits `NOTIFY` on a
+channel, and the resolver `async for`s those notifications, re-reads a read view,
+and `yield`s the fresh value. Everything — documents, operations, presence, comments
+— lives in PostgreSQL.
 
 ---
 
 ## Architecture Overview
 
-**Diagram: Real-Time Architecture** - WebSocket-based collaboration with presence tracking
-
-```d2
-<!-- Code example in D2 Diagram -->
-direction: down
-
-Users: "Collaborators" {
-  shape: box
-  style.fill: "#e3f2fd"
-  children: [
-    UserA: "👤 User A\n(Editor)"
-    UserB: "👤 User B\n(Editor)"
-    UserC: "👤 User C\n(Viewer)"
-  ]
-}
-
-Server: "WebSocket Server\n(FraiseQL Rust)" {
-  shape: box
-  style.fill: "#f3e5f5"
-  style.border: "2px solid #7b1fa2"
-}
-
-Operations: "Mutations\n(operations)" {
-  shape: box
-  style.fill: "#fff3e0"
-}
-
-Subscriptions: "Subscriptions\n(live updates)" {
-  shape: box
-  style.fill: "#f1f8e9"
-}
-
-Presence: "Presence\n(who's online)" {
-  shape: box
-  style.fill: "#ffe0b2"
-}
-
-Database: "PostgreSQL" {
-  shape: box
-  style.fill: "#c8e6c9"
-  children: [
-    Docs: "📄 Documents"
-    Ops: "📝 Operations log"
-    Changes: "📋 Changes (CRDT)"
-  ]
-}
-
-Users -> Server: "WebSocket"
-Server -> Operations
-Server -> Subscriptions
-Server -> Presence
-Operations -> Database: "Write operations"
-Subscriptions -> Database: "Subscribe to changes"
-Presence -> Database: "Update presence"
-Database -> Server: "Broadcast updates"
-Server -> Users: "Real-time sync"
 ```text
-<!-- Code example in TEXT -->
+Collaborators (browsers)
+        |   GraphQL over WebSocket (graphql-transport-ws)
+        v
+FastAPI app  (create_fraiseql_app)
+  - @fraiseql.query      reads v_/tv_ views
+  - @fraiseql.mutation   calls fn_ functions (which also NOTIFY)
+  - @fraiseql.subscription  async generators: LISTEN a channel -> re-read view -> yield
+        |
+        v
+PostgreSQL
+  - tb_document, tb_document_change, tb_presence, tb_comment   (write tables)
+  - triggers: AFTER INSERT/UPDATE -> NOTIFY <channel>, <id>
+  - v_document, v_document_change, v_presence, v_comment       (read views, data JSONB)
+  - fn_apply_operation, fn_update_presence, fn_add_comment     (write functions)
+```
+
+The flow for a single edit:
+
+1. A client sends an `applyOperation` **mutation**. The resolver calls a `fn_` function
+   that writes a row into `tb_document_change` and updates `tb_document`.
+2. A PostgreSQL **trigger** on `tb_document_change` issues
+   `NOTIFY document_change, '<document_id>'`.
+3. Every **subscription** resolver that is `LISTEN`-ing on the `document_change`
+   channel for that document wakes up, re-reads `v_document_change`, and `yield`s the
+   new change.
+4. FraiseQL pushes the yielded payload down each subscribed WebSocket to the other
+   collaborators.
+
+There is no external broker. PostgreSQL is the source of truth and the message bus.
 
 ---
 
 ## Schema Design
 
-### Document Model
+FraiseQL's convention separates the normalized write tables (`tb_`) from the read
+views (`v_`) that build a `data` JSONB column. Internal `pk_` keys stay hidden; the
+public surface is the `id` UUID.
+
+### Write tables
 
 ```sql
-<!-- Code example in SQL -->
 -- Documents (editable items)
-CREATE TABLE documents (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  workspace_id UUID NOT NULL,
-  title VARCHAR(255) NOT NULL,
-  content_type VARCHAR(50) NOT NULL,  -- text, rich-text, spreadsheet, drawing
-  created_by UUID NOT NULL,
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW(),
-  deleted_at TIMESTAMP,  -- Soft delete
-
-  INDEX idx_workspace_id (workspace_id),
-  INDEX idx_updated_at (updated_at)
+CREATE TABLE tb_document (
+    pk_document   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id            UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    workspace_id  UUID NOT NULL,
+    title         TEXT NOT NULL,
+    content_type  TEXT NOT NULL,          -- text, rich-text, spreadsheet, drawing
+    content       TEXT NOT NULL DEFAULT '',
+    created_by    UUID NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at    TIMESTAMPTZ              -- soft delete
 );
+CREATE INDEX idx_document_workspace ON tb_document (workspace_id);
+CREATE INDEX idx_document_updated   ON tb_document (updated_at);
 
 -- Permissions (who can edit/view)
-CREATE TABLE document_permissions (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
-  user_id UUID NOT NULL,
-  permission VARCHAR(50) NOT NULL,  -- view, edit, comment, manage
-  granted_at TIMESTAMP DEFAULT NOW(),
-
-  UNIQUE(document_id, user_id),
-  INDEX idx_document_id (document_id)
+CREATE TABLE tb_document_permission (
+    pk_document_permission BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id           UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    fk_document  BIGINT NOT NULL REFERENCES tb_document (pk_document) ON DELETE CASCADE,
+    user_id      UUID NOT NULL,
+    permission   TEXT NOT NULL,           -- view, edit, comment, manage
+    granted_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (fk_document, user_id)
 );
 
--- Changes/Operations (for CRDT - Conflict-free Replicated Data Type)
-CREATE TABLE document_changes (
-  id BIGSERIAL PRIMARY KEY,
-  document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
-  user_id UUID NOT NULL,
-  operation JSONB NOT NULL,  -- { type: 'insert', position: 100, content: 'text' }
-  vector_clock JSONB NOT NULL,  -- For CRDT: { user_1: 5, user_2: 3 }
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_document_id (document_id),
-  INDEX idx_created_at (created_at)
+-- Changes / operations (one row per edit)
+CREATE TABLE tb_document_change (
+    pk_document_change BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id           UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    fk_document  BIGINT NOT NULL REFERENCES tb_document (pk_document) ON DELETE CASCADE,
+    user_id      UUID NOT NULL,
+    operation    JSONB NOT NULL,          -- { "type": "insert", "position": 100, "content": "text" }
+    vector_clock JSONB NOT NULL,          -- causality, e.g. { "user_1": 5, "user_2": 3 }
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+CREATE INDEX idx_change_document ON tb_document_change (fk_document, pk_document_change);
 
--- Activity Stream (for showing what's happening)
-CREATE TABLE document_activity (
-  id BIGSERIAL PRIMARY KEY,
-  document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
-  user_id UUID NOT NULL,
-  activity_type VARCHAR(50) NOT NULL,  -- edit, comment, join, leave
-  metadata JSONB,
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_document_id (document_id),
-  INDEX idx_created_at (created_at)
+-- Presence (who is currently editing)
+CREATE TABLE tb_presence (
+    pk_presence  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id           UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    fk_document  BIGINT NOT NULL REFERENCES tb_document (pk_document) ON DELETE CASCADE,
+    user_id      UUID NOT NULL,
+    cursor_position INT,
+    selection_start INT,
+    selection_end   INT,
+    color        TEXT,                     -- "#FF5733"
+    last_activity TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (fk_document, user_id)
 );
-
--- Presence (who's currently editing)
-CREATE TABLE document_presence (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  document_id UUID NOT NULL REFERENCES documents(id),
-  user_id UUID NOT NULL,
-  cursor_position INT,  -- Position in document
-  selection_start INT,
-  selection_end INT,
-  color VARCHAR(7),  -- #FF5733 for user's color
-  last_activity TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_document_id (document_id),
-  INDEX idx_last_activity (last_activity)
-);
+CREATE INDEX idx_presence_activity ON tb_presence (fk_document, last_activity);
 
 -- Comments
-CREATE TABLE comments (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
-  user_id UUID NOT NULL,
-  content TEXT NOT NULL,
-  position INT,  -- Where in document (for inline comments)
-  resolved BOOLEAN DEFAULT FALSE,
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_document_id (document_id),
-  INDEX idx_resolved (resolved)
+CREATE TABLE tb_comment (
+    pk_comment   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id           UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    fk_document  BIGINT NOT NULL REFERENCES tb_document (pk_document) ON DELETE CASCADE,
+    fk_parent    BIGINT REFERENCES tb_comment (pk_comment) ON DELETE CASCADE,
+    user_id      UUID NOT NULL,
+    content      TEXT NOT NULL,
+    position     INT,                      -- where in the document, for inline comments
+    resolved     BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-```text
-<!-- Code example in TEXT -->
+CREATE INDEX idx_comment_document ON tb_comment (fk_document);
+```
+
+### Read views (the GraphQL query/subscription sources)
+
+Each view exposes the public `id` plus a `data` JSONB column built with
+`jsonb_build_object(...)`. Never put `pk_*` inside `data`.
+
+```sql
+CREATE VIEW v_document AS
+SELECT
+    d.id,
+    d.workspace_id,
+    jsonb_build_object(
+        'id',            d.id,
+        'title',         d.title,
+        'contentType',   d.content_type,
+        'content',       d.content,
+        'createdBy',     d.created_by,
+        'createdAt',     d.created_at,
+        'updatedAt',     d.updated_at
+    ) AS data
+FROM tb_document d
+WHERE d.deleted_at IS NULL;
+
+CREATE VIEW v_document_change AS
+SELECT
+    c.id,
+    d.id AS document_id,
+    jsonb_build_object(
+        'id',           c.id,
+        'userId',       c.user_id,
+        'operation',    c.operation,
+        'vectorClock',  c.vector_clock,
+        'createdAt',    c.created_at
+    ) AS data
+FROM tb_document_change c
+JOIN tb_document d ON d.pk_document = c.fk_document;
+
+CREATE VIEW v_presence AS
+SELECT
+    p.id,
+    d.id AS document_id,
+    jsonb_build_object(
+        'userId',         p.user_id,
+        'cursorPosition', p.cursor_position,
+        'selectionStart', p.selection_start,
+        'selectionEnd',   p.selection_end,
+        'color',          p.color,
+        'lastActivity',   p.last_activity
+    ) AS data
+FROM tb_presence p
+JOIN tb_document d ON d.pk_document = p.fk_document;
+
+CREATE VIEW v_comment AS
+SELECT
+    c.id,
+    d.id AS document_id,
+    jsonb_build_object(
+        'id',         c.id,
+        'userId',     c.user_id,
+        'content',    c.content,
+        'position',   c.position,
+        'resolved',   c.resolved,
+        'createdAt',  c.created_at
+    ) AS data
+FROM tb_comment c
+JOIN tb_document d ON d.pk_document = c.fk_document;
+```
+
+---
+
+## Triggers: turn writes into NOTIFY events
+
+The bridge between a mutation and every live subscription is a trigger that emits a
+`NOTIFY`. The payload is just the document `id`, so listeners know which document
+changed; they re-read the view to get the fresh data.
+
+```sql
+-- Notify on every new change row
+CREATE OR REPLACE FUNCTION fn_notify_document_change() RETURNS TRIGGER AS $$
+DECLARE
+    v_document_id UUID;
+BEGIN
+    SELECT id INTO v_document_id FROM tb_document WHERE pk_document = NEW.fk_document;
+    PERFORM pg_notify('document_change', v_document_id::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_document_change_notify
+    AFTER INSERT ON tb_document_change
+    FOR EACH ROW
+    EXECUTE FUNCTION fn_notify_document_change();
+
+-- Notify on presence updates
+CREATE OR REPLACE FUNCTION fn_notify_presence() RETURNS TRIGGER AS $$
+DECLARE
+    v_document_id UUID;
+BEGIN
+    SELECT id INTO v_document_id FROM tb_document WHERE pk_document = NEW.fk_document;
+    PERFORM pg_notify('presence', v_document_id::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_presence_notify
+    AFTER INSERT OR UPDATE ON tb_presence
+    FOR EACH ROW
+    EXECUTE FUNCTION fn_notify_presence();
+
+-- Notify on new comments
+CREATE OR REPLACE FUNCTION fn_notify_comment() RETURNS TRIGGER AS $$
+DECLARE
+    v_document_id UUID;
+BEGIN
+    SELECT id INTO v_document_id FROM tb_document WHERE pk_document = NEW.fk_document;
+    PERFORM pg_notify('comment', v_document_id::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_comment_notify
+    AFTER INSERT ON tb_comment
+    FOR EACH ROW
+    EXECUTE FUNCTION fn_notify_comment();
+```
+
+> `pg_notify` payloads are capped at 8000 bytes, which is why we send only the
+> document `id` and re-read the view rather than shipping the whole row over the
+> channel.
+
+---
+
+## Write functions (`fn_`)
+
+Mutations never touch tables directly. They call PostgreSQL functions that hold the
+write logic and return JSONB describing success or failure. Because the writes go
+through `tb_document_change` / `tb_presence` / `tb_comment`, the triggers above fire
+automatically — the mutation does not have to `NOTIFY` by hand.
+
+```sql
+CREATE OR REPLACE FUNCTION fn_apply_operation(
+    p_document_id  UUID,
+    p_user_id      UUID,
+    p_operation    JSONB,
+    p_vector_clock JSONB
+) RETURNS JSONB AS $$
+DECLARE
+    v_pk_document BIGINT;
+    v_change      tb_document_change;
+BEGIN
+    SELECT pk_document INTO v_pk_document
+    FROM tb_document
+    WHERE id = p_document_id AND deleted_at IS NULL;
+
+    IF v_pk_document IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'message', 'document not found');
+    END IF;
+
+    INSERT INTO tb_document_change (fk_document, user_id, operation, vector_clock)
+    VALUES (v_pk_document, p_user_id, p_operation, p_vector_clock)
+    RETURNING * INTO v_change;
+
+    -- Apply the operation to the materialized content (insert/delete on text).
+    UPDATE tb_document
+    SET content = CASE p_operation->>'type'
+            WHEN 'insert' THEN
+                left(content, (p_operation->>'position')::int)
+                || (p_operation->>'content')
+                || substr(content, (p_operation->>'position')::int + 1)
+            WHEN 'delete' THEN
+                left(content, (p_operation->>'position')::int)
+                || substr(content,
+                          (p_operation->>'position')::int
+                          + (p_operation->>'length')::int + 1)
+            ELSE content
+        END,
+        updated_at = now()
+    WHERE pk_document = v_pk_document;
+
+    RETURN jsonb_build_object('success', true, 'change_id', v_change.id);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_update_presence(
+    p_document_id     UUID,
+    p_user_id         UUID,
+    p_cursor_position INT,
+    p_selection_start INT,
+    p_selection_end   INT,
+    p_color           TEXT
+) RETURNS JSONB AS $$
+DECLARE
+    v_pk_document BIGINT;
+BEGIN
+    SELECT pk_document INTO v_pk_document FROM tb_document WHERE id = p_document_id;
+    IF v_pk_document IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'message', 'document not found');
+    END IF;
+
+    INSERT INTO tb_presence
+        (fk_document, user_id, cursor_position, selection_start, selection_end, color)
+    VALUES
+        (v_pk_document, p_user_id, p_cursor_position,
+         p_selection_start, p_selection_end, p_color)
+    ON CONFLICT (fk_document, user_id) DO UPDATE
+        SET cursor_position = EXCLUDED.cursor_position,
+            selection_start = EXCLUDED.selection_start,
+            selection_end   = EXCLUDED.selection_end,
+            color           = EXCLUDED.color,
+            last_activity   = now();
+
+    RETURN jsonb_build_object('success', true);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_add_comment(
+    p_document_id UUID,
+    p_user_id     UUID,
+    p_content     TEXT,
+    p_position    INT
+) RETURNS JSONB AS $$
+DECLARE
+    v_pk_document BIGINT;
+    v_comment     tb_comment;
+BEGIN
+    SELECT pk_document INTO v_pk_document FROM tb_document WHERE id = p_document_id;
+    IF v_pk_document IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'message', 'document not found');
+    END IF;
+
+    INSERT INTO tb_comment (fk_document, user_id, content, position)
+    VALUES (v_pk_document, p_user_id, p_content, p_position)
+    RETURNING * INTO v_comment;
+
+    RETURN jsonb_build_object('success', true, 'comment_id', v_comment.id);
+END;
+$$ LANGUAGE plpgsql;
+```
 
 ---
 
 ## FraiseQL Schema
 
-```python
-<!-- Code example in Python -->
-# collaboration_schema.py
-from FraiseQL import types
-from datetime import datetime
-from typing import Optional
+Types map to the read views. Queries and mutations follow the CQRS split; the
+subscriptions are async generators backed by `LISTEN/NOTIFY`.
 
-@types.object
+```python
+# collaboration_schema.py
+from collections.abc import AsyncGenerator
+from datetime import datetime
+
+import fraiseql
+from fraiseql.types import ID, JSON
+
+
+@fraiseql.type(sql_source="v_document", jsonb_column="data")
 class Document:
-    id: UUID  # UUID v4 for GraphQL ID
+    id: ID
     title: str
     content_type: str
-    content: str  # Current document state
-    created_by: 'User'
+    content: str               # current materialized document state
+    created_by: ID
     created_at: datetime
     updated_at: datetime
-    permissions: list['DocumentPermission']
-    current_editors: list['User']  # Who's online
-    comments: list['Comment']
 
-@types.object
-class DocumentPermission:
-    user_id: UUID  # UUID v4 for GraphQL ID
-    permission: str  # view, edit, comment, manage
-    granted_at: datetime
 
-@types.object
+@fraiseql.type(sql_source="v_document_change", jsonb_column="data")
 class DocumentChange:
-    """Individual operation (for reconstruction)"""
-    id: UUID  # UUID v4 for GraphQL ID
-    user_id: UUID  # UUID v4 for GraphQL ID
-    operation: dict  # type, position, content
-    vector_clock: dict  # For CRDT
+    """A single applied operation."""
+
+    id: ID
+    user_id: ID
+    operation: JSON            # { type, position, content }
+    vector_clock: JSON         # causality across users
     created_at: datetime
 
-@types.object
+
+@fraiseql.type(sql_source="v_presence", jsonb_column="data")
 class Presence:
-    """Real-time user presence"""
-    user_id: UUID  # UUID v4 for GraphQL ID
-    cursor_position: int
-    selection_start: Optional[int]
-    selection_end: Optional[int]
-    color: str
+    """Real-time editor presence."""
 
-@types.object
-class DocumentActivity:
-    """Activity stream"""
-    user_id: UUID  # UUID v4 for GraphQL ID
-    activity_type: str  # edit, comment, join, leave
-    metadata: dict
-    created_at: datetime
+    user_id: ID
+    cursor_position: int | None
+    selection_start: int | None
+    selection_end: int | None
+    color: str | None
+    last_activity: datetime
 
-@types.object
+
+@fraiseql.type(sql_source="v_comment", jsonb_column="data")
 class Comment:
-    id: UUID  # UUID v4 for GraphQL ID
-    user_id: UUID  # UUID v4 for GraphQL ID
+    id: ID
+    user_id: ID
     content: str
-    position: Optional[int]
+    position: int | None
     resolved: bool
     created_at: datetime
-    replies: list['Comment']
 
-@types.object
-class Query:
-    def document(self, id: str) -> Document:
-        """Get document with full content"""
-        pass
 
-    def document_changes(
-        self,
-        document_id: str,
-        since_version: int = 0
-    ) -> list[DocumentChange]:
-        """Get changes since version (for sync)"""
-        pass
+@fraiseql.input
+class ApplyOperationInput:
+    document_id: ID
+    operation: JSON
+    vector_clock: JSON
 
-    def activity_feed(
-        self,
-        document_id: str,
-        limit: int = 50
-    ) -> list[DocumentActivity]:
-        """Activity stream"""
-        pass
 
-@types.object
-class Mutation:
-    def update_document(
-        self,
-        document_id: str,
-        operation: dict,
-        vector_clock: dict
-    ) -> DocumentChange:
-        """Apply operation (edit)"""
-        pass
+@fraiseql.input
+class UpdatePresenceInput:
+    document_id: ID
+    cursor_position: int
+    selection_start: int | None = None
+    selection_end: int | None = None
+    color: str | None = None
 
-    def add_comment(
-        self,
-        document_id: str,
-        content: str,
-        position: Optional[int] = None
-    ) -> Comment:
-        """Add comment"""
-        pass
 
-    def resolve_comment(self, comment_id: str) -> Comment:
-        """Mark comment as resolved"""
-        pass
+@fraiseql.input
+class AddCommentInput:
+    document_id: ID
+    content: str
+    position: int | None = None
 
-@types.object
-class Subscription:
-    def document_changes(self, document_id: str) -> DocumentChange:
-        """Stream of changes from other users"""
-        pass
 
-    def presence(self, document_id: str) -> Presence:
-        """Real-time presence updates"""
-        pass
+@fraiseql.success
+class ChangeSuccess:
+    change: DocumentChange
 
-    def activity(self, document_id: str) -> DocumentActivity:
-        """Real-time activity stream"""
-        pass
 
-    def comments(self, document_id: str) -> Comment:
-        """New comments"""
-        pass
-```text
-<!-- Code example in TEXT -->
+@fraiseql.error
+class ChangeError:
+    message: str
+    code: str = "OPERATION_FAILED"
+```
 
----
-
-## Operational Transformation (OT) for Conflict Resolution
-
-### Apply Operation
+### Queries (reads)
 
 ```python
-<!-- Code example in Python -->
-class OperationTransform:
-    @staticmethod
-    def apply_operation(text: str, operation: dict) -> str:
-        """Apply insert/delete operation"""
-        op_type = operation.get('type')
-        pos = operation.get('position')
-        content = operation.get('content')
+@fraiseql.query
+async def document(info, id: ID) -> Document | None:
+    db = info.context["db"]
+    return await db.find_one("v_document", id=id)
 
-        if op_type == 'insert':
-            return text[:pos] + content + text[pos:]
-        elif op_type == 'delete':
-            length = operation.get('length', 1)
-            return text[:pos] + text[pos + length:]
-        return text
 
-    @staticmethod
-    def transform_operations(op1: dict, op2: dict) -> dict:
-        """Transform op2 against op1 (for conflict resolution)"""
-        # If both insert at same position, use user ID to break tie
-        if op1.get('type') == 'insert' and op2.get('type') == 'insert':
-            if op1.get('position') == op2.get('position'):
-                # Insert later user's content after earlier user's
-                return {
-                    **op2,
-                    'position': op2['position'] + len(op1.get('content', ''))
-                }
-        # If op2 deletes after op1 insert, adjust position
-        elif op1.get('type') == 'insert' and op2.get('type') == 'delete':
-            if op2.get('position') > op1.get('position'):
-                return {
-                    **op2,
-                    'position': op2['position'] + len(op1.get('content', ''))
-                }
-        return op2
-```text
-<!-- Code example in TEXT -->
+@fraiseql.query
+async def document_changes(info, document_id: ID) -> list[DocumentChange]:
+    """Changes for a document, oldest first (used to catch up on reconnect)."""
+    db = info.context["db"]
+    return await db.find("v_document_change", document_id=document_id)
+
+
+@fraiseql.query
+async def comments(info, document_id: ID) -> list[Comment]:
+    db = info.context["db"]
+    return await db.find("v_comment", document_id=document_id)
+```
+
+### Mutations (writes via `fn_`)
+
+```python
+@fraiseql.mutation
+async def apply_operation(
+    info, input: ApplyOperationInput
+) -> ChangeSuccess | ChangeError:
+    db = info.context["db"]
+    user_id = info.context["user_id"]
+    result = await db.execute_function(
+        "fn_apply_operation",
+        {
+            "p_document_id": input.document_id,
+            "p_user_id": user_id,
+            "p_operation": input.operation,
+            "p_vector_clock": input.vector_clock,
+        },
+    )
+    if not result.get("success"):
+        return ChangeError(message=result.get("message", "failed"))
+    change = await db.find_one("v_document_change", id=result["change_id"])
+    return ChangeSuccess(change=change)
+
+
+@fraiseql.mutation
+async def update_presence(info, input: UpdatePresenceInput) -> bool:
+    db = info.context["db"]
+    user_id = info.context["user_id"]
+    result = await db.execute_function(
+        "fn_update_presence",
+        {
+            "p_document_id": input.document_id,
+            "p_user_id": user_id,
+            "p_cursor_position": input.cursor_position,
+            "p_selection_start": input.selection_start,
+            "p_selection_end": input.selection_end,
+            "p_color": input.color,
+        },
+    )
+    return bool(result.get("success"))
+
+
+@fraiseql.mutation
+async def add_comment(info, input: AddCommentInput) -> Comment | None:
+    db = info.context["db"]
+    user_id = info.context["user_id"]
+    result = await db.execute_function(
+        "fn_add_comment",
+        {
+            "p_document_id": input.document_id,
+            "p_user_id": user_id,
+            "p_content": input.content,
+            "p_position": input.position,
+        },
+    )
+    if not result.get("success"):
+        return None
+    return await db.find_one("v_comment", id=result["comment_id"])
+```
 
 ---
 
-## Real-Time Synchronization Flow
+## Subscriptions: async generators over LISTEN/NOTIFY
 
-### Client-Side (React)
+A subscription resolver is an **async generator**. It opens a dedicated PostgreSQL
+connection, runs `LISTEN <channel>`, and `async for`s incoming notifications. When a
+notification arrives whose payload matches the subscribed document, it re-reads the
+relevant view and `yield`s the fresh value. FraiseQL serves each yielded value to the
+client over the WebSocket.
+
+```python
+# realtime.py
+from collections.abc import AsyncGenerator
+
+import fraiseql
+from fraiseql.types import ID
+
+
+async def _listen(pool, channel: str, document_id: str) -> AsyncGenerator[None, None]:
+    """Yield once per NOTIFY on `channel` whose payload is `document_id`."""
+    async with pool.connection() as conn:
+        await conn.execute(f"LISTEN {channel}")
+        async for notify in conn.notifies():
+            if notify.payload == str(document_id):
+                yield None
+
+
+@fraiseql.subscription
+async def document_change_stream(
+    info, document_id: ID
+) -> AsyncGenerator[DocumentChange, None]:
+    """Stream every change applied to a document by anyone."""
+    db = info.context["db"]
+    pool = info.context["pool"]
+    last_seen = None
+    async for _ in _listen(pool, "document_change", document_id):
+        changes = await db.find("v_document_change", document_id=document_id)
+        for change in changes:
+            if last_seen is None or change.created_at > last_seen:
+                last_seen = change.created_at
+                yield change
+
+
+@fraiseql.subscription
+async def presence_stream(
+    info, document_id: ID
+) -> AsyncGenerator[Presence, None]:
+    """Stream presence updates (cursor moves, joins, leaves)."""
+    db = info.context["db"]
+    pool = info.context["pool"]
+    async for _ in _listen(pool, "presence", document_id):
+        for presence in await db.find("v_presence", document_id=document_id):
+            yield presence
+
+
+@fraiseql.subscription
+async def comment_stream(
+    info, document_id: ID
+) -> AsyncGenerator[Comment, None]:
+    """Stream new comments as they are posted."""
+    db = info.context["db"]
+    pool = info.context["pool"]
+    async for _ in _listen(pool, "comment", document_id):
+        for comment in await db.find("v_comment", document_id=document_id):
+            yield comment
+```
+
+Transport is GraphQL-over-WebSocket. FraiseQL's `SubscriptionManager` /
+`WebSocketConnection` handle both the modern `graphql-transport-ws` protocol and the
+legacy `graphql-ws` one, so the standard clients (Apollo, urql, `graphql-ws`) connect
+without custom code.
+
+### Subscription helpers
+
+FraiseQL ships helpers you can layer onto a subscription:
+
+- **`subscription_filter`** — drop yielded values that don't match a predicate
+  (for example, never echo a user's own edit back to them).
+- **`complexity`** — bound the cost of a subscription so a client can't open an
+  unbounded fan-out.
+- **`with_lifecycle`** — run setup/teardown around the generator (for example, write
+  a presence row on connect and remove it on disconnect).
+- **subscription result `cache`** — reuse a recently computed payload across
+  subscribers of the same document.
+
+```python
+from fraiseql.subscriptions import subscription_filter
+
+
+@fraiseql.subscription
+@subscription_filter(lambda change, info: change.user_id != info.context["user_id"])
+async def others_changes(
+    info, document_id: ID
+) -> AsyncGenerator[DocumentChange, None]:
+    """Like document_change_stream, but skips the caller's own changes."""
+    db = info.context["db"]
+    pool = info.context["pool"]
+    last_seen = None
+    async for _ in _listen(pool, "document_change", document_id):
+        for change in await db.find("v_document_change", document_id=document_id):
+            if last_seen is None or change.created_at > last_seen:
+                last_seen = change.created_at
+                yield change
+```
+
+You can also gate a subscription with an authorizer, exactly as for queries:
+
+```python
+@fraiseql.subscription(authorizer=document_viewer_authorizer)
+async def guarded_stream(
+    info, document_id: ID
+) -> AsyncGenerator[DocumentChange, None]:
+    ...
+```
+
+### Wiring it into the app
+
+```python
+from fraiseql.fastapi import create_fraiseql_app
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/collab",
+    types=[Document, DocumentChange, Presence, Comment],
+    queries=[document, document_changes, comments],
+    mutations=[apply_operation, update_presence, add_comment],
+    subscriptions=[document_change_stream, presence_stream, comment_stream],
+    production=False,   # enables the GraphQL playground (and WebSocket testing)
+)
+```
+
+Run it like any FastAPI app:
+
+```bash
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+---
+
+## Conflict resolution
+
+For documents with concurrent edits, resolve order deterministically before applying:
+
+1. **Vector clocks** — track causality between users' operations.
+2. **Position-based transform** — adjust an operation's position against operations
+   that landed earlier.
+3. **User-ID tiebreaker** — when two inserts target the same position, order by user
+   ID so every replica converges on the same result.
+
+This logic can live in the client (apply optimistically, reconcile on the incoming
+stream) and/or in the `fn_apply_operation` function (authoritative ordering). A simple
+position transform:
+
+```python
+def transform_operation(incoming: dict, applied: dict) -> dict:
+    """Shift `incoming` so it stays correct after `applied` already landed."""
+    if applied.get("type") == "insert" and incoming.get("position", 0) >= applied["position"]:
+        shift = len(applied.get("content", ""))
+        return {**incoming, "position": incoming["position"] + shift}
+    if applied.get("type") == "delete" and incoming.get("position", 0) > applied["position"]:
+        shift = applied.get("length", 0)
+        return {**incoming, "position": max(applied["position"], incoming["position"] - shift)}
+    return incoming
+```
+
+Because the authoritative `content` is rebuilt inside `fn_apply_operation`, the server
+is always the tiebreaker of record; clients converge by replaying the
+`document_change_stream`.
+
+---
+
+## Client integration (React + Apollo)
+
+The client subscribes over WebSocket and applies incoming operations.
 
 ```typescript
-<!-- Code example in TypeScript -->
-import { useQuery, useMutation, useSubscription, gql } from '@apollo/client';
-import { useCallback, useRef, useState } from 'react';
+import { useMutation, useQuery, useSubscription, gql } from "@apollo/client";
 
-const DOCUMENT_QUERY = gql`
-  query GetDocument($id: ID!) {
+const DOCUMENT = gql`
+  query Document($id: ID!) {
     document(id: $id) {
       id
       title
       content
-      currentEditors { id email }
-      comments { id content resolved }
     }
   }
 `;
 
-const UPDATE_DOCUMENT = gql`
-  mutation UpdateDocument($docId: ID!, $operation: JSON!, $vectorClock: JSON!) {
-    updateDocument(documentId: $docId, operation: $operation, vectorClock: $vectorClock) {
-      id
-      operation
-      createdAt
+const APPLY_OPERATION = gql`
+  mutation ApplyOperation($input: ApplyOperationInput!) {
+    applyOperation(input: $input) {
+      ... on ChangeSuccess {
+        change { id operation createdAt }
+      }
+      ... on ChangeError {
+        message
+        code
+      }
     }
   }
 `;
 
-const DOCUMENT_CHANGES_SUB = gql`
-  subscription OnDocumentChanges($docId: ID!) {
-    documentChanges(documentId: $docId) {
+const CHANGE_STREAM = gql`
+  subscription ChangeStream($documentId: ID!) {
+    documentChangeStream(documentId: $documentId) {
       id
       userId
       operation
@@ -395,9 +766,9 @@ const DOCUMENT_CHANGES_SUB = gql`
   }
 `;
 
-const PRESENCE_SUB = gql`
-  subscription OnPresence($docId: ID!) {
-    presence(documentId: $docId) {
+const PRESENCE_STREAM = gql`
+  subscription PresenceStream($documentId: ID!) {
+    presenceStream(documentId: $documentId) {
       userId
       cursorPosition
       color
@@ -406,397 +777,54 @@ const PRESENCE_SUB = gql`
 `;
 
 export function CollaborativeEditor({ documentId }: { documentId: string }) {
-  const editorRef = useRef<HTMLDivElement>(null);
-  const [content, setContent] = useState('');
-  const [vectorClock, setVectorClock] = useState<Record<string, number>>({});
-  const [editors, setEditors] = useState<any[]>[]);
-  const userId = getCurrentUserId();
-
-  // Fetch initial document
-  const { data: docData } = useQuery(DOCUMENT_QUERY, {
-    variables: { id: documentId },
+  const { data: doc } = useQuery(DOCUMENT, { variables: { id: documentId } });
+  const { data: change } = useSubscription(CHANGE_STREAM, {
+    variables: { documentId },
   });
-
-  // Listen for changes from other users
-  const { data: changesData } = useSubscription(DOCUMENT_CHANGES_SUB, {
-    variables: { docId: documentId },
+  const { data: presence } = useSubscription(PRESENCE_STREAM, {
+    variables: { documentId },
   });
+  const [applyOperation] = useMutation(APPLY_OPERATION);
 
-  // Listen for presence updates
-  const { data: presenceData } = useSubscription(PRESENCE_SUB, {
-    variables: { docId: documentId },
-  });
+  // Apply remote changes streamed from other editors.
+  // Send local edits via applyOperation(...) — the server's trigger NOTIFYs
+  // every other subscriber on the "document_change" channel.
 
-  const [updateDocument] = useMutation(UPDATE_DOCUMENT);
-
-  // Initialize
-  useEffect(() => {
-    if (docData?.document) {
-      setContent(docData.document.content);
-      setEditors(docData.document.currentEditors);
-    }
-  }, [docData]);
-
-  // Apply remote changes
-  useEffect(() => {
-    if (changesData?.documentChanges) {
-      const change = changesData.documentChanges;
-      const newContent = applyOperation(content, change.operation);
-      setContent(newContent);
-
-      // Update vector clock
-      setVectorClock(prev => ({
-        ...prev,
-        [change.userId]: (prev[change.userId] || 0) + 1,
-      }));
-    }
-  }, [changesData]);
-
-  // Update presence indicators
-  useEffect(() => {
-    if (presenceData?.presence) {
-      renderCursorPosition(presenceData.presence);
-    }
-  }, [presenceData]);
-
-  // Handle local edits
-  const handleChange = useCallback(
-    async (e: React.ChangeEvent<HTMLDivElement>) => {
-      const newContent = e.currentTarget.textContent'';
-      const operation = detectOperation(content, newContent);
-
-      // Update local state immediately
-      setContent(newContent);
-
-      // Increment our vector clock
-      const newClock = {
-        ...vectorClock,
-        [userId]: (vectorClock[userId] || 0) + 1,
-      };
-      setVectorClock(newClock);
-
-      // Send to server
-      await updateDocument({
-        variables: {
-          docId: documentId,
-          operation,
-          vectorClock: newClock,
-        },
-      });
-    },
-    [content, vectorClock, documentId, updateDocument, userId]
-  );
-
-  return (
-    <div>
-      <h1>{docData?.document?.title}</h1>
-
-      {/* Show current editors */}
-      <div className="editors">
-        {editors.map(editor => (
-          <span key={editor.id} title={editor.email}>👤</span>
-        ))}
-      </div>
-
-      {/* Editor with collaborative cursors */}
-      <div
-        ref={editorRef}
-        contentEditable
-        onInput={handleChange}
-        className="editor"
-      >
-        {content}
-      </div>
-
-      {/* Comments sidebar */}
-      <CommentsSidebar documentId={documentId} />
-    </div>
-  );
+  return <Editor doc={doc} change={change} presence={presence} onEdit={applyOperation} />;
 }
+```
 
-function detectOperation(oldContent: string, newContent: string) {
-  // Find the difference
-  const minLen = Math.min(oldContent.length, newContent.length);
-  let start = 0;
-  while (start < minLen && oldContent[start] === newContent[start]) {
-    start++;
-  }
-
-  if (newContent.length > oldContent.length) {
-    // Insert
-    return {
-      type: 'insert',
-      position: start,
-      content: newContent.slice(start, newContent.length - (oldContent.length - start)),
-    };
-  } else {
-    // Delete
-    return {
-      type: 'delete',
-      position: start,
-      length: oldContent.length - newContent.length,
-    };
-  }
-}
-
-function applyOperation(text: string, operation: any): string {
-  if (operation.type === 'insert') {
-    return text.slice(0, operation.position) +
-           operation.content +
-           text.slice(operation.position);
-  } else if (operation.type === 'delete') {
-    return text.slice(0, operation.position) +
-           text.slice(operation.position + operation.length);
-  }
-  return text;
-}
-
-function renderCursorPosition(presence: any) {
-  // Render remote user's cursor in document
-  const cursor = document.querySelector(`[data-user-id="${presence.userId}"]`);
-  if (cursor) {
-    cursor.style.left = presence.cursorPosition + 'px';
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Activity Feed & Presence
-
-### Track Activity
-
-```sql
-<!-- Code example in SQL -->
--- Trigger to log activity
-CREATE OR REPLACE FUNCTION log_activity() RETURNS TRIGGER AS $$
-BEGIN
-  INSERT INTO document_activity (
-    document_id,
-    user_id,
-    activity_type,
-    metadata
-  ) VALUES (
-    NEW.document_id,
-    NEW.user_id,
-    'edit',
-    jsonb_build_object(
-      'operation_type', NEW.operation->>'type',
-      'operation_id', NEW.id
-    )
-  );
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER document_changes_activity
-AFTER INSERT ON document_changes
-FOR EACH ROW
-EXECUTE FUNCTION log_activity();
-```text
-<!-- Code example in TEXT -->
-
-### Presence Management
+Send presence updates on a debounce so cursor movement doesn't flood the channel:
 
 ```typescript
-<!-- Code example in TypeScript -->
-// Update presence every time cursor moves
-const handleCursorMove = useDebouncedCallback((position: number) => {
+const pushPresence = useDebouncedCallback((position: number) => {
   updatePresence({
-    variables: {
-      documentId,
-      cursorPosition: position,
-      selectionStart: selection.start,
-      selectionEnd: selection.end,
-    },
+    variables: { input: { documentId, cursorPosition: position } },
   });
-}, 500); // Debounce to avoid spam
-
-// Clean up on unmount (user left)
-useEffect(() => {
-  return () => {
-    removePresence({
-      variables: { documentId },
-    });
-  };
-}, [documentId]);
-```text
-<!-- Code example in TEXT -->
+}, 500);
+```
 
 ---
 
-## Comments & Threading
+## Performance and operational notes
 
-```typescript
-<!-- Code example in TypeScript -->
-const ADD_COMMENT = gql`
-  mutation AddComment($docId: ID!, $content: String!, $position: Int) {
-    addComment(documentId: $docId, content: $content, position: $position) {
-      id
-      content
-      userId
-      createdAt
-    }
-  }
-`;
-
-export function CommentsSidebar({ documentId }: { documentId: string }) {
-  const [selectedPosition, setSelectedPosition] = useState<number | null>(null);
-  const { data } = useQuery(DOCUMENT_QUERY, { variables: { id: documentId } });
-  const [addComment] = useMutation(ADD_COMMENT);
-
-  const handleHighlightText = (start: number, end: number) => {
-    setSelectedPosition(start);
-  };
-
-  const handleSubmitComment = async (content: string) => {
-    await addComment({
-      variables: {
-        docId: documentId,
-        content,
-        position: selectedPosition,
-      },
-    });
-    setSelectedPosition(null);
-  };
-
-  return (
-    <aside className="comments-sidebar">
-      {data?.document?.comments?.map(comment => (
-        <CommentThread key={comment.id} comment={comment} />
-      ))}
-      {selectedPosition !== null && (
-        <CommentForm onSubmit={handleSubmitComment} />
-      )}
-    </aside>
-  );
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Conflict Resolution Strategy
-
-For documents with concurrent edits:
-
-1. **Vector Clocks** - Track causality
-2. **Last-Write-Wins** - If concurrent edits at same position
-3. **User ID Tiebreaker** - Sort by user ID for determinism
-4. **Operational Transform** - Adjust operations based on order
-
-```python
-<!-- Code example in Python -->
-def resolve_conflict(op1: dict, op2: dict, user1_id: str, user2_id: str) -> tuple:
-    """Return (transformed_op1, transformed_op2)"""
-
-    # If both inserting at same position
-    if (op1['type'] == 'insert' and op2['type'] == 'insert' and
-        op1['position'] == op2['position']):
-
-        # User with earlier ID gets their insert first
-        if user1_id < user2_id:
-            op2_new = {
-                **op2,
-                'position': op2['position'] + len(op1['content'])
-            }
-            return (op1, op2_new)
-        else:
-            op1_new = {
-                **op1,
-                'position': op1['position'] + len(op2['content'])
-            }
-            return (op1_new, op2)
-
-    # Handle other cases...
-    return (op1, op2)
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Testing Real-Time Collaboration
-
-```typescript
-<!-- Code example in TypeScript -->
-describe('Collaborative Editing', () => {
-  it('should merge concurrent edits', async () => {
-    const user1Changes = [
-      { type: 'insert', position: 0, content: 'Hello' },
-    ];
-    const user2Changes = [
-      { type: 'insert', position: 0, content: 'World' },
-    ];
-
-    const result = await resolveConflict(user1Changes, user2Changes);
-
-    // Both changes should be preserved in final content
-    expect(result).toContain('Hello');
-    expect(result).toContain('World');
-  });
-
-  it('should update presence correctly', async () => {
-    const presence = usePresenceHook('doc123');
-
-    expect(presence.editors).toHaveLength(0);
-    presence.join('user1');
-    expect(presence.editors).toHaveLength(1);
-    presence.leave('user1');
-    expect(presence.editors).toHaveLength(0);
-  });
-
-  it('should maintain comment threads', async () => {
-    const comment = await addComment({
-      documentId: 'doc123',
-      content: 'Fix this typo',
-      position: 100,
-    });
-
-    expect(comment.id).toBeDefined();
-    expect(comment.position).toBe(100);
-
-    const reply = await replyToComment({
-      commentId: comment.id,
-      content: 'Already fixed!',
-    });
-
-    expect(reply.parentCommentId).toBe(comment.id);
-  });
-});
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Performance Optimization
-
-- **Debounce presence updates** - Only send every 500ms
-- **Batch operations** - Group changes from same user
-- **Archive old changes** - Delete changes older than 30 days
-- **Snapshot documents** - Store full content snapshot periodically
-- **Compress change log** - Compact operations into final state
+- **One `LISTEN` connection per subscription stream.** `LISTEN/NOTIFY` requires a
+  session-level connection, so keep a small dedicated pool for subscriptions and put a
+  ceiling on concurrent streams (the `complexity` helper helps here).
+- **Payloads carry only the `id`.** Re-reading the view keeps notifications tiny and
+  under PostgreSQL's 8000-byte limit, and guarantees subscribers see committed data.
+- **Debounce presence.** Send cursor updates at most every ~500ms.
+- **Archive old changes.** Move `tb_document_change` rows older than your retention
+  window to cold storage; the materialized `content` is the snapshot.
+- **Snapshot periodically.** The `content` column is already a snapshot, so reconnecting
+  clients only need to replay changes since their last seen `created_at`.
 
 ---
 
 ## See Also
 
-**Related Patterns:**
-
-- [Multi-Tenant SaaS](./saas-multi-tenant.md) - Document ownership/permissions
-- [Activity Feeds in Social Networks](../patterns/realtime-collaboration.md) - Similar patterns
-
-**Real-Time Features:**
-
-- [Real-Time Patterns](../guides/patterns.md)
-- [Subscriptions & WebSockets](../guides/clients/README.md)
-
-**Production Deployment:**
-
-- [Production Deployment](../guides/production-deployment.md)
-- [Observability & Monitoring](../guides/observability.md)
-
----
-
-**Last Updated:** 2026-02-05
-**Version:** v2.0.0-alpha.1
+- [Patterns overview](./README.md)
+- [E-commerce workflows](./ecommerce-workflows.md) — mutations via `fn_` functions
+- [Multi-tenant SaaS](./saas-multi-tenant.md) — document ownership and permissions via RLS
+- [Subscriptions architecture](../architecture/realtime/subscriptions.md) — WebSocket transport internals
+- [Core concepts](../foundation/02-core-concepts.md) — the `tb_`/`v_`/`fn_` CQRS model

--- a/docs/patterns/saas-multi-tenant.md
+++ b/docs/patterns/saas-multi-tenant.md
@@ -1,830 +1,807 @@
-<!-- Skip to main content -->
 ---
-
 title: Multi-Tenant SaaS with Row-Level Security
-description: Complete guide to building a production-grade multi-tenant SaaS application using FraiseQL with row-level security (RLS).
-keywords: ["workflow", "saas", "realtime", "ecommerce", "analytics", "federation", "security"]
-tags: ["documentation", "reference"]
+description: Building a production-grade multi-tenant SaaS application with FraiseQL v1 using PostgreSQL Row-Level Security (RLS).
+keywords: ["saas", "multi-tenant", "row-level-security", "rls", "postgresql", "security"]
+tags: ["documentation", "patterns"]
 ---
 
 # Multi-Tenant SaaS with Row-Level Security
 
-**Status:** ✅ Production Ready
-**Complexity:** ⭐⭐⭐⭐ (Advanced)
+**Status:** Production Ready
+**Complexity:** Advanced
 **Audience:** SaaS architects, backend developers
 **Reading Time:** 30-35 minutes
-**Last Updated:** 2026-02-05
 
-Complete guide to building a production-grade multi-tenant SaaS application using FraiseQL with row-level security (RLS).
+A blueprint for building a multi-tenant SaaS application on FraiseQL v1. Tenant
+isolation is enforced where it belongs — inside PostgreSQL — using **Row-Level
+Security (RLS)** policies. FraiseQL sets a per-transaction session variable from the
+request context, and every RLS policy reads it. Application code never has to
+remember to add `WHERE tenant_id = ...`; the database does it for you.
 
 ---
 
-## Architecture Overview
+## How Isolation Works
 
-**Diagram: Security Architecture** - Multi-layer security pipeline from request to response
+Tenant context flows from the HTTP request all the way down to the row filter:
 
-```d2
-<!-- Code example in D2 Diagram -->
-direction: down
-
-Clients: "Web/Mobile Clients" {
-  shape: box
-  style.fill: "#e3f2fd"
-  style.border: "2px solid #1976d2"
-  children: [
-    React: "React"
-    Vue: "Vue"
-    Flutter: "Flutter"
-    RN: "React Native"
-  ]
-}
-
-Server: "FraiseQL Server (Rust)" {
-  shape: box
-  style.fill: "#f3e5f5"
-  style.border: "2px solid #7b1fa2"
-  children: [
-    Extract: "Extract tenant_id from JWT"
-    Inject: "Inject tenant_id into queries"
-    AuthHandle: "Handle authentication/authorization"
-  ]
-}
-
-Database: "PostgreSQL Database with RLS" {
-  shape: box
-  style.fill: "#f1f8e9"
-  style.border: "2px solid #388e3c"
-  children: [
-    RLS: "Row-Level Security Policies"
-    Isolation: "WHERE tenant_id = user.tenant_id"
-    Safety: "Data isolation at database level"
-  ]
-}
-
-Clients -> Server: "GraphQL queries + JWT"
-Server -> Database: "SQL queries (with RLS)"
-Database -> Server: "Row-filtered results"
-Server -> Clients: "JSON response"
 ```text
-<!-- Code example in TEXT -->
+GraphQL request (+ JWT)
+   │  your auth middleware verifies the token
+   ▼
+info.context["tenant_id"]   (also "user_id", "is_super_admin", role, …)
+   │  FraiseQL CQRS repository issues, per transaction:
+   ▼
+SET LOCAL app.tenant_id = '<uuid>'
+   │  PostgreSQL evaluates RLS policies:
+   ▼
+USING (tenant_id = current_setting('app.tenant_id')::uuid)
+   ▼
+Only the current tenant's rows are visible / writable
+```
+
+The mechanism has three moving parts:
+
+1. **A `tenant_id` column** on every tenant-scoped `tb_*` table.
+2. **RLS policies** on those tables that compare `tenant_id` against
+   `current_setting('app.tenant_id')`.
+3. **FraiseQL's CQRS repository** (`info.context["db"]`), which reads `tenant_id`
+   (and `user_id`, `is_super_admin`, and any role claims) out of `info.context` and
+   emits `SET LOCAL app.tenant_id = …` at the start of each transaction. Because the
+   GUC is set with `SET LOCAL`, it is scoped to that transaction and resets cleanly —
+   safe to use with pooled connections.
+
+There is no separate server process and no build step. FraiseQL is a runtime,
+PostgreSQL-only framework: you run a FastAPI app, and tenant isolation lives entirely
+in PostgreSQL.
 
 ---
 
 ## Schema Design
 
-### Core Tables
+FraiseQL v1 follows a CQRS layout. Writes target normalized `tb_*` tables through
+`fn_*` functions; reads come from `v_*`/`tv_*` views that expose a `data` JSONB
+column. RLS is applied to the `tb_*` tables — and because views run with the
+querying role's privileges, the same policies transparently filter the views too.
+
+### Write Tables (`tb_*`)
 
 ```sql
-<!-- Code example in SQL -->
--- Tenants (the SaaS customers)
-CREATE TABLE tenants (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  slug VARCHAR(255) UNIQUE NOT NULL, -- mycompany.example.com
-  name VARCHAR(255) NOT NULL,
-  plan VARCHAR(50) NOT NULL, -- free, starter, pro, enterprise
-  stripe_customer_id VARCHAR(255),
-  status VARCHAR(50) NOT NULL, -- active, suspended, cancelled
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW()
+-- Tenants (the SaaS customers). Not tenant-scoped itself.
+CREATE TABLE tb_tenant (
+  pk_tenant          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                 UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  identifier         TEXT UNIQUE NOT NULL,        -- slug, e.g. "acme"
+  name               TEXT NOT NULL,
+  plan               TEXT NOT NULL DEFAULT 'free', -- free, starter, pro, enterprise
+  stripe_customer_id TEXT,
+  status             TEXT NOT NULL DEFAULT 'active', -- active, suspended, cancelled
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Users (tenant members)
-CREATE TABLE users (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-  email VARCHAR(255) NOT NULL,
-  password_hash VARCHAR(255) NOT NULL,
-  full_name VARCHAR(255),
-  role VARCHAR(50) NOT NULL, -- owner, admin, member, viewer
-  status VARCHAR(50) NOT NULL, -- active, invited, deactivated
-  last_login TIMESTAMP,
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  UNIQUE(tenant_id, email),
-  INDEX idx_tenant_id (tenant_id)
+-- Users (tenant members).
+CREATE TABLE tb_user (
+  pk_user       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id            UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  tenant_id     UUID NOT NULL REFERENCES tb_tenant(id) ON DELETE CASCADE,
+  email         TEXT NOT NULL,
+  password_hash TEXT NOT NULL,
+  full_name     TEXT,
+  role          TEXT NOT NULL DEFAULT 'member', -- owner, admin, member, viewer
+  status        TEXT NOT NULL DEFAULT 'invited', -- active, invited, deactivated
+  last_login    TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, email)
 );
+CREATE INDEX ix_user_tenant ON tb_user (tenant_id);
 
--- Projects (tenant workspace items)
-CREATE TABLE projects (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-  name VARCHAR(255) NOT NULL,
+-- Projects (tenant workspace items).
+CREATE TABLE tb_project (
+  pk_project  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id          UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  tenant_id   UUID NOT NULL REFERENCES tb_tenant(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
   description TEXT,
-  owner_id UUID NOT NULL REFERENCES users(id),
-  status VARCHAR(50) NOT NULL, -- active, archived
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_tenant_id (tenant_id),
-  INDEX idx_owner_id (owner_id)
+  owner_id    UUID NOT NULL REFERENCES tb_user(id),
+  status      TEXT NOT NULL DEFAULT 'active', -- active, archived
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+CREATE INDEX ix_project_tenant ON tb_project (tenant_id);
+CREATE INDEX ix_project_owner ON tb_project (owner_id);
 
--- Project Members (who can access each project)
-CREATE TABLE project_members (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  role VARCHAR(50) NOT NULL, -- editor, viewer, admin
-  invited_at TIMESTAMP DEFAULT NOW(),
-  joined_at TIMESTAMP,
-
-  UNIQUE(project_id, user_id),
-  INDEX idx_project_id (project_id),
-  INDEX idx_user_id (user_id)
+-- Project members (who can access each project).
+CREATE TABLE tb_project_member (
+  pk_project_member BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  tenant_id         UUID NOT NULL REFERENCES tb_tenant(id) ON DELETE CASCADE,
+  project_id        UUID NOT NULL REFERENCES tb_project(id) ON DELETE CASCADE,
+  user_id           UUID NOT NULL REFERENCES tb_user(id) ON DELETE CASCADE,
+  role              TEXT NOT NULL DEFAULT 'viewer', -- editor, viewer, admin
+  invited_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  joined_at         TIMESTAMPTZ,
+  UNIQUE (project_id, user_id)
 );
+CREATE INDEX ix_project_member_tenant ON tb_project_member (tenant_id);
 
--- Tasks (project work items)
-CREATE TABLE tasks (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-  title VARCHAR(255) NOT NULL,
+-- Tasks (project work items).
+CREATE TABLE tb_task (
+  pk_task     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id          UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  tenant_id   UUID NOT NULL REFERENCES tb_tenant(id) ON DELETE CASCADE,
+  project_id  UUID NOT NULL REFERENCES tb_project(id) ON DELETE CASCADE,
+  title       TEXT NOT NULL,
   description TEXT,
-  status VARCHAR(50) NOT NULL, -- todo, in_progress, done
-  assigned_to UUID REFERENCES users(id),
-  priority VARCHAR(50) NOT NULL, -- low, medium, high
-  due_date DATE,
-  created_by UUID NOT NULL REFERENCES users(id),
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW(),
+  status      TEXT NOT NULL DEFAULT 'todo', -- todo, in_progress, done
+  assigned_to UUID REFERENCES tb_user(id),
+  priority    TEXT NOT NULL DEFAULT 'medium', -- low, medium, high
+  due_date    DATE,
+  created_by  UUID NOT NULL REFERENCES tb_user(id),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ix_task_tenant ON tb_task (tenant_id);
+CREATE INDEX ix_task_project ON tb_task (project_id);
+CREATE INDEX ix_task_status ON tb_task (status);
 
-  INDEX idx_tenant_id (tenant_id),
-  INDEX idx_project_id (project_id),
-  INDEX idx_assigned_to (assigned_to),
-  INDEX idx_status (status)
+-- Audit log (compliance & debugging).
+CREATE TABLE tb_audit_log (
+  pk_audit_log BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id           UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  tenant_id    UUID NOT NULL REFERENCES tb_tenant(id) ON DELETE CASCADE,
+  user_id      UUID REFERENCES tb_user(id),
+  entity_type  TEXT NOT NULL,
+  entity_id    UUID NOT NULL,
+  action       TEXT NOT NULL, -- created, updated, deleted
+  old_values   JSONB,
+  new_values   JSONB,
+  ip_address   INET,
+  user_agent   TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ix_audit_tenant ON tb_audit_log (tenant_id);
+CREATE INDEX ix_audit_created ON tb_audit_log (created_at);
+
+-- Subscription (one per tenant, drives billing).
+CREATE TABLE tb_subscription (
+  pk_subscription        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id                     UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  tenant_id              UUID NOT NULL UNIQUE REFERENCES tb_tenant(id) ON DELETE CASCADE,
+  stripe_subscription_id TEXT,
+  plan                   TEXT NOT NULL,
+  status                 TEXT NOT NULL, -- active, past_due, cancelled
+  current_period_start   DATE,
+  current_period_end     DATE,
+  cancel_at_period_end   BOOLEAN NOT NULL DEFAULT false,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at             TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Audit Log (compliance & debugging)
-CREATE TABLE audit_logs (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-  user_id UUID REFERENCES users(id),
-  entity_type VARCHAR(50) NOT NULL, -- users, projects, tasks, etc.
-  entity_id UUID NOT NULL,
-  action VARCHAR(50) NOT NULL, -- created, updated, deleted
-  old_values JSONB,
-  new_values JSONB,
-  ip_address INET,
-  user_agent TEXT,
-  created_at TIMESTAMP DEFAULT NOW(),
-
-  INDEX idx_tenant_id (tenant_id),
-  INDEX idx_user_id (user_id),
-  INDEX idx_created_at (created_at)
+-- Usage metrics (for metered billing).
+CREATE TABLE tb_usage_metric (
+  pk_usage_metric BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  id              UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  tenant_id       UUID NOT NULL REFERENCES tb_tenant(id) ON DELETE CASCADE,
+  metric_name     TEXT NOT NULL, -- api_calls, storage_gb, …
+  metric_value    NUMERIC(15, 2) NOT NULL DEFAULT 0,
+  period_start    DATE NOT NULL,
+  period_end      DATE NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, metric_name, period_start, period_end)
 );
+CREATE INDEX ix_usage_tenant ON tb_usage_metric (tenant_id);
+```
 
--- Subscriptions (usage tracking for billing)
-CREATE TABLE subscriptions (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL UNIQUE REFERENCES tenants(id) ON DELETE CASCADE,
-  stripe_subscription_id VARCHAR(255),
-  plan VARCHAR(50) NOT NULL,
-  status VARCHAR(50) NOT NULL, -- active, past_due, cancelled
-  current_period_start DATE,
-  current_period_end DATE,
-  cancel_at_period_end BOOLEAN DEFAULT FALSE,
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW(),
+Note the trinity identifier pattern: `pk_*` is an internal `BIGINT` for fast joins
+(never exposed), `id` is the public `UUID`, and `identifier` is an optional
+human-readable slug. GraphQL only ever sees `id` and `identifier`.
 
-  INDEX idx_tenant_id (tenant_id)
-);
+### Read Views (`v_*`)
 
--- Usage Metrics (for billing)
-CREATE TABLE usage_metrics (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-  metric_name VARCHAR(100) NOT NULL, -- api_calls, storage_gb, etc.
-  metric_value DECIMAL(15, 2),
-  period_start DATE NOT NULL,
-  period_end DATE NOT NULL,
-  created_at TIMESTAMP DEFAULT NOW(),
+Reads come from views that build a `data` JSONB column. RLS on the underlying
+`tb_*` tables is enforced automatically when the view runs as the querying role.
 
-  INDEX idx_tenant_id (tenant_id),
-  INDEX idx_period (period_start, period_end)
-);
-```text
-<!-- Code example in TEXT -->
+```sql
+CREATE VIEW v_project AS
+SELECT
+  p.id,
+  p.tenant_id,
+  jsonb_build_object(
+    'id',          p.id,
+    'name',        p.name,
+    'description', p.description,
+    'status',      p.status,
+    'ownerId',     p.owner_id,
+    'createdAt',   p.created_at
+  ) AS data
+FROM tb_project p;
+
+CREATE VIEW v_task AS
+SELECT
+  t.id,
+  t.tenant_id,
+  t.project_id,
+  jsonb_build_object(
+    'id',         t.id,
+    'title',      t.title,
+    'status',     t.status,
+    'priority',   t.priority,
+    'assignedTo', t.assigned_to,
+    'dueDate',    t.due_date,
+    'createdAt',  t.created_at
+  ) AS data
+FROM tb_task t;
+```
+
+The view exposes `id` (for `WHERE id = $1` lookups), `tenant_id` (for optional
+`mandatory_filters`), and the `data` JSONB. The internal `pk_*` columns never leave
+the table.
 
 ---
 
 ## Row-Level Security Policies
 
+This is the heart of tenant isolation. Enable RLS, then write policies that read the
+session GUC FraiseQL sets for you.
+
 ### Enable RLS
 
 ```sql
-<!-- Code example in SQL -->
-ALTER TABLE users ENABLE ROW LEVEL SECURITY;
-ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
-ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;
-ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
-ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
-ALTER TABLE usage_metrics ENABLE ROW LEVEL SECURITY;
-```text
-<!-- Code example in TEXT -->
+ALTER TABLE tb_user           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tb_project        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tb_project_member ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tb_task           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tb_audit_log      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tb_subscription   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tb_usage_metric   ENABLE ROW LEVEL SECURITY;
 
-### Tenant Context Function
+-- Force RLS even for the table owner, so no role bypasses isolation.
+ALTER TABLE tb_user           FORCE ROW LEVEL SECURITY;
+ALTER TABLE tb_project        FORCE ROW LEVEL SECURITY;
+ALTER TABLE tb_task           FORCE ROW LEVEL SECURITY;
+ALTER TABLE tb_subscription   FORCE ROW LEVEL SECURITY;
+ALTER TABLE tb_usage_metric   FORCE ROW LEVEL SECURITY;
+```
+
+### Session Context Helpers
+
+FraiseQL emits `SET LOCAL app.tenant_id = …`, `SET LOCAL app.user_id = …`, and
+`SET LOCAL app.is_super_admin = …` from `info.context`. Thin SQL helpers make the
+policies readable. The second `true` argument to `current_setting` returns `NULL`
+instead of erroring when the GUC is unset.
 
 ```sql
-<!-- Code example in SQL -->
--- Get current tenant from JWT claims
 CREATE OR REPLACE FUNCTION current_tenant_id() RETURNS UUID AS $$
-  SELECT (current_setting('app.tenant_id', true))::UUID;
+  SELECT NULLIF(current_setting('app.tenant_id', true), '')::UUID;
 $$ LANGUAGE SQL STABLE;
 
--- Get current user from JWT claims
 CREATE OR REPLACE FUNCTION current_user_id() RETURNS UUID AS $$
-  SELECT (current_setting('app.user_id', true))::UUID;
+  SELECT NULLIF(current_setting('app.user_id', true), '')::UUID;
 $$ LANGUAGE SQL STABLE;
 
--- Get current user's role
+-- Populate this GUC from a role claim in your auth middleware
+-- (info.context["user_role"]) if you want role checks inside RLS.
 CREATE OR REPLACE FUNCTION current_user_role() RETURNS TEXT AS $$
-  SELECT (current_setting('app.user_role', true))::TEXT;
+  SELECT NULLIF(current_setting('app.user_role', true), '');
 $$ LANGUAGE SQL STABLE;
-```text
-<!-- Code example in TEXT -->
+```
 
-### RLS Policies - Users Table
+### Users Table
 
 ```sql
-<!-- Code example in SQL -->
--- Users can only see users in their tenant
-CREATE POLICY users_tenant_isolation ON users
+-- See only users in the current tenant.
+CREATE POLICY user_tenant_isolation ON tb_user
   FOR SELECT
   USING (tenant_id = current_tenant_id());
 
--- Users can only update their own profile
-CREATE POLICY users_self_update ON users
+-- Update your own profile; admins and owners can update anyone in the tenant.
+CREATE POLICY user_self_update ON tb_user
   FOR UPDATE
   USING (
-    id = current_user_id() OR
-    current_user_role() IN ('owner', 'admin')
+    tenant_id = current_tenant_id()
+    AND (id = current_user_id() OR current_user_role() IN ('owner', 'admin'))
   );
 
--- Only admins can delete users
-CREATE POLICY users_delete ON users
+-- Only owners/admins delete users.
+CREATE POLICY user_delete ON tb_user
   FOR DELETE
-  USING (current_user_role() IN ('owner', 'admin'));
+  USING (
+    tenant_id = current_tenant_id()
+    AND current_user_role() IN ('owner', 'admin')
+  );
 
--- Allow new user creation (signup)
-CREATE POLICY users_insert ON users
+-- New users must be created inside the active tenant.
+CREATE POLICY user_insert ON tb_user
   FOR INSERT
-  WITH CHECK (true); -- Allow insertion, FraiseQL handles tenant assignment
-```text
-<!-- Code example in TEXT -->
+  WITH CHECK (tenant_id = current_tenant_id());
+```
 
-### RLS Policies - Projects Table
+### Projects Table
 
 ```sql
-<!-- Code example in SQL -->
--- Users can only see projects in their tenant
--- AND either they're the owner or a project member
-CREATE POLICY projects_visibility ON projects
+-- See projects in your tenant that you own or are a member of.
+CREATE POLICY project_visibility ON tb_project
   FOR SELECT
   USING (
-    tenant_id = current_tenant_id() AND
-    (
-      owner_id = current_user_id() OR
-      id IN (
-        SELECT project_id FROM project_members
+    tenant_id = current_tenant_id()
+    AND (
+      owner_id = current_user_id()
+      OR id IN (
+        SELECT project_id FROM tb_project_member
         WHERE user_id = current_user_id()
       )
     )
   );
 
--- Only project owners and admins can update
-CREATE POLICY projects_update ON projects
+-- Owners and tenant admins can update.
+CREATE POLICY project_update ON tb_project
   FOR UPDATE
   USING (
-    owner_id = current_user_id() OR
-    current_user_role() IN ('owner', 'admin')
+    tenant_id = current_tenant_id()
+    AND (owner_id = current_user_id() OR current_user_role() IN ('owner', 'admin'))
   );
 
--- Only owners can delete
-CREATE POLICY projects_delete ON projects
+-- Only the project owner deletes.
+CREATE POLICY project_delete ON tb_project
   FOR DELETE
-  USING (owner_id = current_user_id());
+  USING (tenant_id = current_tenant_id() AND owner_id = current_user_id());
 
--- Can create in own tenant
-CREATE POLICY projects_insert ON projects
+-- Create only inside the active tenant.
+CREATE POLICY project_insert ON tb_project
   FOR INSERT
   WITH CHECK (tenant_id = current_tenant_id());
-```text
-<!-- Code example in TEXT -->
+```
 
-### RLS Policies - Tasks Table
+### Tasks Table
 
 ```sql
-<!-- Code example in SQL -->
--- Users can only see tasks in projects they have access to
-CREATE POLICY tasks_visibility ON tasks
+-- See tasks in projects you can access.
+CREATE POLICY task_visibility ON tb_task
   FOR SELECT
   USING (
-    tenant_id = current_tenant_id() AND
-    project_id IN (
-      SELECT id FROM projects
+    tenant_id = current_tenant_id()
+    AND project_id IN (
+      SELECT id FROM tb_project
       WHERE owner_id = current_user_id()
-         OR id IN (SELECT project_id FROM project_members WHERE user_id = current_user_id())
+         OR id IN (
+           SELECT project_id FROM tb_project_member
+           WHERE user_id = current_user_id()
+         )
     )
   );
 
--- Project members and admins can update tasks
-CREATE POLICY tasks_update ON tasks
+-- Project participants and tenant admins update tasks.
+CREATE POLICY task_update ON tb_task
   FOR UPDATE
   USING (
-    project_id IN (
-      SELECT id FROM projects
-      WHERE owner_id = current_user_id()
-         OR id IN (SELECT project_id FROM project_members WHERE user_id = current_user_id())
-    ) OR
-    current_user_role() IN ('owner', 'admin')
+    tenant_id = current_tenant_id()
+    AND (
+      project_id IN (
+        SELECT id FROM tb_project
+        WHERE owner_id = current_user_id()
+           OR id IN (
+             SELECT project_id FROM tb_project_member
+             WHERE user_id = current_user_id()
+           )
+      )
+      OR current_user_role() IN ('owner', 'admin')
+    )
   );
+```
 
--- Only project owners can delete tasks
-CREATE POLICY tasks_delete ON tasks
-  FOR DELETE
-  USING (
-    project_id IN (
-      SELECT id FROM projects WHERE owner_id = current_user_id()
-    ) OR
-    current_user_role() IN ('owner', 'admin')
-  );
-```text
-<!-- Code example in TEXT -->
-
-### RLS Policies - Audit Logs
+### Audit Logs
 
 ```sql
-<!-- Code example in SQL -->
--- Users can only see audit logs for their tenant
-CREATE POLICY audit_logs_visibility ON audit_logs
+-- Only tenant admins read audit logs, scoped to their tenant.
+CREATE POLICY audit_log_visibility ON tb_audit_log
   FOR SELECT
   USING (
-    tenant_id = current_tenant_id() AND
-    current_user_role() IN ('owner', 'admin') -- Only admins see logs
+    tenant_id = current_tenant_id()
+    AND current_user_role() IN ('owner', 'admin')
   );
 
--- Prevent direct manipulation of audit logs
-CREATE POLICY audit_logs_immutable ON audit_logs
-  FOR UPDATE, DELETE
-  USING (false);
-```text
-<!-- Code example in TEXT -->
+-- Audit logs are append-only: no policy allows UPDATE or DELETE,
+-- so RLS denies them outright once FORCE ROW LEVEL SECURITY is on.
+```
+
+### Cross-Tenant Reads with `mandatory_filters`
+
+RLS is your defense-in-depth baseline. For an extra explicit guard — or for code
+paths where you want belt-and-braces filtering on the read side — FraiseQL's
+repository accepts `mandatory_filters`, which are AND-ed into every generated query
+and cannot be overridden by client arguments:
+
+```python
+projects = await db.find(
+    "v_project",
+    mandatory_filters={"tenant_id": info.context["tenant_id"]},
+)
+```
+
+With RLS in place this is redundant, but it documents intent and protects you if a
+table ever ships without a policy.
 
 ---
 
-## FraiseQL Schema Definition (Python)
+## FraiseQL Types and Queries (Python)
+
+Define types against the read views and let RLS handle tenant scoping. The
+namespaced API (`import fraiseql`) avoids shadowing builtins.
 
 ```python
-<!-- Code example in Python -->
-# schema.py
-from FraiseQL import types, authorize
-from datetime import datetime
+import fraiseql
+from fraiseql.types import ID, DateTime
 
-@types.object
+@fraiseql.type(sql_source="v_tenant", jsonb_column="data")
 class Tenant:
-    id: UUID  # UUID v4 for GraphQL ID
-    slug: str
+    id: ID
+    identifier: str
     name: str
     plan: str
     status: str
-    users: list['User']
-    projects: list['Project']
-    subscription: 'Subscription'
-    created_at: datetime
+    created_at: DateTime
 
-@types.object
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
-    id: UUID  # UUID v4 for GraphQL ID
+    id: ID
     email: str
-    full_name: str
-    role: str  # owner, admin, member, viewer
+    full_name: str | None
+    role: str            # owner, admin, member, viewer
     status: str
-    tenant: Tenant
-    projects: list['Project']  # Projects this user is a member of
-    tasks: list['Task']  # Tasks assigned to this user
-    created_at: datetime
+    created_at: DateTime
 
-@types.object
+@fraiseql.type(sql_source="v_project", jsonb_column="data")
 class Project:
-    id: UUID  # UUID v4 for GraphQL ID
+    id: ID
     name: str
-    description: str
-    owner: User
+    description: str | None
     status: str
-    members: list[User]
-    tasks: list['Task']
-    created_at: datetime
+    created_at: DateTime
 
-@types.object
+@fraiseql.type(sql_source="v_task", jsonb_column="data")
 class Task:
-    id: UUID  # UUID v4 for GraphQL ID
+    id: ID
     title: str
-    description: str
+    description: str | None
     status: str
-    assigned_to: User | None
-    project: Project
     priority: str
     due_date: str | None
-    created_by: User
-    created_at: datetime
+    created_at: DateTime
+```
 
-@types.object
-class Subscription:
-    id: UUID  # UUID v4 for GraphQL ID
-    plan: str
-    status: str
-    current_period_start: str
-    current_period_end: str
-    stripe_subscription_id: str | None
+Queries read from the views. Because the repository has already issued
+`SET LOCAL app.tenant_id`, every row returned belongs to the caller's tenant — no
+manual filtering required.
 
-@types.object
-class Query:
-    @authorize(roles=['owner', 'admin', 'member', 'viewer'])
-    def me(self) -> User:
-        """Current authenticated user"""
-        pass
+```python
+@fraiseql.query
+async def me(info) -> User | None:
+    db = info.context["db"]
+    return await db.find_one("v_user", id=info.context["user_id"])
 
-    @authorize(roles=['owner', 'admin', 'member'])
-    def users(self, limit: int = 50, offset: int = 0) -> list[User]:
-        """List all users in current tenant"""
-        pass
+@fraiseql.query
+async def projects(info, status: str | None = None) -> list[Project]:
+    db = info.context["db"]
+    filters = {"status": status} if status else {}
+    return await db.find("v_project", **filters)
 
-    @authorize(roles=['owner', 'admin', 'member', 'viewer'])
-    def projects(self, status: str | None = None) -> list[Project]:
-        """List accessible projects"""
-        pass
+@fraiseql.query
+async def tasks(
+    info,
+    project_id: ID,
+    status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[Task]:
+    db = info.context["db"]
+    filters = {"project_id": project_id}
+    if status:
+        filters["status"] = status
+    return await db.find("v_task", limit=limit, offset=offset, **filters)
+```
 
-    @authorize(roles=['owner', 'admin', 'member', 'viewer'])
-    def tasks(
-        self,
-        project_id: str,
-        status: str | None = None,
-        assigned_to: str | None = None,
-        limit: int = 50,
-        offset: int = 0
-    ) -> list[Task]:
-        """List tasks in a project"""
-        pass
+### Authorization Beyond Tenant Isolation
 
-    @authorize(roles=['owner', 'admin'])
-    def usage_report(self, period_start: str, period_end: str) -> dict:
-        """Get usage metrics for current tenant"""
-        pass
+RLS already enforces *tenant* boundaries. For coarser operation-level checks (for
+example, "only owners may view billing"), use one of two real v1 mechanisms:
 
-    @authorize(roles=['owner', 'admin'])
-    def audit_logs(self, limit: int = 100, offset: int = 0) -> list[dict]:
-        """Get audit logs (admin only)"""
-        pass
+**1. Role checks inside RLS.** If your auth middleware populates `app.user_role` (or
+checks `current_user_id()` against a role table), the policies above already gate
+SELECT/UPDATE/DELETE by role. This keeps authorization in one place — the database.
 
-@types.object
-class Mutation:
-    @authorize(roles=['owner', 'admin'])
-    def invite_user(self, email: str, role: str = 'member') -> User:
-        """Send invitation to new user"""
-        pass
+**2. An `Authorizer` on the query.** FraiseQL accepts an authorizer callable that
+runs before the resolver and can reject the request based on `info.context`:
 
-    @authorize(roles=['owner', 'admin'])
-    def create_project(self, name: str, description: str = '') -> Project:
-        """Create new project"""
-        pass
+```python
+def require_roles(*allowed: str):
+    async def authorizer(info) -> bool:
+        return info.context.get("user_role") in allowed
+    return authorizer
 
-    @authorize(roles=['owner', 'admin', 'member'])
-    def create_task(
-        self,
-        project_id: str,
-        title: str,
-        description: str = '',
-        assigned_to: str | None = None,
-        priority: str = 'medium'
-    ) -> Task:
-        """Create task in project"""
-        pass
+@fraiseql.query(authorizer=require_roles("owner", "admin"))
+async def audit_logs(info, limit: int = 100, offset: int = 0) -> list[AuditLog]:
+    db = info.context["db"]
+    return await db.find("v_audit_log", limit=limit, offset=offset)
+```
 
-    @authorize(roles=['owner', 'admin', 'member'])
-    def update_task(
-        self,
-        task_id: str,
-        status: str | None = None,
-        assigned_to: str | None = None
-    ) -> Task:
-        """Update task status/assignment"""
-        pass
+v1 has no role-based authorization decorator — authorization is expressed through
+RLS policies and/or `@fraiseql.query(authorizer=...)`.
 
-    @authorize(roles=['owner'])
-    def upgrade_plan(self, plan: str, stripe_token: str) -> Subscription:
-        """Upgrade subscription plan"""
-        pass
-```text
-<!-- Code example in TEXT -->
+### Mutations via `fn_*` Functions
+
+Writes call PostgreSQL functions through `db.execute_function`. The function runs
+inside the same transaction, so `app.tenant_id` is set and any RLS `WITH CHECK`
+clauses apply.
+
+```python
+@fraiseql.input
+class CreateProjectInput:
+    name: str
+    description: str = ""
+
+@fraiseql.success
+class CreateProjectSuccess:
+    project: Project
+
+@fraiseql.error
+class CreateProjectError:
+    message: str
+    code: str = "VALIDATION_ERROR"
+
+@fraiseql.mutation
+async def create_project(
+    info, input: CreateProjectInput
+) -> CreateProjectSuccess | CreateProjectError:
+    db = info.context["db"]
+    result = await db.execute_function(
+        "fn_create_project",
+        {
+            "tenant_id": info.context["tenant_id"],
+            "owner_id": info.context["user_id"],
+            "name": input.name,
+            "description": input.description,
+        },
+    )
+    if not result.get("success"):
+        return CreateProjectError(message=result.get("message", "failed"))
+    return CreateProjectSuccess(project=Project(**result["project"]))
+```
+
+---
+
+## Wiring Tenant Context (FastAPI)
+
+Tenant isolation only works if `info.context["tenant_id"]` is populated. You do that
+in FastAPI middleware (or a context getter) that verifies the JWT and copies its
+claims into the GraphQL context. FraiseQL then turns those context keys into session
+GUCs automatically.
+
+```python
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+
+async def build_context(request) -> dict:
+    # Verify the JWT however you like (PyJWT, Auth0, etc.).
+    claims = verify_jwt(request.headers.get("authorization"))
+    return {
+        "tenant_id": claims["tenant_id"],
+        "user_id": claims["user_id"],
+        "user_role": claims["role"],
+        "is_super_admin": claims.get("is_super_admin", False),
+    }
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/saas",
+    types=[Tenant, User, Project, Task],
+    queries=[me, projects, tasks, audit_logs],
+    mutations=[create_project],
+    context_getter=build_context,
+    production=True,
+)
+```
+
+Run it like any FastAPI app:
+
+```bash
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+The critical rule: **never trust a `tenant_id` sent by the client.** It must come
+from the verified token. The client cannot forge `info.context["tenant_id"]` because
+it is derived server-side from a signed JWT before any query runs.
 
 ---
 
 ## JWT Token Structure
 
-### Token Payload
-
 ```json
-<!-- Code example in JSON -->
 {
   "sub": "user_123",
-  "email": "alice@company.com",
-  "tenant_id": "tenant_456",
-  "user_id": "user_123",
+  "email": "alice@acme.com",
+  "tenant_id": "9f1c2b...",
+  "user_id": "3a7e9d...",
   "role": "admin",
   "iat": 1640000000,
   "exp": 1640086400
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-### Setting Tenant Context in FraiseQL Server
-
-```rust
-<!-- Code example in RUST -->
-// FraiseQL-server middleware (pseudo-code)
-async fn set_tenant_context(token: &Claims) -> Result<()> {
-    // Set tenant and user context for RLS policies
-    client.execute(
-        "SET app.tenant_id = $1",
-        &[&token.tenant_id]
-    ).await?;
-
-    client.execute(
-        "SET app.user_id = $1",
-        &[&token.user_id]
-    ).await?;
-
-    client.execute(
-        "SET app.user_role = $1",
-        &[&token.role]
-    ).await?;
-
-    Ok(())
-}
-```text
-<!-- Code example in TEXT -->
+Your middleware verifies the signature and expiry, then maps `tenant_id`, `user_id`,
+and `role` into the GraphQL context. From there FraiseQL handles the
+`SET LOCAL app.*` calls and PostgreSQL handles the rest.
 
 ---
 
-## Client Implementation
+## Billing and Usage Tracking
 
-### React Hook for Current Tenant
-
-```typescript
-<!-- Code example in TypeScript -->
-import { useQuery, gql } from '@apollo/client';
-
-const ME_QUERY = gql`
-  query Me {
-    me {
-      id
-      email
-      full_name
-      role
-      tenant {
-        id
-        slug
-        name
-        plan
-      }
-    }
-  }
-`;
-
-export function useCurrentUser() {
-  const { data, loading, error } = useQuery(ME_QUERY);
-  return {
-    user: data?.me,
-    tenant: data?.me?.tenant,
-    loading,
-    error,
-  };
-}
-```text
-<!-- Code example in TEXT -->
-
-### List Projects Query
-
-```typescript
-<!-- Code example in TypeScript -->
-const LIST_PROJECTS = gql`
-  query ListProjects {
-    projects {
-      id
-      name
-      owner {
-        full_name
-      }
-      members {
-        id
-        email
-      }
-    }
-  }
-`;
-
-export function ProjectList() {
-  const { data, loading } = useQuery(LIST_PROJECTS);
-
-  if (loading) return <div>Loading...</div>;
-
-  return (
-    <ul>
-      {data?.projects?.map((project) => (
-        <li key={project.id}>
-          <h3>{project.name}</h3>
-          <p>Owner: {project.owner.full_name}</p>
-          <p>Members: {project.members.length}</p>
-        </li>
-      ))}
-    </ul>
-  );
-}
-```text
-<!-- Code example in TEXT -->
-
-### Create Project Mutation
-
-```typescript
-<!-- Code example in TypeScript -->
-const CREATE_PROJECT = gql`
-  mutation CreateProject($name: String!, $description: String!) {
-    createProject(name: $name, description: $description) {
-      id
-      name
-      description
-      owner {
-        id
-        full_name
-      }
-    }
-  }
-`;
-
-export function CreateProjectForm() {
-  const [name, setName] = useState('');
-  const [createProject, { loading }] = useMutation(CREATE_PROJECT, {
-    refetchQueries: [{ query: LIST_PROJECTS }],
-  });
-
-  const handleCreate = async () => {
-    await createProject({
-      variables: { name, description: '' },
-    });
-    setName('');
-  };
-
-  return (
-    <form onSubmit={(e) => { e.preventDefault(); handleCreate(); }}>
-      <input
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="Project name"
-      />
-      <button disabled={loading}>Create</button>
-    </form>
-  );
-}
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Billing Integration
-
-### Track Usage
+Plan limits and metered usage live in PostgreSQL functions, so they run in the same
+transaction as the rest of the request and respect tenant isolation.
 
 ```sql
-<!-- Code example in SQL -->
--- Function to increment usage
-CREATE OR REPLACE FUNCTION increment_usage(
-  p_tenant_id UUID,
-  p_metric_name VARCHAR,
-  p_amount DECIMAL
+-- Increment a usage counter for the current billing period.
+CREATE OR REPLACE FUNCTION fn_increment_usage(
+  p_tenant_id  UUID,
+  p_metric     TEXT,
+  p_amount     NUMERIC
 ) RETURNS void AS $$
 BEGIN
-  INSERT INTO usage_metrics (tenant_id, metric_name, metric_value, period_start, period_end)
+  INSERT INTO tb_usage_metric (tenant_id, metric_name, metric_value, period_start, period_end)
   VALUES (
     p_tenant_id,
-    p_metric_name,
+    p_metric,
     p_amount,
-    DATE_TRUNC('month', NOW())::DATE,
-    DATE_TRUNC('month', NOW() + INTERVAL '1 month')::DATE - INTERVAL '1 day'
+    DATE_TRUNC('month', now())::DATE,
+    (DATE_TRUNC('month', now()) + INTERVAL '1 month' - INTERVAL '1 day')::DATE
   )
   ON CONFLICT (tenant_id, metric_name, period_start, period_end)
-  DO UPDATE SET metric_value = metric_value + EXCLUDED.metric_value;
+  DO UPDATE SET metric_value = tb_usage_metric.metric_value + EXCLUDED.metric_value;
 END;
 $$ LANGUAGE plpgsql;
-```text
-<!-- Code example in TEXT -->
 
-### Check Usage Limits
-
-```sql
-<!-- Code example in SQL -->
--- Example: Check if tenant has exceeded API call limit
-CREATE OR REPLACE FUNCTION check_api_limit(p_tenant_id UUID) RETURNS BOOLEAN AS $$
+-- Enforce a per-plan API limit.
+CREATE OR REPLACE FUNCTION fn_check_api_limit(p_tenant_id UUID) RETURNS BOOLEAN AS $$
 DECLARE
-  v_current_usage DECIMAL;
-  v_plan VARCHAR;
-  v_limit DECIMAL;
+  v_usage NUMERIC;
+  v_plan  TEXT;
+  v_limit NUMERIC;
 BEGIN
-  SELECT plan INTO v_plan FROM tenants WHERE id = p_tenant_id;
+  SELECT plan INTO v_plan FROM tb_tenant WHERE id = p_tenant_id;
 
-  SELECT metric_value INTO v_current_usage FROM usage_metrics
+  SELECT metric_value INTO v_usage
+  FROM tb_usage_metric
   WHERE tenant_id = p_tenant_id
     AND metric_name = 'api_calls'
-    AND period_start = DATE_TRUNC('month', NOW())::DATE;
+    AND period_start = DATE_TRUNC('month', now())::DATE;
 
-  v_current_usage := COALESCE(v_current_usage, 0);
-
-  -- Define limits per plan
+  v_usage := COALESCE(v_usage, 0);
   v_limit := CASE v_plan
-    WHEN 'free' THEN 1000
-    WHEN 'starter' THEN 10000
-    WHEN 'pro' THEN 100000
+    WHEN 'free'       THEN 1000
+    WHEN 'starter'    THEN 10000
+    WHEN 'pro'        THEN 100000
     WHEN 'enterprise' THEN 999999999
+    ELSE 0
   END;
 
-  RETURN v_current_usage < v_limit;
+  RETURN v_usage < v_limit;
 END;
 $$ LANGUAGE plpgsql;
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
-## Security Considerations
+## Provisioning a New Tenant
 
-### 1. Token Validation
-
-```typescript
-<!-- Code example in TypeScript -->
-// Verify JWT before setting context
-function validateToken(token: string): Claims | null {
-  try {
-    return jwt.verify(token, process.env.JWT_SECRET) as Claims;
-  } catch (err) {
-    console.error('Invalid token:', err);
-    return null;
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-### 2. Prevent Tenant ID Forgery
-
-```typescript
-<!-- Code example in TypeScript -->
-// Never trust tenant_id from client - get it from token
-const getTenantIdFromToken = (token: Claims): string => {
-  if (!token.tenant_id) {
-    throw new Error('Invalid token: missing tenant_id');
-  }
-  return token.tenant_id;
-};
-```text
-<!-- Code example in TEXT -->
-
-### 3. Audit All Changes
+Tenant signup is a single `fn_*` function that creates the tenant, its first user
+(the owner), and a default subscription atomically. Because the new tenant has no
+prior rows, you typically run provisioning with a super-admin context
+(`info.context["is_super_admin"] = True`) or a dedicated service role whose policies
+permit the initial inserts.
 
 ```sql
-<!-- Code example in SQL -->
--- Trigger to auto-log changes
-CREATE OR REPLACE FUNCTION audit_trigger() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION fn_provision_tenant(
+  p_slug       TEXT,
+  p_name       TEXT,
+  p_owner_email TEXT,
+  p_owner_hash  TEXT
+) RETURNS JSONB AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_user_id   UUID;
 BEGIN
-  INSERT INTO audit_logs (
-    tenant_id,
-    user_id,
-    entity_type,
-    entity_id,
-    action,
-    old_values,
-    new_values
+  INSERT INTO tb_tenant (identifier, name, plan, status)
+  VALUES (p_slug, p_name, 'free', 'active')
+  RETURNING id INTO v_tenant_id;
+
+  INSERT INTO tb_user (tenant_id, email, password_hash, role, status)
+  VALUES (v_tenant_id, p_owner_email, p_owner_hash, 'owner', 'active')
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO tb_subscription (tenant_id, plan, status, current_period_start, current_period_end)
+  VALUES (
+    v_tenant_id, 'free', 'active',
+    now()::DATE, (now() + INTERVAL '1 month')::DATE
+  );
+
+  RETURN jsonb_build_object('success', true, 'tenantId', v_tenant_id, 'ownerId', v_user_id);
+END;
+$$ LANGUAGE plpgsql;
+```
+
+---
+
+## Audit Logging
+
+A single trigger function reads the session GUCs and records who changed what. It
+relies on the same `current_tenant_id()` / `current_user_id()` helpers, so the audit
+trail is automatically tenant-scoped.
+
+```sql
+CREATE OR REPLACE FUNCTION fn_audit_trigger() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO tb_audit_log (
+    tenant_id, user_id, entity_type, entity_id, action, old_values, new_values
   ) VALUES (
     current_tenant_id(),
     current_user_id(),
     TG_TABLE_NAME,
     CASE WHEN TG_OP = 'DELETE' THEN OLD.id ELSE NEW.id END,
-    TG_OP,
-    CASE WHEN TG_OP = 'DELETE' THEN row_to_json(OLD) ELSE NULL END,
-    CASE WHEN TG_OP IN ('INSERT', 'UPDATE') THEN row_to_json(NEW) ELSE NULL END
+    lower(TG_OP),
+    CASE WHEN TG_OP IN ('UPDATE', 'DELETE') THEN row_to_json(OLD)::jsonb END,
+    CASE WHEN TG_OP IN ('INSERT', 'UPDATE') THEN row_to_json(NEW)::jsonb END
   );
   RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
 END;
 $$ LANGUAGE plpgsql;
 
--- Apply trigger to all tables
-CREATE TRIGGER users_audit AFTER INSERT OR UPDATE OR DELETE ON users
-FOR EACH ROW EXECUTE FUNCTION audit_trigger();
+CREATE TRIGGER user_audit
+  AFTER INSERT OR UPDATE OR DELETE ON tb_user
+  FOR EACH ROW EXECUTE FUNCTION fn_audit_trigger();
 
-CREATE TRIGGER projects_audit AFTER INSERT OR UPDATE OR DELETE ON projects
-FOR EACH ROW EXECUTE FUNCTION audit_trigger();
+CREATE TRIGGER project_audit
+  AFTER INSERT OR UPDATE OR DELETE ON tb_project
+  FOR EACH ROW EXECUTE FUNCTION fn_audit_trigger();
 
-CREATE TRIGGER tasks_audit AFTER INSERT OR UPDATE OR DELETE ON tasks
-FOR EACH ROW EXECUTE FUNCTION audit_trigger();
-```text
-<!-- Code example in TEXT -->
+CREATE TRIGGER task_audit
+  AFTER INSERT OR UPDATE OR DELETE ON tb_task
+  FOR EACH ROW EXECUTE FUNCTION fn_audit_trigger();
+```
+
+---
+
+## Testing Tenant Isolation
+
+The cheapest, most convincing test is at the SQL layer: set a tenant GUC and confirm
+you cannot see another tenant's rows. This exercises the exact mechanism FraiseQL
+uses at runtime.
+
+```sql
+-- Seed two tenants, then prove isolation.
+SET LOCAL app.tenant_id = '<tenant-a-uuid>';
+SET LOCAL app.user_id   = '<tenant-a-owner-uuid>';
+SET LOCAL app.user_role = 'owner';
+
+-- Returns only tenant A's projects; tenant B's rows are invisible.
+SELECT count(*) FROM tb_project;            -- only A
+SELECT count(*) FROM tb_project WHERE tenant_id = '<tenant-b-uuid>';  -- 0
+```
+
+At the application level, drive two different JWTs through the GraphQL endpoint and
+assert each only ever sees its own data:
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_tenant_isolation(client):
+    token_a = make_jwt(tenant_id=TENANT_A, user_id=OWNER_A, role="owner")
+    resp = await client.post(
+        "/graphql",
+        json={"query": "{ projects { id name } }"},
+        headers={"authorization": f"Bearer {token_a}"},
+    )
+    project_ids = {p["id"] for p in resp.json()["data"]["projects"]}
+    assert project_ids <= TENANT_A_PROJECT_IDS  # never tenant B's
+```
 
 ---
 
@@ -832,110 +809,57 @@ FOR EACH ROW EXECUTE FUNCTION audit_trigger();
 
 ### Connection Pooling
 
-- Use PgBouncer for connection pooling
-- Set pool size to 100-200 per tenant segment
-- Use transaction pooling mode for high-concurrency scenarios
+- PgBouncer in **transaction** pooling mode pairs well with `SET LOCAL`: the GUC is
+  scoped to the transaction, so it never leaks to the next request on a reused
+  connection.
+- Size the pool to your concurrency, not your tenant count — tenants share the pool.
 
 ### Caching
 
-- Cache tenant configuration (plan limits, features)
-- Cache user roles (expires after 5 minutes)
-- Invalidate on role/permission changes
+- FraiseQL ships PostgreSQL-backed result caching (`PostgresCache`, `ResultCache`,
+  `CachedRepository`) with cascade invalidation rules. Cache keys include the query
+  and arguments; keep tenant context out of cached payloads or scope keys per tenant.
+- Cache slow-changing tenant configuration (plan limits, feature flags) and
+  invalidate on plan or role changes.
 
-### Monitoring
+### Read Replicas
 
-- Track per-tenant query performance
-- Monitor RLS policy evaluation time
-- Alert on unusual usage patterns
-
-### Multi-Region Deployment
-
-```text
-<!-- Code example in TEXT -->
-Region 1 (US-East)           Region 2 (EU)
-    ↓                             ↓
-FraiseQL Server ----------- Replication -------- FraiseQL Server
-    ↓                             ↓
-PostgreSQL Primary ---------- Streaming -------- PostgreSQL Replica
-(tenant_a, tenant_b)         (standby)         (for reads)
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Testing Multi-Tenant Isolation
-
-```typescript
-<!-- Code example in TypeScript -->
-describe('Multi-Tenant Isolation', () => {
-  it('tenant_a cannot see tenant_b data', async () => {
-    // Login as user from tenant_a
-    const token_a = generateToken({ tenant_id: 'a', user_id: 'user_1' });
-
-    // Try to query with tenant_b context (should fail)
-    const result = await client.query(LIST_PROJECTS, {
-      headers: { authorization: `Bearer ${token_a}` },
-    });
-
-    // RLS policy should prevent access
-    expect(result.errors).toBeDefined();
-  });
-
-  it('users can only see their tenant projects', async () => {
-    const token = generateToken({ tenant_id: 'a', user_id: 'user_1' });
-    const result = await client.query(LIST_PROJECTS, {
-      headers: { authorization: `Bearer ${token}` },
-    });
-
-    // All returned projects should have tenant_id = 'a'
-    expect(result.data.projects.every(p => p.tenant_id === 'a')).toBe(true);
-  });
-});
-```text
-<!-- Code example in TEXT -->
+- Route read-only queries to a streaming replica. RLS policies and the `app.*` GUCs
+  apply identically on replicas, so tenant isolation holds for replica reads too.
 
 ---
 
 ## Common Pitfalls
 
-### ❌ Storing tenant_id in app, not JWT
+### Trusting a client-supplied `tenant_id`
 
-Vulnerable to token swapping. Always extract from verified token.
+Always derive `tenant_id` from the verified JWT in your context getter, never from a
+GraphQL argument or header the client controls.
 
-### ❌ Relying only on app-level filtering
+### Relying only on application-level filtering
 
-Use database RLS as defense in depth.
+App filters are easy to forget on one code path. Make RLS the baseline so a missing
+`WHERE` clause still cannot leak data. Use `mandatory_filters` as an additional
+explicit guard.
 
-### ❌ Not auditing sensitive operations
+### Forgetting `FORCE ROW LEVEL SECURITY`
 
-Track who accessed what, when, for compliance.
+Plain `ENABLE ROW LEVEL SECURITY` is bypassed by the table owner. Add `FORCE` so no
+role — including the one your app connects as, if it owns the tables — escapes the
+policies.
 
-### ❌ Same schema for all tenants
+### Leaving a GUC set between requests
 
-Multi-schema is better if tenants are large, separate instances.
+`SET LOCAL` (which FraiseQL uses) resets at transaction end. Avoid plain `SET`, which
+persists on the connection and can leak one tenant's context into the next request on
+a pooled connection.
 
 ---
 
 ## See Also
 
-**Related Patterns:**
-
-- [Database Federation](./federation-patterns.md) - Multiple databases
-- [Real-Time Collaboration](./realtime-collaboration.md) - Live updates
-- [E-Commerce Workflows](./ecommerce-workflows.md) - Complex workflows
-
-**Security Guides:**
-
-- [Production Security Checklist](../guides/production-security-checklist.md)
-- [Authentication & Authorization](../guides/authorization-quick-start.md)
-- [Audit Logging](../guides/observers.md)
-
-**Deployment:**
-
-- [Production Deployment](../guides/production-deployment.md)
-- [Kubernetes Setup](../guides/production-deployment.md)
-
----
-
-**Last Updated:** 2026-02-05
-**Version:** v2.0.0-alpha.1
+- [Patterns Overview](./README.md)
+- [Analytics OLAP Platform](./analytics-olap-platform.md)
+- [Extension Points](../architecture/integration/extension-points.md)
+- [Consistency Model](../architecture/reliability/consistency-model.md)
+- [Database-Centric Architecture](../foundation/03-database-centric-architecture.md)


### PR DESCRIPTION
Phase 2 of the docs cleanup (follows #418–#423). Rewrites the **Patterns** nav pages — the application "blueprint" docs — which used a fictional v2 API (`from FraiseQL import types`, `@types.object`, `@authorize(roles=)`, "FraiseQL Server (Rust)") with `v2.0.0-alpha` footers. All 6 rewritten onto **real v1 APIs** (each verified against `src/`), keeping the application architectures.

## Per-file summary

| File | Key v2→v1 changes |
|------|-------------------|
| `README` | v1 patterns index; drop multi-DB federation section + alpha footer |
| `saas-multi-tenant` | real tenant isolation: `tenant_id` columns + **PostgreSQL RLS** reading `current_setting('app.tenant_id')`, FraiseQL setting the session GUC from `info.context` (`SET LOCAL app.tenant_id`) + `mandatory_filters`; `create_fraiseql_app(context_getter=...)` |
| `analytics-olap-platform` | runtime auto-aggregation + `v_`/`tv_` views + `DATE_TRUNC`/`FILTER`/window functions; drop `fact_table=`/Arrow/ClickHouse/compiler |
| `realtime-collaboration` | real `@fraiseql.subscription` async generators backed by **LISTEN/NOTIFY** (`conn.notifies`) over WebSocket; `create_fraiseql_app(subscriptions=[...])`; drop observer/CRDT/event-log |
| `ecommerce-workflows` | workflows as `fn_` functions (transactions) + `status` state machine + **transactional outbox** worker (`FOR UPDATE SKIP LOCKED`); `@success`/`@error` unions; auth via `authorizer=`/RLS (no `@authorize`) |
| `iot-timeseries` | native `PARTITION BY RANGE` tables, `tv_` rollups refreshed by `fn_`, `DATE_TRUNC` bucketing, window functions, optional LISTEN/NOTIFY push; external systems noted as separate (FraiseQL is PostgreSQL-only) |

## Verification

- `grep`: **zero** `@types.` / `@authorize(` / `from FraiseQL import` / `FraiseQL Server` / `v2.0.0` / `fact_table=` / Arrow-Flight artifacts; every "compile" mention is a negation.
- **Source-verified**: `create_fraiseql_app(context_getter=, subscriptions=)`; the RLS `app.tenant_id` GUC flow in `db.py`; the auto-aggregation and subscription APIs.
- All cross-links resolve; fences balanced; no Rust leftovers; `mkdocs build` no new warnings.

Net: **+3365 / −3525** lines (mostly API/framing corrections, not deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)