### PR TITLE
docs(enterprise): rewrite/clean Enterprise pages for v1 (Phase 2)

### DIFF
--- a/docs/enterprise/README.md
+++ b/docs/enterprise/README.md
@@ -1,171 +1,184 @@
-<!-- Skip to main content -->
 ---
-
-title: FraiseQL v2 Enterprise Features
+title: FraiseQL Enterprise Features
 description: Enterprise-grade security, compliance, and audit capabilities for production deployments.
 keywords: []
 tags: ["documentation", "reference"]
 ---
 
-# FraiseQL v2 Enterprise Features
+# FraiseQL Enterprise Features
 
-Enterprise-grade security, compliance, and audit capabilities for production deployments.
-
-Enterprise-grade runtime security hardening including error sanitization, rate limiting, token protection, and encrypted state management.
+Enterprise-grade runtime security hardening for production PostgreSQL deployments, including error sanitization, rate limiting, token protection, and encrypted state management.
 
 ---
 
-## 🔐 Runtime Security Features
+## Runtime Security Features
 
-Configured via `FraiseQL.toml` with environment variable overrides.
+All runtime security is configured at application startup through
+[`FraiseQLConfig`](https://github.com/fraiseql/fraiseql-python/blob/main/src/fraiseql/fastapi/config.py) — a Pydantic
+`BaseSettings` class — and/or `create_fraiseql_app(...)` keyword arguments.
+Every setting can be overridden by an environment variable prefixed with
+`FRAISEQL_` (for example `FRAISEQL_RATE_LIMIT_ENABLED`). There is no
+configuration file: settings live in code, in `.env`, or in the process
+environment.
+
+```python
+from fraiseql.fastapi import FraiseQLConfig, create_fraiseql_app
+
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+    environment="production",
+    rate_limit_enabled=True,
+    complexity_enabled=True,
+    revocation_enabled=True,
+)
+
+app = create_fraiseql_app(types=[...], queries=[...], config=config)
+```
 
 ### Error Sanitization
 
-**Hide implementation details from client errors**, preventing information leakage:
+**Hide implementation details from client errors**, preventing information
+leakage. Setting `environment="production"` (or
+`FRAISEQL_ENVIRONMENT=production`) switches FraiseQL into hardened mode:
 
-- `error_sanitization.enabled` — Enable/disable error message masking
-- `error_sanitization.level` — Control verbosity (internal/user/public)
-- Client receives generic "An error occurred" instead of SQL details
-- Server logs full errors for debugging
+- Clients receive generic error messages instead of SQL, stack traces, or
+  internal identifiers.
+- Full error detail is still written to server logs for debugging.
+- Schema introspection is disabled and the GraphQL playground is turned off
+  automatically in production.
 
-**Example:**
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+    environment="production",  # masks internal error detail from clients
+)
+```
 
-```toml
-<!-- Code example in TOML -->
-[FraiseQL.security.error_sanitization]
-enabled = true
-level = "user"  # Only expose user-friendly messages to clients
-```text
-<!-- Code example in TEXT -->
+```bash
+FRAISEQL_ENVIRONMENT=production
+```
 
 ### Constant-Time Token Comparison
 
 **Prevent timing attacks** on token validation:
 
-- Token comparison uses constant-time algorithm (bitwise operations)
-- Attack duration independent of token position in storage
-- Prevents brute-force attacks via timing analysis
-- Automatic for all authentication tokens
+- Token and credential comparisons use a constant-time algorithm.
+- Verification duration is independent of where a mismatch occurs.
+- Defends against brute-force inference via timing analysis.
+- Applied automatically to all authentication tokens — no configuration
+  needed.
 
-### PKCE State Encryption
+### Token Revocation
 
-**Protect OAuth state parameters** from inspection:
+**Invalidate compromised or logged-out tokens** before their natural
+expiry. Revocation is enabled by default and tunable through `FraiseQLConfig`:
 
-- State parameter encrypted before transmission
-- Prevents state parameter tampering
-- REQUIRED for public clients (SPAs, mobile apps)
-- Configurable encryption algorithm (AES-256 default)
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+    revocation_enabled=True,
+    revocation_check_enabled=True,
+    revocation_ttl=86400,          # how long a revocation is retained (seconds)
+    revocation_store_type="redis", # "memory" (default) or "redis"
+)
+```
 
-**Example:**
-
-```toml
-<!-- Code example in TOML -->
-[FraiseQL.security.pkce]
-state_encryption_enabled = true
-encryption_algorithm = "aes-256-gcm"
-```text
-<!-- Code example in TEXT -->
+```bash
+FRAISEQL_REVOCATION_ENABLED=true
+FRAISEQL_REVOCATION_CHECK_ENABLED=true
+FRAISEQL_REVOCATION_TTL=86400
+```
 
 ### Rate Limiting
 
-**Brute-force protection** on authentication endpoints:
+**Brute-force and abuse protection** on the GraphQL endpoint:
 
-- Per-IP rate limiting (configurable window)
-- Per-user rate limiting (account lockout protection)
-- Exponential backoff on repeated failures
-- Configurable thresholds per endpoint
+- Per-minute and per-hour request ceilings.
+- Burst allowance for short traffic spikes.
+- Sliding or fixed time windows.
+- Whitelist/blacklist of client identifiers.
 
-**Example:**
-
-```toml
-<!-- Code example in TOML -->
-[FraiseQL.security.rate_limiting]
-enabled = true
-auth_start_max_requests = 100
-auth_start_window_secs = 60
-auth_verify_max_requests = 50
-auth_verify_window_secs = 60
-```text
-<!-- Code example in TEXT -->
-
-### Audit Logging (v2.0)
-
-**Track secret access** with cryptographic verification:
-
-- Log all authentication events (login, token refresh, failures)
-- Log all data mutations (create, update, delete)
-- HMAC signatures prevent tampering
-- Queryable audit trail for compliance
-
-### Full Configuration Reference
-
-All runtime security features are configured in `FraiseQL.toml` under `[FraiseQL.security]`:
-
-```toml
-<!-- Code example in TOML -->
-[FraiseQL.security]
-# Error handling
-[FraiseQL.security.error_sanitization]
-enabled = true
-level = "user"  # internal|user|public
-
-# Token security
-[FraiseQL.security.constant_time_comparison]
-enabled = true
-
-# OAuth security
-[FraiseQL.security.pkce]
-state_encryption_enabled = true
-encryption_algorithm = "aes-256-gcm"
-
-# Rate limiting
-[FraiseQL.security.rate_limiting]
-enabled = true
-auth_start_max_requests = 100
-auth_start_window_secs = 60
-auth_verify_max_requests = 50
-auth_verify_window_secs = 60
-
-# Audit logging
-[FraiseQL.security.audit_logging]
-enabled = true
-log_level = "info"
-secret_access_logging = true
-```text
-<!-- Code example in TEXT -->
-
-Environment variable overrides (production):
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+    rate_limit_enabled=True,
+    rate_limit_requests_per_minute=60,
+    rate_limit_requests_per_hour=1000,
+    rate_limit_burst_size=10,
+    rate_limit_window_type="sliding",  # "sliding" or "fixed"
+)
+```
 
 ```bash
-<!-- Code example in BASH -->
-# Rate limiting per environment
-FRAISEQL_RATE_LIMITING_ENABLED=true
-FRAISEQL_RATE_LIMITING_AUTH_START_MAX_REQUESTS=50  # Stricter in prod
+FRAISEQL_RATE_LIMIT_ENABLED=true
+FRAISEQL_RATE_LIMIT_REQUESTS_PER_MINUTE=30   # stricter in production
+FRAISEQL_RATE_LIMIT_REQUESTS_PER_HOUR=500
+```
 
-# Audit logging
-FRAISEQL_AUDIT_LOGGING_ENABLED=true
-FRAISEQL_AUDIT_LOGGING_LEVEL=debug
-```text
-<!-- Code example in TEXT -->
+### Query Complexity Limits
 
-See [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md) for full configuration management details.
+**Reject expensive or abusive queries** before they reach PostgreSQL:
+
+- Per-query complexity scoring with a configurable maximum.
+- Maximum nesting depth enforcement.
+- Optional per-field complexity multipliers.
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+    complexity_enabled=True,
+    complexity_max_score=1000,
+    complexity_max_depth=10,
+)
+```
+
+```bash
+FRAISEQL_COMPLEXITY_ENABLED=true
+FRAISEQL_COMPLEXITY_MAX_SCORE=1000
+FRAISEQL_COMPLEXITY_MAX_DEPTH=10
+```
+
+### Encrypted State and Audit Logging
+
+**Tamper-evident audit trails** with HMAC signatures track authentication
+events and data mutations. Audit logging is implemented as a PostgreSQL
+pattern (immutable log tables plus HMAC signature chains) and is documented in
+detail in [audit-logging.md](./audit-logging.md). OAuth state and other
+sensitive parameters are encrypted before transmission so they cannot be
+inspected or tampered with in transit.
+
+### Configuration Summary
+
+| Concern | `FraiseQLConfig` field(s) | Environment variable |
+|---------|---------------------------|----------------------|
+| Error sanitization | `environment="production"` | `FRAISEQL_ENVIRONMENT` |
+| Token revocation | `revocation_enabled`, `revocation_check_enabled`, `revocation_ttl`, `revocation_store_type` | `FRAISEQL_REVOCATION_*` |
+| Rate limiting | `rate_limit_enabled`, `rate_limit_requests_per_minute`, `rate_limit_requests_per_hour`, `rate_limit_burst_size`, `rate_limit_window_type` | `FRAISEQL_RATE_LIMIT_*` |
+| Query complexity | `complexity_enabled`, `complexity_max_score`, `complexity_max_depth` | `FRAISEQL_COMPLEXITY_*` |
+| Introspection control | `introspection_policy` | `FRAISEQL_INTROSPECTION_POLICY` |
+| CORS | `cors_enabled`, `cors_origins` | `FRAISEQL_CORS_*` |
+| Authentication | `auth_enabled`, `auth_provider` | `FRAISEQL_AUTH_*` |
+
+Constant-time token comparison applies automatically and has no configuration
+flag. See the full field list and defaults in
+[`src/fraiseql/fastapi/config.py`](https://github.com/fraiseql/fraiseql-python/blob/main/src/fraiseql/fastapi/config.py).
 
 ---
 
-## 🔒 Enterprise Features Overview
+## Enterprise Features Overview
 
 ### Access Control
 
-| Document | Description | Lines | Est. Time |
-|----------|-------------|-------|-----------|
-| [rbac.md](rbac.md) | Role-Based Access Control | 844 | 60 min |
+| Document | Description |
+|----------|-------------|
+| [rbac.md](./rbac.md) | Role-Based Access Control |
 
-**Topics Covered:**
+**Topics covered:**
 
 - Hierarchical role system
 - Field-level permissions
-- Row-level security
-- Authorization enforcement layers
+- PostgreSQL Row-Level Security (RLS)
+- Authorization enforcement via `Authorizer` and `@fraiseql.query(authorizer=...)`
 - JWT claims integration
 - Dynamic role assignment
 
@@ -173,28 +186,28 @@ See [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md) for full configuration manage
 
 ### Audit & Compliance
 
-| Document | Description | Lines | Est. Time |
-|----------|-------------|-------|-----------|
-| [audit-logging.md](audit-logging.md) | Cryptographic audit trails | 887 | 60 min |
+| Document | Description |
+|----------|-------------|
+| [audit-logging.md](./audit-logging.md) | Cryptographic audit trails |
 
-**Topics Covered:**
+**Topics covered:**
 
-- Immutable audit log
+- Immutable audit log tables
 - HMAC signature chains
 - Tamper detection
-- Audit columns (created_at, updated_at, deleted_at)
-- Compliance with GDPR, SOC2, NIS2
+- Audit columns (`created_at`, `updated_at`, `deleted_at`)
+- Compliance with GDPR, SOC 2, NIS2
 - Retention policies
 
 ---
 
 ### Data Protection
 
-| Document | Description | Lines | Est. Time |
-|----------|-------------|-------|-----------|
-| [kms.md](kms.md) | Key Management Service integration | 854 | 50 min |
+| Document | Description |
+|----------|-------------|
+| [kms.md](./kms.md) | Key Management Service integration |
 
-**Topics Covered:**
+**Topics covered:**
 
 - Field-level encryption
 - AWS KMS integration
@@ -205,38 +218,40 @@ See [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md) for full configuration manage
 
 ---
 
-## 🎯 Quick Start
+## Quick Start
 
-**For Security Engineers:**
+**For security engineers:**
 
-1. Read [rbac.md](rbac.md) for access control design
-2. Review [audit-logging.md](audit-logging.md) for compliance requirements
-3. Configure [kms.md](kms.md) for data encryption
+1. Read [rbac.md](./rbac.md) for access control design.
+2. Review [audit-logging.md](./audit-logging.md) for compliance requirements.
+3. Configure [kms.md](./kms.md) for data encryption.
 
-**For Compliance Teams:**
+**For compliance teams:**
 
-1. Start with [audit-logging.md](audit-logging.md)
-2. Review security profiles in [Specs: Security Compliance](../specs/security-compliance.md)
-3. Understand RBAC enforcement in [rbac.md](rbac.md)
-
----
-
-## 📚 Related Documentation
-
-- **[Security Model](../architecture/security/security-model.md)** — Security model and authentication
-- **[Specs: Security Compliance](../specs/security-compliance.md)** — Security profiles (STANDARD, REGULATED, RESTRICTED)
-- **[Guides: Production Deployment](../guides/production-deployment.md)** — Security hardening checklist
+1. Start with [audit-logging.md](./audit-logging.md).
+2. Review security profiles in [Specs: Security Compliance](../specs/security-compliance.md).
+3. Understand RBAC enforcement in [rbac.md](./rbac.md).
 
 ---
 
-## ✅ Compliance Standards Supported
+## Related Documentation
 
-- **GDPR** — Data protection and privacy
-- **SOC 2** — Security, availability, confidentiality
-- **NIS2** — EU cybersecurity directive
-- **HIPAA** — Healthcare data protection (with proper configuration)
-- **PCI DSS** — Payment card data security (with proper configuration)
+- **[Security Model](../architecture/security/security-model.md)** — Security model and authentication.
+- **[Specs: Security Compliance](../specs/security-compliance.md)** — Security profiles (STANDARD, REGULATED, RESTRICTED).
+- **[Guides: Production Deployment](../guides/production-deployment.md)** — Security hardening checklist.
 
 ---
 
-**Back to:** [Documentation Home](../README.md)
+## Compliance Standards Supported
+
+- **GDPR** — Data protection and privacy.
+- **SOC 2** — Security, availability, confidentiality.
+- **NIS2** — EU cybersecurity directive.
+- **HIPAA** — Healthcare data protection (with proper configuration).
+- **PCI DSS** — Payment card data security (with proper configuration).
+
+---
+
+**Back to:** [Documentation Home](../index.md)
+</content>
+</invoke>

--- a/docs/enterprise/audit-logging.md
+++ b/docs/enterprise/audit-logging.md
@@ -10,7 +10,6 @@ tags: ["documentation", "reference"]
 # Enterprise Audit Logging Documentation
 
 **Status:** ✅ Production Ready
-**Version:** FraiseQL v2.0.0-alpha.1+
 **Topic**: Audit Event Logging & Chain Verification
 **Performance**: ~1ms per event (Rust FFI), ~5-10ms (Python fallback)
 
@@ -35,8 +34,7 @@ FraiseQL's Enterprise Audit Logging system provides:
 ### Basic Setup
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.enterprise.audit import AuditEventLogger
+from fraiseql.enterprise.audit import AuditEventLogger
 
 # Initialize at application startup
 audit_logger = AuditEventLogger(
@@ -44,13 +42,11 @@ audit_logger = AuditEventLogger(
     connection_string="postgresql://user:pass@host/db",
     use_rust=True  # Prefer Rust FFI (faster)
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Logging Events
 
 ```python
-<!-- Code example in Python -->
 # Log a mutation completion
 event_id = await audit_logger.log_event(
     tenant_id="tenant-123",
@@ -69,14 +65,12 @@ event_id = await audit_logger.log_event(
     event_type="auth.login",
     ip_address="203.0.113.1"
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Querying Audit Events
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.enterprise.audit import AuditEventFilter
+from fraiseql.enterprise.audit import AuditEventFilter
 
 # Get recent events
 events, total = await audit_logger.get_events(
@@ -90,13 +84,11 @@ events, total = await audit_logger.get_events(
 
 for event in events:
     print(f"{event.created_at} {event.event_type}: {event.user_id}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Verifying Chain Integrity
 
 ```python
-<!-- Code example in Python -->
 # Verify cryptographic chain
 result = await audit_logger.verify_chain(
     tenant_id="tenant-123"
@@ -107,8 +99,7 @@ if result.is_valid:
 else:
     print(f"Chain broken at event {result.broken_at_index}")
     print(f"Error: {result.error_message}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -119,7 +110,6 @@ else:
 Each audit event captures comprehensive change information:
 
 ```python
-<!-- Code example in Python -->
 @strawberry.type
 class AuditEvent:
     # Identity
@@ -155,15 +145,13 @@ class AuditEvent:
 
     # Metadata
     created_at: datetime      # Immutable timestamp
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Debezium-Compatible Format
 
 FraiseQL audit events follow Debezium CDC format:
 
 ```python
-<!-- Code example in Python -->
 @strawberry.type
 class DebeziumEvent:
     """
@@ -176,13 +164,11 @@ class DebeziumEvent:
     source: dict           # Source metadata
     op: str                # Operation: c/r/u/d
     ts_ms: int             # Timestamp in milliseconds
-```text
-<!-- Code example in TEXT -->
+```
 
 **Example**:
 
 ```json
-<!-- Code example in JSON -->
 {
   "before": {
     "id": "user-123",
@@ -203,15 +189,13 @@ class DebeziumEvent:
   "op": "u",
   "ts_ms": 1705000000000
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Cryptographic Chain
 
 FraiseQL maintains an immutable cryptographic chain:
 
 ```text
-<!-- Code example in TEXT -->
 Event 1
 ├─ event_hash: SHA256(event_data)
 ├─ previous_hash: NULL (first event)
@@ -226,8 +210,7 @@ Event 3
 ├─ event_hash: SHA256(event_data)
 ├─ previous_hash: Event2.event_hash
 └─ signature: HMAC(event_hash, secret_key)
-```text
-<!-- Code example in TEXT -->
+```
 
 **Chain Verification**:
 
@@ -302,7 +285,6 @@ FraiseQL supports 40+ event types across all operations:
 ### Log Events
 
 ```python
-<!-- Code example in Python -->
 # Basic event
 event_id = await audit_logger.log_event(
     tenant_id="tenant-123",
@@ -333,13 +315,11 @@ event_id = await audit_logger.log_event(
     duration_ms=78.5,
     result_size_bytes=2048
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Query Events
 
 ```python
-<!-- Code example in Python -->
 # Get recent events for a tenant
 events, total = await audit_logger.get_events(
     tenant_id="tenant-123"
@@ -372,13 +352,11 @@ events, total = await audit_logger.get_events(
         start_time=datetime.now() - timedelta(days=7)
     )
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Verify Chain Integrity
 
 ```python
-<!-- Code example in Python -->
 # Verify cryptographic chain
 result = await audit_logger.verify_chain(
     tenant_id="tenant-123"
@@ -391,8 +369,7 @@ print(f"Verified events: {result.verified_events}")
 if not result.is_valid:
     print(f"Break at event {result.broken_at_index}")
     print(f"Error: {result.error_message}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -401,7 +378,6 @@ if not result.is_valid:
 ### QueryEventData
 
 ```python
-<!-- Code example in Python -->
 @strawberry.input
 class QueryEventData:
     query_hash: str
@@ -410,13 +386,11 @@ class QueryEventData:
     query_depth: int
     query_complexity: int
     query_fields_count: int
-```text
-<!-- Code example in TEXT -->
+```
 
 ### MutationEventData
 
 ```python
-<!-- Code example in Python -->
 @strawberry.input
 class MutationEventData:
     mutation_hash: str
@@ -424,13 +398,11 @@ class MutationEventData:
     variables: dict | None
     changes_count: int
     affected_tables: list[str]
-```text
-<!-- Code example in TEXT -->
+```
 
 ### QueryCompletionEventData
 
 ```python
-<!-- Code example in Python -->
 @strawberry.input
 class QueryCompletionEventData:
     query_hash: str
@@ -438,13 +410,11 @@ class QueryCompletionEventData:
     field_count: int
     cache_hit: bool
     result_size_bytes: int
-```text
-<!-- Code example in TEXT -->
+```
 
 ### AuthenticationEventData
 
 ```python
-<!-- Code example in Python -->
 @strawberry.input
 class AuthenticationEventData:
     auth_method: str  # "oauth", "jwt", "session", "mfa"
@@ -453,13 +423,11 @@ class AuthenticationEventData:
     user_agent: str | None
     success: bool
     failure_reason: str | None
-```text
-<!-- Code example in TEXT -->
+```
 
 ### SecurityViolationEventData
 
 ```python
-<!-- Code example in Python -->
 @strawberry.input
 class SecurityViolationEventData:
     violation_type: str  # "injection", "xss", "csrfblocked"
@@ -467,8 +435,7 @@ class SecurityViolationEventData:
     ip_address: str
     user_id: str | None
     details: dict
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -477,8 +444,7 @@ class SecurityViolationEventData:
 ### Automatic Event Logging Middleware
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.enterprise.audit.middleware import create_audit_middleware
+from fraiseql.enterprise.audit.middleware import create_audit_middleware
 
 # Add audit logging middleware
 schema = strawberry.Schema(
@@ -486,8 +452,7 @@ schema = strawberry.Schema(
     mutation=Mutation,
     extensions=[create_audit_middleware(audit_logger=audit_logger)]
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 **Automatically logs**:
 
@@ -500,8 +465,7 @@ schema = strawberry.Schema(
 ### Manual Event Logging
 
 ```python
-<!-- Code example in Python -->
-import strawberry
+from fraiseql.strawberry_compat import strawberry
 
 @strawberry.mutation
 async def publish_post(
@@ -523,8 +487,7 @@ async def publish_post(
     )
 
     return post
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -542,7 +505,6 @@ Audit events are **immutable**:
 **Database enforcement**:
 
 ```sql
-<!-- Code example in SQL -->
 -- Audit table is append-only
 CREATE TABLE audit_events (
     id UUID PRIMARY KEY,
@@ -557,13 +519,11 @@ CREATE TRIGGER audit_immutable
 BEFORE UPDATE OR DELETE ON audit_events
 FOR EACH ROW
 RAISE EXCEPTION 'Audit events are immutable';
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Retention Policies
 
 ```python
-<!-- Code example in Python -->
 # Configure retention
 config = AuditConfig(
     retention_days=90,           # Keep 90 days of events
@@ -577,13 +537,11 @@ archived = await audit_logger.archive_events(
     before_date=datetime.now() - timedelta(days=90),
     destination="s3://archive-bucket/audit/"
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Compliance Reporting
 
 ```python
-<!-- Code example in Python -->
 # Generate compliance report
 report = await audit_logger.generate_compliance_report(
     tenant_id="tenant-123",
@@ -597,8 +555,7 @@ print(f"Mutations: {report.mutation_count}")
 print(f"Auth events: {report.auth_count}")
 print(f"Security violations: {report.violation_count}")
 print(f"Chain valid: {report.chain_verification.is_valid}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -609,7 +566,6 @@ print(f"Chain valid: {report.chain_verification.is_valid}")
 Log query and mutation performance:
 
 ```python
-<!-- Code example in Python -->
 event_id = await audit_logger.log_event(
     tenant_id="tenant-123",
     user_id="user-456",
@@ -621,15 +577,13 @@ event_id = await audit_logger.log_event(
     duration_ms=45.3,
     result_size_bytes=4096
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Performance Analytics
 
 ```python
-<!-- Code example in Python -->
 # Get slow queries
-from FraiseQL.enterprise.audit import AuditEventFilter
+from fraiseql.enterprise.audit import AuditEventFilter
 
 slow_queries = await audit_logger.get_events(
     tenant_id="tenant-123",
@@ -644,13 +598,11 @@ for event in slow_queries:
     print(f"Query: {event.query_hash}")
     print(f"Duration: {event.duration_ms}ms")
     print(f"Complexity: {event.query_complexity}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Query Complexity Distribution
 
 ```python
-<!-- Code example in Python -->
 # Analyze query complexity
 report = await audit_logger.get_complexity_report(
     tenant_id="tenant-123",
@@ -660,8 +612,7 @@ report = await audit_logger.get_complexity_report(
 print(f"Avg complexity: {report.avg_complexity}")
 print(f"Max complexity: {report.max_complexity}")
 print(f"Queries > 100: {report.high_complexity_count}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -670,7 +621,6 @@ print(f"Queries > 100: {report.high_complexity_count}")
 ### User Activity Audit
 
 ```python
-<!-- Code example in Python -->
 # Get all activities for a specific user
 events, total = await audit_logger.get_events(
     tenant_id="tenant-123",
@@ -682,13 +632,11 @@ events, total = await audit_logger.get_events(
 
 for event in events:
     print(f"{event.created_at} {event.event_type}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Failed Authentication Detection
 
 ```python
-<!-- Code example in Python -->
 # Find suspicious failed login patterns
 failed_logins = await audit_logger.get_events(
     tenant_id="tenant-123",
@@ -704,13 +652,11 @@ ips = Counter(e.ip_address for e in failed_logins)
 for ip, count in ips.most_common(10):
     if count > 5:
         print(f"Alert: {count} failed logins from {ip}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Data Access Audit
 
 ```python
-<!-- Code example in Python -->
 # Track who accessed sensitive data
 sensitive_queries = await audit_logger.get_events(
     tenant_id="tenant-123",
@@ -723,13 +669,11 @@ sensitive_queries = await audit_logger.get_events(
 for event in sensitive_queries:
     print(f"User {event.user_id} accessed sensitive data at {event.created_at}")
     print(f"From IP: {event.ip_address}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Configuration Change Tracking
 
 ```python
-<!-- Code example in Python -->
 # Find all configuration changes
 config_changes = await audit_logger.get_events(
     tenant_id="tenant-123",
@@ -743,8 +687,7 @@ for event in config_changes:
     print(f"Changed by: {event.user_id}")
     print(f"Before: {event.before_data}")
     print(f"After: {event.after_data}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -755,7 +698,6 @@ for event in config_changes:
 Run chain verification periodically (e.g., daily):
 
 ```python
-<!-- Code example in Python -->
 # Daily verification task
 async def verify_audit_chain_daily():
     tenants = await get_all_tenants()
@@ -776,8 +718,7 @@ async def verify_audit_chain_daily():
                 verified_count=result.verified_events,
                 total_count=result.total_events
             )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Chain Repair
 
@@ -825,7 +766,6 @@ If tampering is detected:
 Always include full context:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Full context
 await audit_logger.log_event(
     tenant_id=tenant_id,
@@ -843,15 +783,13 @@ await audit_logger.log_event(
     tenant_id=tenant_id,
     event_type="mutation.completed"
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 2. Use Rust FFI Mode
 
 Prefer Rust FFI for better performance:
 
 ```python
-<!-- Code example in Python -->
 # GOOD
 audit_logger = AuditEventLogger(
     repo=repo,
@@ -860,30 +798,26 @@ audit_logger = AuditEventLogger(
 )
 
 # Falls back to Python if Rust unavailable
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 3. Run Regular Verification
 
 Set up periodic chain verification:
 
 ```python
-<!-- Code example in Python -->
 # Daily verification
 scheduler.add_job(
     verify_audit_chain_daily,
     trigger="cron",
     hour=2  # 2 AM daily
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 4. Archive Old Events
 
 Archive events older than retention period:
 
 ```python
-<!-- Code example in Python -->
 # Monthly archive task
 scheduler.add_job(
     archive_old_events,
@@ -891,23 +825,20 @@ scheduler.add_job(
     day=1,  # First day of month
     hour=3
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 5. Monitor Chain Health
 
 Alert on chain breaks:
 
 ```python
-<!-- Code example in Python -->
 # Set up alert
 if not verification_result.is_valid:
     send_critical_alert(
         f"Audit chain integrity violation detected "
         f"at event {verification_result.broken_at_index}"
     )
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -918,39 +849,31 @@ if not verification_result.is_valid:
 1. Check event counts:
 
    ```sql
-<!-- Code example in SQL -->
    SELECT COUNT(*) FROM audit_events WHERE tenant_id = ?;
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 2. Inspect event at break point:
 
    ```sql
-<!-- Code example in SQL -->
    SELECT id, event_hash, previous_hash FROM audit_events
    WHERE tenant_id = ? AND created_at > ?
    ORDER BY created_at LIMIT 10;
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 3. Verify signatures:
 
    ```sql
-<!-- Code example in SQL -->
    SELECT id, signature FROM audit_events WHERE tenant_id = ?
    ORDER BY created_at DESC LIMIT 100;
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 ### High Event Logging Latency
 
 1. Check database:
 
    ```sql
-<!-- Code example in SQL -->
    EXPLAIN ANALYZE INSERT INTO audit_events (...);
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 2. Monitor Rust FFI:
    - Check if Rust library is loaded: `audit_logger.use_rust`
@@ -959,12 +882,10 @@ if not verification_result.is_valid:
 3. Consider batching:
 
    ```python
-<!-- Code example in Python -->
    # Batch multiple events
    events = [...]
    await audit_logger.batch_log_events(events)
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 ---
 

--- a/docs/enterprise/kms.md
+++ b/docs/enterprise/kms.md
@@ -10,7 +10,6 @@ tags: ["documentation", "reference"]
 # Key Management Service (KMS) Documentation
 
 **Status:** ✅ Production Ready
-**Version:** FraiseQL v2.0.0-alpha.1+
 **Topic**: Encryption Key Management
 **Performance**: Microseconds (local), 50-200ms (per-request KMS)
 
@@ -35,8 +34,7 @@ FraiseQL's Key Management Service provides unified encryption/decryption across 
 ### Vault Setup (Recommended)
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.security.kms import KeyManager, VaultKMSProvider, VaultConfig
+from fraiseql.security.kms import KeyManager, VaultKMSProvider, VaultConfig
 
 # Configure Vault provider
 vault_config = VaultConfig(
@@ -55,14 +53,12 @@ key_manager = KeyManager(
 
 # Initialize (generates cached data key)
 await key_manager.initialize()
-```text
-<!-- Code example in TEXT -->
+```
 
 ### AWS KMS Setup
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.security.kms import KeyManager, AWSKMSProvider, AWSKMSConfig
+from fraiseql.security.kms import KeyManager, AWSKMSProvider, AWSKMSConfig
 
 # Configure AWS KMS
 aws_config = AWSKMSConfig(
@@ -78,14 +74,12 @@ key_manager = KeyManager(
 )
 
 await key_manager.initialize()
-```text
-<!-- Code example in TEXT -->
+```
 
 ### GCP Cloud KMS Setup
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.security.kms import KeyManager, GCPKMSProvider, GCPKMSConfig
+from fraiseql.security.kms import KeyManager, GCPKMSProvider, GCPKMSConfig
 
 # Configure GCP KMS
 gcp_config = GCPKMSConfig(
@@ -102,13 +96,11 @@ key_manager = KeyManager(
 )
 
 await key_manager.initialize()
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Using KMS in GraphQL
 
 ```python
-<!-- Code example in Python -->
 # Add to GraphQL context
 async def get_context() -> dict:
     return {
@@ -129,8 +121,7 @@ async def create_user(
     )
 
     return create_user_record(email, encrypted_password)
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -145,7 +136,6 @@ FraiseQL KMS supports two distinct patterns depending on your security needs:
 **Best for**: High-throughput applications, response data encryption
 
 ```python
-<!-- Code example in Python -->
 # At startup: Contact KMS once to get data key
 await key_manager.initialize()
 
@@ -155,8 +145,7 @@ decrypted = key_manager.local_decrypt(encrypted)  # Microseconds
 
 # Periodically: Rotate the data key
 scheduler.add_job(key_manager.rotate_data_key, trigger="interval", hours=1)
-```text
-<!-- Code example in TEXT -->
+```
 
 **Performance**:
 
@@ -168,19 +157,16 @@ scheduler.add_job(key_manager.rotate_data_key, trigger="interval", hours=1)
 **Envelope Encryption**:
 
 ```text
-<!-- Code example in TEXT -->
 KMS stores: Master key (never leaves KMS)
 Application stores: Data key (AES-256) encrypted by master key
 Application RAM: Decrypted data key (for current hour)
-```text
-<!-- Code example in TEXT -->
+```
 
 #### Pattern 2: Per-Request KMS (High Security)
 
 **Best for**: Secrets management, high-security keys, rare encryption
 
 ```python
-<!-- Code example in Python -->
 # Every request: Contact KMS for encryption
 encrypted = await key_manager.encrypt(
     plaintext,
@@ -190,8 +176,7 @@ encrypted = await key_manager.encrypt(
 
 # Decryption with context
 plaintext = await key_manager.decrypt(encrypted, context={"purpose": "api_key_encryption"})
-```text
-<!-- Code example in TEXT -->
+```
 
 **Performance**:
 
@@ -210,7 +195,6 @@ plaintext = await key_manager.decrypt(encrypted, context={"purpose": "api_key_en
 FraiseQL uses **AES-256-GCM** for local encryption:
 
 ```text
-<!-- Code example in TEXT -->
 Plaintext
     ↓
 Generate random 96-bit nonce
@@ -222,8 +206,7 @@ Compute authentication tag (128-bit)
 Serialize: nonce + ciphertext + auth_tag
     ↓
 Encrypted data
-```text
-<!-- Code example in TEXT -->
+```
 
 **Security Properties**:
 
@@ -241,8 +224,7 @@ Encrypted data
 **Best for**: Self-hosted, multi-cloud, fine-grained access control
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.security.kms import VaultConfig, VaultKMSProvider
+from fraiseql.security.kms import VaultConfig, VaultKMSProvider
 
 config = VaultConfig(
     vault_addr="https://vault.example.com:8200",
@@ -254,13 +236,11 @@ config = VaultConfig(
 )
 
 provider = VaultKMSProvider(config)
-```text
-<!-- Code example in TEXT -->
+```
 
 **Vault Setup** (one-time):
 
 ```bash
-<!-- Code example in BASH -->
 # Enable transit secrets engine
 vault secrets enable transit
 
@@ -283,8 +263,7 @@ EOF
 # Generate AppRole credentials
 vault auth enable approle
 vault write auth/approle/role/app policies="app"
-```text
-<!-- Code example in TEXT -->
+```
 
 **Authentication Methods**:
 
@@ -297,8 +276,7 @@ vault write auth/approle/role/app policies="app"
 **Best for**: AWS-native deployments, AWS IAM integration
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.security.kms import AWSKMSConfig, AWSKMSProvider
+from fraiseql.security.kms import AWSKMSConfig, AWSKMSProvider
 
 config = AWSKMSConfig(
     region="us-east-1",
@@ -308,23 +286,19 @@ config = AWSKMSConfig(
 )
 
 provider = AWSKMSProvider(config)
-```text
-<!-- Code example in TEXT -->
+```
 
 **Key ID Formats**:
 
 ```text
-<!-- Code example in TEXT -->
 arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 alias/my-encryption-key
 12345678-1234-1234-1234-123456789012
-```text
-<!-- Code example in TEXT -->
+```
 
 **Permissions Required**:
 
 ```json
-<!-- Code example in JSON -->
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -340,16 +314,14 @@ alias/my-encryption-key
     }
   ]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### GCP Cloud KMS
 
 **Best for**: GCP-native deployments, multi-region
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.security.kms import GCPKMSConfig, GCPKMSProvider
+from fraiseql.security.kms import GCPKMSConfig, GCPKMSProvider
 
 config = GCPKMSConfig(
     project_id="my-project",
@@ -360,32 +332,27 @@ config = GCPKMSConfig(
 )
 
 provider = GCPKMSProvider(config)
-```text
-<!-- Code example in TEXT -->
+```
 
 **Key ID Format**:
 
 ```text
-<!-- Code example in TEXT -->
 projects/my-project/locations/global/keyRings/my-keyring/cryptoKeys/my-key
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Local Development KMS
 
 **Best for**: Development, testing (not production!)
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.security.kms import LocalKMSConfig, LocalKMSProvider
+from fraiseql.security.kms import LocalKMSConfig, LocalKMSProvider
 
 config = LocalKMSConfig(
     master_key=b"development-master-key-32-bytes!"  # 32-byte key
 )
 
 provider = LocalKMSProvider(config)
-```text
-<!-- Code example in TEXT -->
+```
 
 **Warning**: Local KMS stores everything in-memory and is NOT suitable for production!
 
@@ -398,7 +365,6 @@ provider = LocalKMSProvider(config)
 Immutable reference to a key:
 
 ```python
-<!-- Code example in Python -->
 @dataclass(frozen=True)
 class KeyReference:
     provider: str              # "vault", "aws", "gcp"
@@ -410,15 +376,13 @@ class KeyReference:
     @property
     def qualified_id(self) -> str:
         return f"{provider}:{key_id}"
-```text
-<!-- Code example in TEXT -->
+```
 
 ### EncryptedData
 
 Immutable encrypted data with metadata:
 
 ```python
-<!-- Code example in Python -->
 @dataclass(frozen=True)
 class EncryptedData:
     ciphertext: bytes           # Encrypted data (nonce + ciphertext + tag)
@@ -439,37 +403,32 @@ class EncryptedData:
             "encrypted_at": self.encrypted_at.isoformat(),
             "context": self.context
         }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### DataKeyPair
 
 For envelope encryption:
 
 ```python
-<!-- Code example in Python -->
 @dataclass(frozen=True)
 class DataKeyPair:
     plaintext_key: bytes        # Use immediately, never persist
     encrypted_key: EncryptedData # Persist alongside data
     key_reference: KeyReference
-```text
-<!-- Code example in TEXT -->
+```
 
 ### RotationPolicy
 
 Key rotation configuration:
 
 ```python
-<!-- Code example in Python -->
 @dataclass(frozen=True)
 class RotationPolicy:
     enabled: bool
     rotation_period_days: int
     last_rotation: datetime | None
     next_rotation: datetime | None
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -478,32 +437,27 @@ class RotationPolicy:
 ### Initialization
 
 ```python
-<!-- Code example in Python -->
 # Generate cached data key via KMS
 await key_manager.initialize()
 
 # Check if initialized
 if key_manager.is_initialized:
     print("Ready to encrypt/decrypt")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Hot-Path Encryption (No KMS)
 
 ```python
-<!-- Code example in Python -->
 # Encrypt with cached key (microseconds)
 encrypted_bytes = key_manager.local_encrypt(plaintext_bytes)
 
 # Decrypt with cached key (microseconds)
 plaintext_bytes = key_manager.local_decrypt(encrypted_bytes)
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Per-Request Encryption (With KMS)
 
 ```python
-<!-- Code example in Python -->
 # Encrypt via KMS
 encrypted_data = await key_manager.encrypt(
     plaintext=secret_string.encode(),
@@ -520,13 +474,11 @@ db.save(encrypted_data.to_dict())
 
 # Decrypt via KMS (reads key_reference from encrypted_data)
 plaintext = await key_manager.decrypt(encrypted_data)
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Field Encryption
 
 ```python
-<!-- Code example in Python -->
 # Encrypt a field
 encrypted_password = await key_manager.encrypt_field(
     value="my-password",
@@ -539,13 +491,11 @@ password = await key_manager.decrypt_field(
     encrypted_password,
     field_type="text"
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Key Rotation
 
 ```python
-<!-- Code example in Python -->
 # Rotate the cached data key (background task)
 await key_manager.rotate_data_key()
 
@@ -559,13 +509,11 @@ scheduler.add_job(
 # Get rotation status
 policy = key_manager.get_rotation_policy()
 print(f"Next rotation: {policy.next_rotation}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Generate Data Key Pair
 
 ```python
-<!-- Code example in Python -->
 # For envelope encryption
 key_pair = await key_manager.generate_data_key(
     key_id="master-key",
@@ -580,8 +528,7 @@ db.save(encrypted_key=key_pair.encrypted_key)
 
 # Later: Decrypt to get plaintext_key again
 decrypted_key = await key_manager.decrypt(key_pair.encrypted_key)
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -605,7 +552,6 @@ decrypted_key = await key_manager.decrypt(key_pair.encrypted_key)
 Vault is the recommended provider for production:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Vault with secure token rotation
 vault_provider = VaultKMSProvider(
     VaultConfig(
@@ -617,15 +563,13 @@ vault_provider = VaultKMSProvider(
 
 # BAD - Local KMS in production
 local_provider = LocalKMSProvider(...)  # Development only!
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 2. Rotate Keys Regularly
 
 Set up automated key rotation:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Hourly rotation
 scheduler.add_job(
     key_manager.rotate_data_key,
@@ -635,15 +579,13 @@ scheduler.add_job(
 
 # BAD - Manual or no rotation
 # (forgotten rotations = outdated keys)
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 3. Use Encryption Context
 
 Add additional authenticated data (AAD):
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Context for key derivation
 encrypted = await key_manager.encrypt(
     secret,
@@ -656,15 +598,13 @@ encrypted = await key_manager.encrypt(
 
 # BAD - No context (less secure)
 encrypted = await key_manager.encrypt(secret)
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 4. Separate Key Per Purpose
 
 Use different keys for different purposes:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Key per purpose
 api_key_encryption = await key_manager.encrypt(
     api_key,
@@ -678,15 +618,13 @@ password_hashing = await key_manager.encrypt(
 # BAD - Single key for everything
 secret = await key_manager.encrypt(api_key, key_id="universal-key")
 password = await key_manager.encrypt(password, key_id="universal-key")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 5. Never Log Plaintext Keys
 
 Prevent accidental key exposure:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Don't log secrets
 try:
     decrypted = await key_manager.decrypt(encrypted_data)
@@ -695,15 +633,13 @@ except DecryptionError as e:
 
 # BAD - Logs plaintext key
 logger.debug(f"Decrypted key: {decrypted_key}")  # SECURITY RISK!
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 6. Verify TLS Certificates
 
 Enable TLS verification for KMS:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - TLS verification enabled
 vault_config = VaultConfig(
     vault_addr="https://vault.example.com",
@@ -716,8 +652,7 @@ vault_config = VaultConfig(
     vault_addr="https://vault.example.com",
     tls_verify=False  # Security risk!
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -726,7 +661,6 @@ vault_config = VaultConfig(
 ### User Password Encryption
 
 ```python
-<!-- Code example in Python -->
 @strawberry.mutation
 async def register_user(
     info: strawberry.types.Info,
@@ -749,13 +683,11 @@ async def register_user(
     await db.save(user)
 
     return user
-```text
-<!-- Code example in TEXT -->
+```
 
 ### API Key Encryption
 
 ```python
-<!-- Code example in Python -->
 @strawberry.mutation
 async def generate_api_key(
     info: strawberry.types.Info,
@@ -783,8 +715,7 @@ async def generate_api_key(
 
     # Return plaintext key ONLY at creation time
     return ApiKeyResponse(api_key=api_key)
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -793,8 +724,7 @@ async def generate_api_key(
 FraiseQL KMS defines specific exceptions:
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.security.kms import (
+from fraiseql.security.kms import (
     KMSError,
     EncryptionError,
     DecryptionError,
@@ -814,8 +744,7 @@ except ProviderConnectionError:
 except EncryptionError as e:
     # General encryption failure
     logger.error(f"Encryption failed: {e}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -824,7 +753,6 @@ except EncryptionError as e:
 ### Vault Connection Issues
 
 ```python
-<!-- Code example in Python -->
 # Check connection
 try:
     await key_manager.initialize()
@@ -836,13 +764,11 @@ except ProviderConnectionError:
     # 2. Vault is running
     # 3. Network/firewall allows connection
     # 4. TLS certificate is valid
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Key Rotation Failures
 
 ```python
-<!-- Code example in Python -->
 # Monitor rotation status
 policy = key_manager.get_rotation_policy()
 
@@ -852,13 +778,11 @@ if policy.last_rotation is None:
 time_since_rotation = datetime.now() - policy.last_rotation
 if time_since_rotation > timedelta(hours=2):
     print("Rotation may be delayed")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Decryption Errors
 
 ```python
-<!-- Code example in Python -->
 # Common causes:
 # 1. Wrong key used
 # 2. Encrypted with different provider
@@ -872,8 +796,7 @@ except DecryptionError:
     print(f"Provider: {encrypted_data.key_reference.provider}")
     print(f"Algorithm: {encrypted_data.algorithm}")
     print(f"Context: {encrypted_data.context}")
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -884,21 +807,18 @@ except DecryptionError:
 If `initialize()` times out:
 
 ```python
-<!-- Code example in Python -->
 # Increase timeout
 key_manager = KeyManager(
     providers=providers,
     initialization_timeout=10  # 10 seconds
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Rotation Frequency
 
 Balance between security and performance:
 
 ```python
-<!-- Code example in Python -->
 # More frequent (more secure, slight overhead)
 scheduler.add_job(key_manager.rotate_data_key, trigger="interval", hours=1)
 
@@ -906,13 +826,11 @@ scheduler.add_job(key_manager.rotate_data_key, trigger="interval", hours=1)
 scheduler.add_job(key_manager.rotate_data_key, trigger="interval", hours=12)
 
 # Recommended: 1-4 hours for most applications
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Caching Strategy
 
 ```python
-<!-- Code example in Python -->
 # Cache encrypted API keys (reduces KMS calls)
 @cache.lru(maxsize=1000)
 async def get_api_key_decrypted(api_key_id):
@@ -921,8 +839,7 @@ async def get_api_key_decrypted(api_key_id):
 
 # Don't cache plaintext secrets (security risk)
 # Always decrypt on demand for passwords/tokens
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 

--- a/docs/enterprise/rbac.md
+++ b/docs/enterprise/rbac.md
@@ -10,7 +10,6 @@ tags: ["documentation", "reference"]
 # Enterprise RBAC Documentation
 
 **Status:** ✅ Production Ready
-**Version:** FraiseQL v2.0.0-alpha.1+
 **Topic**: Role-Based Access Control
 **Performance**: <0.5ms cached, <100ms uncached
 
@@ -35,9 +34,8 @@ FraiseQL's Enterprise Role-Based Access Control (RBAC) system provides:
 ### Basic Setup
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.enterprise.rbac import setup_rbac_cache
-from FraiseQL.enterprise.rbac import PermissionResolver
+from fraiseql.enterprise.rbac import setup_rbac_cache
+from fraiseql.enterprise.rbac import PermissionResolver
 
 # At application startup
 async def app_startup(db_pool):
@@ -46,14 +44,12 @@ async def app_startup(db_pool):
 
     # Create permission resolver
     resolver = PermissionResolver(db_pool)
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Using in GraphQL
 
 ```python
-<!-- Code example in Python -->
-from FraiseQL.enterprise.rbac.middleware import create_rbac_middleware
+from fraiseql.enterprise.rbac.middleware import create_rbac_middleware
 
 # Add RBAC middleware to GraphQL schema
 schema = strawberry.Schema(
@@ -61,15 +57,13 @@ schema = strawberry.Schema(
     mutation=Mutation,
     extensions=[create_rbac_middleware(permission_resolver=resolver)]
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Field-Level Authorization
 
 ```python
-<!-- Code example in Python -->
-import strawberry
-from FraiseQL.enterprise.rbac.directives import requires_permission, requires_role
+from fraiseql.strawberry_compat import strawberry
+from fraiseql.enterprise.rbac.directives import requires_permission, requires_role
 
 @strawberry.type
 class User:
@@ -85,8 +79,7 @@ class User:
     def salary(self) -> float:
         """Only admins can see salary"""
         return self.salary_value
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -97,7 +90,6 @@ class User:
 FraiseQL supports hierarchical role inheritance where roles can inherit from parent roles.
 
 ```text
-<!-- Code example in TEXT -->
 ┌─────────────┐
 │   System    │  (root role)
 └──────┬──────┘
@@ -111,8 +103,7 @@ FraiseQL supports hierarchical role inheritance where roles can inherit from par
 ┌──▼─────┐
 │Manager  │
 └─────────┘
-```text
-<!-- Code example in TEXT -->
+```
 
 **Key Concepts**:
 
@@ -140,7 +131,6 @@ FraiseQL supports hierarchical role inheritance where roles can inherit from par
 **Cache Invalidation**:
 
 ```text
-<!-- Code example in TEXT -->
 User modifies permission
        ↓
 domain_version incremented
@@ -148,15 +138,13 @@ domain_version incremented
 All cached permissions with old version invalidated
        ↓
 Next request checks version, refreshes if needed
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Domain Versioning
 
 FraiseQL uses domain versioning for automatic cache invalidation:
 
 ```sql
-<!-- Code example in SQL -->
 -- Each domain has a version
 SELECT version FROM domain_versions WHERE domain = 'role';
 
@@ -169,8 +157,7 @@ WHERE domain = 'role';
 SELECT * FROM permission_cache
 WHERE user_id = ?
   AND version = (SELECT version FROM domain_versions WHERE domain = 'role');
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -181,7 +168,6 @@ WHERE user_id = ?
 A role represents a set of permissions within your system.
 
 ```python
-<!-- Code example in Python -->
 @strawberry.type
 class Role:
     id: strawberry.ID
@@ -192,8 +178,7 @@ class Role:
     tenant_id: strawberry.ID | None  # Multi-tenancy support
     created_at: datetime
     updated_at: datetime
-```text
-<!-- Code example in TEXT -->
+```
 
 **System Roles** (predefined):
 
@@ -211,7 +196,6 @@ class Role:
 A permission is a pairing of **resource** and **action**.
 
 ```python
-<!-- Code example in Python -->
 @strawberry.type
 class Permission:
     id: strawberry.ID
@@ -219,38 +203,32 @@ class Permission:
     action: str    # e.g., "create", "read", "update", "delete"
     description: str | None
     constraints: dict | None  # Optional JSONB constraints
-```text
-<!-- Code example in TEXT -->
+```
 
 **Standard Permissions**:
 
 ```text
-<!-- Code example in TEXT -->
 user.create, user.read, user.update, user.delete
 product.create, product.read, product.update, product.delete
 order.create, order.read, order.update, order.delete
-```text
-<!-- Code example in TEXT -->
+```
 
 **Constraints** (optional JSONB):
 
 ```json
-<!-- Code example in JSON -->
 {
   "own_data_only": true,
   "max_records": 1000,
   "time_restricted": "9-17",
   "department_only": "engineering"
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### User Roles
 
 Assignment of roles to users, with optional expiration.
 
 ```python
-<!-- Code example in Python -->
 @strawberry.type
 class UserRole:
     id: strawberry.ID
@@ -260,8 +238,7 @@ class UserRole:
     expires_at: datetime | None
     granted_by: strawberry.ID  # Who granted this role
     created_at: datetime
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -270,7 +247,6 @@ class UserRole:
 ### How Permissions Are Resolved
 
 ```text
-<!-- Code example in TEXT -->
 User Request
     ↓
 Check request-level cache
@@ -286,13 +262,11 @@ Check request-level cache
 
 Total uncached: 2-15ms (depends on hierarchy depth)
 Total cached: < 0.5ms
-```text
-<!-- Code example in TEXT -->
+```
 
 ### API Methods
 
 ```python
-<!-- Code example in Python -->
 # Get all permissions for a user
 permissions = await resolver.get_user_permissions(
     user_id="user-123",
@@ -326,8 +300,7 @@ perms = await resolver.get_role_permissions(
     role_id="role-789",
     include_inherited=True
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -336,7 +309,6 @@ perms = await resolver.get_role_permissions(
 ### Creating Role Hierarchies
 
 ```python
-<!-- Code example in Python -->
 # Define roles via GraphQL mutations
 mutation CreateRoles {
   # Create system admin role
@@ -358,13 +330,11 @@ mutation CreateRoles {
     id
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 **Inheritance Chain**:
 
 ```text
-<!-- Code example in TEXT -->
 admin (system role)
   ↑
 user (system role)
@@ -374,8 +344,7 @@ sales_team
 sales_manager
   ↑
 sales_director
-```text
-<!-- Code example in TEXT -->
+```
 
 A `sales_director` inherits all permissions from:
 
@@ -388,7 +357,6 @@ A `sales_director` inherits all permissions from:
 ### Assigning Roles to Users
 
 ```python
-<!-- Code example in Python -->
 mutation AssignRole {
   assignRoleToUser(
     userId: "user-123"
@@ -408,15 +376,13 @@ mutation AssignRole {
     expiresAt
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 **Expiration**: Optional time-based role revocation.
 
 ### Querying Role Hierarchy
 
 ```python
-<!-- Code example in Python -->
 query GetRoleHierarchy {
   role(id: "role-789") {
     id
@@ -444,8 +410,7 @@ query GetRoleHierarchy {
     }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -458,7 +423,6 @@ FraiseQL provides GraphQL directives for field-level access control.
 #### `@requires_permission` Directive
 
 ```python
-<!-- Code example in Python -->
 @strawberry.type
 class User:
     id: strawberry.ID
@@ -473,8 +437,7 @@ class User:
     def salary(self) -> float:
         """Only accessible to users with user:read_salary permission"""
         return self.salary_value
-```text
-<!-- Code example in TEXT -->
+```
 
 **Behavior**:
 
@@ -485,7 +448,6 @@ class User:
 #### `@requires_role` Directive
 
 ```python
-<!-- Code example in Python -->
 @strawberry.type
 class Product:
     id: strawberry.ID
@@ -500,8 +462,7 @@ class Product:
     def margin(self) -> float:
         """Only sales managers can see margin"""
         return (self.price - self.cost) / self.price
-```text
-<!-- Code example in TEXT -->
+```
 
 **Behavior**:
 
@@ -514,7 +475,6 @@ class Product:
 When a user doesn't have permission for a field:
 
 ```graphql
-<!-- Code example in GraphQL -->
 query {
   user(id: "user-123") {
     id        # ✓ Always included
@@ -523,13 +483,11 @@ query {
     salary    # ✗ HIDDEN - user lacks "user:read_salary"
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 **Response**:
 
 ```json
-<!-- Code example in JSON -->
 {
   "data": {
     "user": {
@@ -544,8 +502,7 @@ query {
     "path": ["user", "email"]
   }]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -556,9 +513,8 @@ query {
 Row-level security automatically filters query results based on user permissions.
 
 ```python
-<!-- Code example in Python -->
 # Install Rust row constraint resolver
-from FraiseQL.enterprise.rbac.rust_row_constraints import RustRowConstraintResolver
+from fraiseql.enterprise.rbac.rust_row_constraints import RustRowConstraintResolver
 
 row_resolver = RustRowConstraintResolver(
     db_pool=db_pool,
@@ -571,15 +527,13 @@ schema = strawberry.Schema(
     mutation=Mutation,
     extensions=[create_rbac_middleware(row_constraint_resolver=row_resolver)]
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Row Constraints
 
 Define what rows each role can access:
 
 ```python
-<!-- Code example in Python -->
 # Example: Employees can only see their own data
 constraint = RowConstraint(
     role_id="employee",
@@ -593,8 +547,7 @@ constraint = RowConstraint(
     table_name="employees",
     where_clause="department_id = (SELECT department_id FROM users WHERE id = current_user_id)"
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Performance
 
@@ -607,7 +560,6 @@ Row constraint checking with Rust FFI:
 **Example Query**:
 
 ```graphql
-<!-- Code example in GraphQL -->
 query {
   users {
     id
@@ -615,18 +567,15 @@ query {
     salary  # Only included if has permission
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 **Behind the scenes**:
 
 ```sql
-<!-- Code example in SQL -->
 SELECT id, name, salary
 FROM users
 WHERE department_id = ? -- Automatically added by Rust resolver
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -637,7 +586,6 @@ WHERE department_id = ? -- Automatically added by Rust resolver
 Each role can be scoped to a tenant:
 
 ```python
-<!-- Code example in Python -->
 # Global role (NULL tenant_id)
 role = {
     "id": "role-1",
@@ -653,13 +601,11 @@ role = {
     "tenant_id": "tenant-123",
     "permissions": [...]
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Permission Resolution with Tenants
 
 ```python
-<!-- Code example in Python -->
 # Get permissions scoped to tenant
 permissions = await resolver.get_user_permissions(
     user_id="user-123",
@@ -673,8 +619,7 @@ await resolver.check_permission(
     action="read",
     tenant_id="tenant-456"  # Tenant isolation
 )
-```text
-<!-- Code example in TEXT -->
+```
 
 **Isolation**:
 
@@ -689,7 +634,6 @@ await resolver.check_permission(
 ### Creating Roles
 
 ```graphql
-<!-- Code example in GraphQL -->
 mutation {
   createRole(
     name: "content_manager"
@@ -702,13 +646,11 @@ mutation {
     parentRole { id name }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Assigning Permissions
 
 ```graphql
-<!-- Code example in GraphQL -->
 mutation {
   grantPermissionToRole(
     roleId: "role-456"
@@ -720,13 +662,11 @@ mutation {
     permission { resource action }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Managing User Roles
 
 ```graphql
-<!-- Code example in GraphQL -->
 mutation {
   assignRoleToUser(
     userId: "user-123"
@@ -750,8 +690,7 @@ mutation {
     success
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -792,7 +731,6 @@ mutation {
 Always reuse resolved permissions within a request:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Single resolution
 user_permissions = await resolver.get_user_permissions(user_id)
 has_create = "resource:create" in user_permissions
@@ -803,15 +741,13 @@ has_update = "resource:update" in user_permissions
 has_create = await resolver.has_permission(user_id, "resource", "create")
 has_read = await resolver.has_permission(user_id, "resource", "read")
 has_update = await resolver.has_permission(user_id, "resource", "update")
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 2. Use Domain Versioning
 
 Domain versioning automatically handles cache invalidation - don't manually clear caches:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Let domain versioning handle invalidation
 mutation {
   createRole(name: "new_role") {
@@ -822,30 +758,26 @@ mutation {
 
 # BAD - Manual cache management
 cache.invalidate_all()  # Throws away valid data
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 3. Prefer Inheritance Over Duplication
 
 Build role hierarchies rather than copying permissions:
 
 ```python
-<!-- Code example in Python -->
 # GOOD - Inheritance
 user → team_lead → team_manager → director
 
 # BAD - Duplication
 user (has all permissions copied)
 team_lead (has all same permissions again)
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 4. Set Expiration Dates
 
 Use role expiration for temporary assignments:
 
 ```graphql
-<!-- Code example in GraphQL -->
 mutation {
   assignRoleToUser(
     userId: "contractor-123"
@@ -855,20 +787,17 @@ mutation {
     id
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### 5. Audit Role Changes
 
 Log who made what changes:
 
 ```python
-<!-- Code example in Python -->
 # Automatically captured in audit logging
 granted_by: "admin-user-456"  # Who granted the role
 created_at: "2025-01-11T10:30:00Z"
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -879,7 +808,6 @@ created_at: "2025-01-11T10:30:00Z"
 1. Check role inheritance:
 
    ```graphql
-<!-- Code example in GraphQL -->
    query {
      user(id: "user-123") {
        roles {
@@ -889,56 +817,45 @@ created_at: "2025-01-11T10:30:00Z"
        }
      }
    }
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 2. Verify permission assignment:
 
    ```graphql
-<!-- Code example in GraphQL -->
    query {
      role(id: "role-456") {
        permissions { resource action }
      }
    }
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 3. Check cache version:
 
    ```sql
-<!-- Code example in SQL -->
    SELECT * FROM domain_versions WHERE domain = 'role';
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 ### High Latency on Permission Checks
 
 1. Check cache hit ratio:
 
    ```sql
-<!-- Code example in SQL -->
    SELECT * FROM permission_cache_stats;
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 2. Verify domain versioning is working:
 
    ```sql
-<!-- Code example in SQL -->
    SELECT version FROM domain_versions WHERE domain = 'role';
    -- Should be same across requests unless roles changed
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 3. Monitor role hierarchy depth:
 
    ```sql
-<!-- Code example in SQL -->
    SELECT role_id, max_depth FROM role_hierarchy_depths;
    -- Limit to <10 for optimal performance
-   ```text
-<!-- Code example in TEXT -->
+   ```
 
 ---
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -100,7 +100,7 @@ Complete overview of all FraiseQL capabilities.
 | **Event Sourcing** | ✅ Stable | [Event Sourcing](../advanced/event-sourcing.md) | [complete_cqrs_blog](../../examples/complete_cqrs_blog/) |
 | **Domain Events** | ✅ Stable | [Event Sourcing](../advanced/event-sourcing.md#domain-events) | [blog_enterprise](../../examples/blog_enterprise/) |
 | **CQRS Architecture** | ✅ Stable | [Patterns Guide](../patterns/README.md#cqrs) | [blog_enterprise](../../examples/blog_enterprise/) |
-| **Compliance (GDPR/SOC2/HIPAA)** | ✅ Stable | [Enterprise Guide](../enterprise/enterprise.md) | [saas-starter](../../examples/saas-starter/) |
+| **Compliance (GDPR/SOC2/HIPAA)** | ✅ Stable | [Enterprise Guide](../enterprise/README.md) | [saas-starter](../../examples/saas-starter/) |
 
 ---
 


### PR DESCRIPTION
Phase 2 of the docs cleanup (follows #418–#424). Fixes the **Enterprise** nav pages. The `audit-logging`/`kms`/`rbac` pages are **real v1 Python content** (audit, KMS, RBAC all exist in `src/`) needing only light cleanup; `README` was v2 `FraiseQL.toml` config-as-code.

## Per-file summary

| File | Changes |
|------|---------|
| `README` | reframe `FraiseQL.toml`/`[FraiseQL.security]` config-as-code → real v1 config via **`FraiseQLConfig`** (pydantic `BaseSettings`, `env_prefix=FRAISEQL_`) + `create_fraiseql_app(...)` kwargs, using verified fields (`environment`, `revocation_*`, `rate_limit_*`, `complexity_*`); drop the "v2" title |
| `audit-logging` / `kms` / `rbac` | **minimal** cleanup — drop the `v2.0.0-alpha.1+` stamps, remove all `<!-- Code example -->` comments, fix malformed ` ```text ` closing fences; fix capital-`F` import paths (`from FraiseQL.*` → `from fraiseql.*`) and bare `import strawberry` → `from fraiseql.strawberry_compat import strawberry` (the real audit module uses the compat layer). Content preserved verbatim. |
| `features/index.md` | repoint the dangling Enterprise Guide link (`enterprise/enterprise.md` → `enterprise/README.md`) |

## Verification

- `grep`: **zero** `FraiseQL.toml` / `[FraiseQL` / `v2.0.0` / `@FraiseQL.` / `from FraiseQL ` artifacts.
- `@strawberry` usage **confirmed legitimate** — matches `src/fraiseql/enterprise/audit/` which imports `from fraiseql.strawberry_compat import strawberry`. KMS backends (Vault/AWS/GCP/local) and RBAC (RLS) verified real in `src/`.
- Fences balanced; `mkdocs build` no new warnings (the `features/index.md` → enterprise dangling link is now fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)