### PR TITLE
docs(operations): rewrite the Operations section for v1 (Python/FastAPI/PostgreSQL)

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -2,57 +2,40 @@
 ---
 
 title: Operations Guide
-description: Complete guide for deploying, monitoring, and maintaining FraiseQL in production environments.
-keywords: ["deployment", "scaling", "performance", "monitoring", "troubleshooting"]
+description: Guide for deploying, monitoring, and maintaining a FraiseQL (Python/FastAPI/PostgreSQL) application in production.
+keywords: ["deployment", "monitoring", "performance", "observability", "troubleshooting"]
 tags: ["documentation", "reference"]
 ---
 
 # Operations Guide
 
-Complete guide for deploying, monitoring, and maintaining FraiseQL in production environments.
+Operating a FraiseQL application in production. FraiseQL builds its GraphQL schema in
+memory at startup and serves it from a FastAPI app (run under an ASGI server such as
+`uvicorn`) backed by PostgreSQL. These pages cover configuring observability, tracing,
+and tuning query performance.
 
-## Quick Navigation
+## In This Section
 
-### Core Guides
+- **[Observability](observability.md)** — Metrics, logging, and health signals for the running FastAPI app.
+- **[Distributed Tracing](distributed-tracing.md)** — Trace requests across the app and into PostgreSQL.
+- **[Observability Configuration](configuration.md)** — Configuration reference for the observability features.
+- **[Performance Tuning Runbook](performance-tuning-runbook.md)** — Diagnose and optimize GraphQL/PostgreSQL query performance.
 
-- **[Deployment Guide](../deployment/guide.md)** — Deploy FraiseQL to production
-- **[Operations Guide](guide.md)** — Day-to-day operations and maintenance
-- **[Observability Guide](observability.md)** — Monitoring, metrics, and observability
+## Related Guides
 
-### Infrastructure & Integration
-
-- **[Distributed Tracing](distributed-tracing.md)** — Set up distributed tracing
-- **[Structured Logging](structured-logging.md)** — Configure structured logging
-- **[Configuration Guide](../configuration/)** — Security, TLS, rate limiting
-
-### Reference
-
-- **[Health Checks](reference/health-checks.md)** — Health check endpoints and patterns
-- **[Metrics Reference](reference/metrics.md)** — Prometheus metrics catalog
-
-### Advanced
-
-- **[Observability Architecture](observability-architecture.md)** — Deep dive into observability design
-- **[Configuration](configuration.md)** — Advanced observability configuration
-- **[Analysis Guide](analysis-guide.md)** — Analyzing observability data
+- **[Production Deployment](../guides/production-deployment.md)** — Deploy the FastAPI app to production.
+- **[Monitoring](../guides/monitoring.md)** — Day-to-day monitoring guidance.
+- **[TLS Configuration](../configuration/tls-configuration.md)** — Terminate TLS for the app.
+- **[Rate Limiting](../configuration/rate-limiting.md)** — Protect endpoints from abuse.
+- **[PostgreSQL Authentication](../configuration/postgresql-authentication.md)** — Secure the database connection.
 
 ## Running in Production
 
-1. **Deploy**: Follow [Deployment Guide](../deployment/guide.md)
-2. **Configure**: Set up [TLS](../configuration/tls-configuration.md), [Rate Limiting](../configuration/rate-limiting.md)
-3. **Monitor**: Enable [metrics](../guides/monitoring.md) and [distributed tracing](distributed-tracing.md)
-4. **Maintain**: Use [operations guide](guide.md) for day-to-day tasks
-
-## Federation
-
-For multi-database federation operations, see [Federation Guide](../integrations/federation/).
+1. **Deploy** — Run the FastAPI app under an ASGI server (`uvicorn app:app`) following the [Production Deployment](../guides/production-deployment.md) guide.
+2. **Secure** — Configure [TLS](../configuration/tls-configuration.md), [rate limiting](../configuration/rate-limiting.md), and [PostgreSQL authentication](../configuration/postgresql-authentication.md).
+3. **Observe** — Enable [observability](observability.md) and [distributed tracing](distributed-tracing.md).
+4. **Tune** — Use the [Performance Tuning Runbook](performance-tuning-runbook.md) to diagnose slow queries.
 
 ## Support
 
-- **Troubleshooting**: See [main troubleshooting guide](../troubleshooting.md)
-- **Known Limitations**: See [alpha limitations](../alpha-limitations.md)
-
----
-
-**Version**: v2.0.0
-**Last Updated**: February 1, 2026
+- **Troubleshooting**: See the [troubleshooting guide](../guides/troubleshooting.md).

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1,17 +1,24 @@
-<!-- Skip to main content -->
 ---
 
-title: Observability Configuration Reference
-description: This document provides complete configuration reference for FraiseQL's observability system. All settings are **opt-in** and carefully tuned for production safe
+title: Configuration Reference
+description: Complete configuration reference for a FraiseQL application. Settings are managed through FraiseQLConfig (pydantic), FRAISEQL_-prefixed environment variables, and create_fraiseql_app(...) keyword arguments.
 keywords: ["deployment", "scaling", "performance", "monitoring", "troubleshooting"]
 tags: ["documentation", "reference"]
 ---
 
-# Observability Configuration Reference
+# Configuration Reference
 
 ## Overview
 
-This document provides complete configuration reference for FraiseQL's observability system. All settings are **opt-in** and carefully tuned for production safety.
+FraiseQL is a Python runtime GraphQL framework for PostgreSQL. A FraiseQL app is
+configured at startup through a single pydantic settings object, `FraiseQLConfig`.
+You can populate it from environment variables (prefixed `FRAISEQL_`), a `.env`
+file, or directly in Python. There is no separate config file format, no CLI, and
+no build step: the GraphQL schema is assembled in memory when the FastAPI app
+starts.
+
+This document is the complete reference for `FraiseQLConfig` (the main application
+config) and `MetricsConfig` (the optional Prometheus metrics integration).
 
 ---
 
@@ -19,1095 +26,756 @@ This document provides complete configuration reference for FraiseQL's observabi
 
 ### Minimal Configuration
 
-Enable observability with defaults:
+The only required setting is the PostgreSQL connection URL. Set it via an
+environment variable:
 
 ```bash
-<!-- Code example in BASH -->
-# Environment variable
-export FRAISEQL_OBSERVABILITY_ENABLED=true
-export FRAISEQL_DATABASE_URL=postgres://user:pass@localhost/mydb
-```text
-<!-- Code example in TEXT -->
+export FRAISEQL_DATABASE_URL=postgresql://user:pass@localhost/mydb
+```
 
-Or in `FraiseQL.toml`:
+Then create the app:
 
-```toml
-<!-- Code example in TOML -->
-[observability]
-enabled = true
+```python
+from fraiseql.fastapi import create_fraiseql_app
 
-[database]
-url = "postgres://user:pass@localhost/mydb"
-```text
-<!-- Code example in TEXT -->
+app = create_fraiseql_app(
+    database_url="postgresql://user:pass@localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+)
+```
 
-That's it! The system will use conservative defaults.
+Run it with uvicorn:
+
+```bash
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+That's it. Every other setting has a conservative default.
 
 ---
 
 ## Configuration Methods
 
-FraiseQL supports three configuration methods (in order of precedence):
+`FraiseQLConfig` is a `pydantic_settings.BaseSettings` subclass, so values resolve
+in this order of precedence:
 
-1. **Environment Variables** (highest priority)
-2. **Configuration File** (`FraiseQL.toml`)
-3. **Default Values** (lowest priority)
+1. **Explicit Python values** (highest priority) — passed to `FraiseQLConfig(...)`
+   or directly as `create_fraiseql_app(...)` keyword arguments.
+2. **Environment variables** — any field can be set with a `FRAISEQL_`-prefixed,
+   case-insensitive env var (e.g. `FRAISEQL_DATABASE_URL`,
+   `FRAISEQL_ENVIRONMENT`).
+3. **`.env` file** — a `.env` file in the working directory is loaded
+   automatically.
+4. **Field defaults** (lowest priority).
 
-### Environment Variables
+### Building a config object
 
-```bash
-<!-- Code example in BASH -->
-# Core settings
-export FRAISEQL_OBSERVABILITY_ENABLED=true
-export FRAISEQL_OBSERVABILITY_SAMPLE_RATE=0.1
-export FRAISEQL_METRICS_DATABASE_URL=postgres://...
+```python
+from fraiseql.fastapi import FraiseQLConfig, create_fraiseql_app
 
-# Retention settings
-export FRAISEQL_METRICS_RETENTION_DAYS=30
-export FRAISEQL_METRICS_BUFFER_SIZE=100
+# Production configuration
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+    environment="production",
+    auth_enabled=True,
+    auth_provider="auth0",
+    auth0_domain="myapp.auth0.com",
+    auth0_api_identifier="https://api.myapp.com",
+)
 
-# Performance tuning
-export FRAISEQL_METRICS_FLUSH_INTERVAL_SECS=60
-export FRAISEQL_METRICS_BATCH_SIZE=100
-```text
-<!-- Code example in TEXT -->
+app = create_fraiseql_app(types=[User, Post], config=config)
+```
 
-### Configuration File
-
-Create `FraiseQL.toml` in your project root:
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-enabled = true
-sample_rate = 0.1
-retention_days = 30
-
-[observability.metrics]
-buffer_size = 100
-flush_interval_secs = 60
-batch_size = 100
-
-[observability.database]
-# Optional: Separate database for metrics (recommended for production)
-url = "postgres://metrics:pass@metrics-db:5432/fraiseql_metrics"
-pool_size = 10
-timeout_secs = 30
-
-[observability.analysis]
-# Default thresholds for analyze command
-min_frequency = 1000
-min_speedup = 5.0
-min_selectivity = 0.1
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Core Configuration
-
-### `observability.enabled`
-
-**Type**: `boolean`
-**Default**: `false`
-**Environment**: `FRAISEQL_OBSERVABILITY_ENABLED`
-
-Enable or disable observability system.
-
-**Important**: Observability is **opt-in** for production safety. You must explicitly enable it.
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-enabled = true
-```text
-<!-- Code example in TEXT -->
+### Letting environment variables drive everything
 
 ```bash
-<!-- Code example in BASH -->
-export FRAISEQL_OBSERVABILITY_ENABLED=true
-```text
-<!-- Code example in TEXT -->
+export FRAISEQL_DATABASE_URL=postgresql://user:pass@localhost/mydb
+export FRAISEQL_ENVIRONMENT=production
+export FRAISEQL_AUTH_ENABLED=true
+export FRAISEQL_AUTH_PROVIDER=auth0
+export FRAISEQL_AUTH0_DOMAIN=myapp.auth0.com
+export FRAISEQL_AUTH0_API_IDENTIFIER=https://api.myapp.com
+```
 
----
+```python
+from fraiseql.fastapi import FraiseQLConfig, create_fraiseql_app
 
-### `observability.sample_rate`
+# Reads all FRAISEQL_-prefixed env vars / .env automatically
+config = FraiseQLConfig()
+app = create_fraiseql_app(types=[User, Post], config=config)
+```
 
-**Type**: `float` (0.0 - 1.0)
-**Default**: `0.1` (10%)
-**Environment**: `FRAISEQL_OBSERVABILITY_SAMPLE_RATE`
+### `create_fraiseql_app(...)` keyword arguments
 
-Percentage of queries to collect metrics for.
+Some settings can also be passed directly to `create_fraiseql_app`, which builds a
+config for you. Verified keyword arguments:
 
-**Guidelines**:
+```python
+app = create_fraiseql_app(
+    database_url="postgresql://user:pass@localhost/mydb",
+    types=[User, Post],
+    queries=[users, user],
+    mutations=[create_user],
+    auth=auth_provider,                # an AuthProvider instance
+    context_getter=get_context,        # custom GraphQL context builder
+    config=config,                     # a FraiseQLConfig instance
+    title="My API",
+    version="1.0.0",
+    description="My GraphQL API",
+    production=False,                  # False enables the GraphQL playground
+    connection_pool_size=20,
+    connection_max_overflow=10,
+    connection_timeout=30,
+    connection_recycle=3600,
+)
+```
 
-| Traffic Level | Recommended Rate | Expected Overhead |
-|--------------|------------------|-------------------|
-| Low (< 100 qps) | 1.0 (100%) | < 2% |
-| Medium (100-1000 qps) | 0.1 (10%) | < 5% |
-| High (> 1000 qps) | 0.01 (1%) | < 1% |
-
-**Example**:
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-# Sample 1% of queries in high-traffic production
-sample_rate = 0.01
-```text
-<!-- Code example in TEXT -->
-
-**Note**: Even at 1% sampling, patterns are reliably detected with sufficient traffic.
-
----
-
-### `observability.retention_days`
-
-**Type**: `integer`
-**Default**: `30`
-**Environment**: `FRAISEQL_METRICS_RETENTION_DAYS`
-
-How long to keep metrics data before automatic cleanup.
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-retention_days = 30  # Keep metrics for 30 days
-```text
-<!-- Code example in TEXT -->
-
-**Storage Estimates** (per day, 10% sampling, 1000 qps):
-
-| Database Size | Metrics Storage Per Day |
-|--------------|------------------------|
-| Small (< 10 tables) | ~50 MB |
-| Medium (10-50 tables) | ~200 MB |
-| Large (> 50 tables) | ~500 MB |
-
-**Cleanup Query** (runs daily):
-
-```sql
-<!-- Code example in SQL -->
--- PostgreSQL
-DELETE FROM fraiseql_metrics.query_executions
-WHERE executed_at < NOW() - INTERVAL '30 days';
-
--- SQL Server
-DELETE FROM fraiseql_metrics.query_executions
-WHERE executed_at < DATEADD(day, -30, GETDATE());
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Metrics Collection
-
-### `observability.metrics.buffer_size`
-
-**Type**: `integer`
-**Default**: `100`
-**Environment**: `FRAISEQL_METRICS_BUFFER_SIZE`
-
-In-memory buffer size before flushing to database.
-
-```toml
-<!-- Code example in TOML -->
-[observability.metrics]
-buffer_size = 100  # Flush after 100 queries
-```text
-<!-- Code example in TEXT -->
-
-**Trade-offs**:
-
-- **Smaller buffer** (50): More frequent writes, less memory, higher DB load
-- **Larger buffer** (500): Fewer writes, more memory, risk of data loss on crash
-
-**Recommendation**: Use default 100 for most cases.
-
----
-
-### `observability.metrics.flush_interval_secs`
-
-**Type**: `integer`
-**Default**: `60`
-**Environment**: `FRAISEQL_METRICS_FLUSH_INTERVAL_SECS`
-
-Maximum seconds to wait before flushing buffer (even if not full).
-
-```toml
-<!-- Code example in TOML -->
-[observability.metrics]
-flush_interval_secs = 60  # Flush at least every minute
-```text
-<!-- Code example in TEXT -->
-
-**Why needed**: Ensures metrics aren't delayed indefinitely during low traffic.
-
----
-
-### `observability.metrics.batch_size`
-
-**Type**: `integer`
-**Default**: `100`
-**Environment**: `FRAISEQL_METRICS_BATCH_SIZE`
-
-Number of metrics to insert in a single database transaction.
-
-```toml
-<!-- Code example in TOML -->
-[observability.metrics]
-batch_size = 100
-```text
-<!-- Code example in TEXT -->
-
-**Performance Impact**:
-
-| Batch Size | Inserts/sec | Latency | Transaction Log |
-|-----------|-------------|---------|-----------------|
-| 1 | 100 | High | Large |
-| 100 | 10,000 | Low | Small |
-| 1000 | 50,000 | Very Low | Tiny |
-
-**Recommendation**: 100-500 for balanced performance.
+There is **no `middleware=` keyword argument**. Add middleware with
+`app.add_middleware(...)` on the returned app, or pass your own FastAPI app via
+`create_fraiseql_app(app=...)`.
 
 ---
 
 ## Database Configuration
 
-### `observability.database.url`
+### `database_url`
 
-**Type**: `string`
-**Default**: Same as main database
-**Environment**: `FRAISEQL_METRICS_DATABASE_URL`
+**Type**: `str` (PostgreSQL DSN)
+**Required**: yes
+**Environment**: `FRAISEQL_DATABASE_URL`
 
-Database connection string for metrics storage.
+PostgreSQL connection URL. Must start with `postgresql://` or `postgres://`.
+Unix-domain socket URLs are also supported
+(`postgresql://user@/var/run/postgresql:5432/mydb`).
 
-**Options**:
+```bash
+export FRAISEQL_DATABASE_URL=postgresql://app:pass@localhost:5432/myapp
+```
 
-1. **Same database as application** (simple):
+```python
+config = FraiseQLConfig(database_url="postgresql://app:pass@localhost:5432/myapp")
+```
 
-   ```toml
-<!-- Code example in TOML -->
-   # Omit this setting to use main database
-   ```text
-<!-- Code example in TEXT -->
+### `database_pool_size`
 
-2. **Separate database on same server** (recommended):
+**Type**: `int`
+**Default**: `20`
+**Environment**: `FRAISEQL_DATABASE_POOL_SIZE`
 
-   ```toml
-<!-- Code example in TOML -->
-   [observability.database]
-   url = "postgres://app:pass@localhost:5432/fraiseql_metrics"
-   ```text
-<!-- Code example in TEXT -->
-
-3. **Separate metrics server** (production best practice):
-
-   ```toml
-<!-- Code example in TOML -->
-   [observability.database]
-   url = "postgres://metrics:pass@metrics-db.internal:5432/metrics"
-   ```text
-<!-- Code example in TEXT -->
-
-**Benefits of Separate Database**:
-
-- ✅ Isolation: Metrics don't impact application database
-- ✅ Scaling: Scale metrics storage independently
-- ✅ Retention: Different backup/retention policies
-- ✅ Security: Restricted access to metrics
-
----
-
-### `observability.database.pool_size`
-
-**Type**: `integer`
-**Default**: `10`
-**Environment**: `FRAISEQL_METRICS_DB_POOL_SIZE`
-
-Connection pool size for metrics database.
-
-```toml
-<!-- Code example in TOML -->
-[observability.database]
-pool_size = 10
-```text
-<!-- Code example in TEXT -->
-
-**Guidelines**:
+Number of persistent connections kept open in the pool.
 
 | Traffic | Pool Size | Reasoning |
 |---------|-----------|-----------|
-| Low (< 100 qps) | 5 | Minimal connections needed |
-| Medium (100-1000 qps) | 10 | Default works well |
-| High (> 1000 qps) | 20 | More concurrent writes |
+| Low (< 100 rps) | 5–10 | Minimal connections needed |
+| Medium (100–1000 rps) | 20 | Default works well |
+| High (> 1000 rps) | 40+ | More concurrent connections |
 
----
+### `database_max_overflow`
 
-### `observability.database.timeout_secs`
+**Type**: `int`
+**Default**: `10`
+**Environment**: `FRAISEQL_DATABASE_MAX_OVERFLOW`
 
-**Type**: `integer`
+Extra connections the pool may open beyond `database_pool_size` under load.
+
+### `database_pool_timeout`
+
+**Type**: `int` (seconds)
 **Default**: `30`
-**Environment**: `FRAISEQL_METRICS_DB_TIMEOUT_SECS`
+**Environment**: `FRAISEQL_DATABASE_POOL_TIMEOUT`
 
-Query timeout for metrics writes (seconds).
+How long a request waits for a free connection before raising.
 
-```toml
-<!-- Code example in TOML -->
-[observability.database]
-timeout_secs = 30
-```text
-<!-- Code example in TEXT -->
+### `database_pool_recycle`
 
-**Important**: If metrics writes timeout, they're dropped (doesn't block application queries).
+**Type**: `int` (seconds)
+**Default**: `3600`
+**Environment**: `FRAISEQL_DATABASE_POOL_RECYCLE`
+
+Recycle a connection after this many seconds, even if idle. Prevents stale
+connections behind proxies and load balancers.
+
+### `database_echo`
+
+**Type**: `bool`
+**Default**: `false`
+**Environment**: `FRAISEQL_DATABASE_ECHO`
+
+Log generated SQL. Useful in development; keep off in production.
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost:5432/myapp",
+    database_pool_size=20,
+    database_max_overflow=10,
+    database_pool_timeout=30,
+    database_pool_recycle=3600,
+)
+```
 
 ---
 
-## Analysis Configuration
+## Application Settings
 
-These settings control the `FraiseQL-cli analyze` command behavior.
+### `environment`
 
-### `observability.analysis.min_frequency`
+**Type**: `"development" | "production" | "testing"`
+**Default**: `"development"`
+**Environment**: `FRAISEQL_ENVIRONMENT`
 
-**Type**: `integer`
+Setting `environment="production"` tightens defaults automatically: introspection
+is disabled (unless explicitly set) and the GraphQL playground is turned off.
+
+### `app_name`
+
+**Type**: `str`
+**Default**: `"FraiseQL API"`
+**Environment**: `FRAISEQL_APP_NAME`
+
+### `app_version`
+
+**Type**: `str`
+**Default**: `"1.0.0"`
+**Environment**: `FRAISEQL_APP_VERSION`
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    environment="production",
+    app_name="My GraphQL API",
+    app_version="2.3.1",
+)
+```
+
+---
+
+## GraphQL Settings
+
+### `introspection_policy`
+
+**Type**: `IntrospectionPolicy` (`"public" | "disabled" | "authenticated"`)
+**Default**: `"public"` (forced to `"disabled"` in production unless set)
+**Environment**: `FRAISEQL_INTROSPECTION_POLICY`
+
+Controls who may run GraphQL introspection queries.
+
+```python
+from fraiseql.fastapi import FraiseQLConfig
+from fraiseql.fastapi.config import IntrospectionPolicy
+
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    introspection_policy=IntrospectionPolicy.AUTHENTICATED,
+)
+```
+
+### `enable_playground`
+
+**Type**: `bool`
+**Default**: `true` (forced to `false` in production unless explicitly set)
+**Environment**: `FRAISEQL_ENABLE_PLAYGROUND`
+
+Mount the in-browser GraphQL IDE. The `production=False` flag on
+`create_fraiseql_app(...)` is the convenient way to enable it during development.
+
+### `playground_tool`
+
+**Type**: `"graphiql" | "apollo-sandbox"`
+**Default**: `"graphiql"`
+**Environment**: `FRAISEQL_PLAYGROUND_TOOL`
+
+Which GraphQL IDE to serve.
+
+### `max_query_depth`
+
+**Type**: `int | None`
+**Default**: `None` (no depth limit)
+**Environment**: `FRAISEQL_MAX_QUERY_DEPTH`
+
+Maximum nesting depth allowed in a query.
+
+### `auto_camel_case`
+
+**Type**: `bool`
+**Default**: `true`
+**Environment**: `FRAISEQL_AUTO_CAMEL_CASE`
+
+Auto-convert `snake_case` Python field names to `camelCase` in the GraphQL schema.
+
+### `query_timeout`
+
+**Type**: `int` (seconds)
+**Default**: `30`
+**Environment**: `FRAISEQL_QUERY_TIMEOUT`
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    enable_playground=False,
+    max_query_depth=12,
+    query_timeout=30,
+)
+```
+
+---
+
+## Performance Settings
+
+### `cache_ttl`
+
+**Type**: `int` (seconds)
+**Default**: `300`
+**Environment**: `FRAISEQL_CACHE_TTL`
+
+Default time-to-live for cached query results.
+
+### `execution_timeout_ms`
+
+**Type**: `int` (milliseconds)
+**Default**: `30000`
+**Environment**: `FRAISEQL_EXECUTION_TIMEOUT_MS`
+
+Maximum time a query may execute before being cancelled.
+
+### `include_execution_metadata`
+
+**Type**: `bool`
+**Default**: `false`
+**Environment**: `FRAISEQL_INCLUDE_EXECUTION_METADATA`
+
+Include timing/diagnostic metadata in GraphQL responses. Useful during
+development and profiling.
+
+### `jsonb_field_limit_threshold`
+
+**Type**: `int`
+**Default**: `20`
+**Environment**: `FRAISEQL_JSONB_FIELD_LIMIT_THRESHOLD`
+
+When a query selects more than this many fields, FraiseQL switches to returning
+the full `data` JSONB column instead of projecting individual paths.
+
+### `turbo_router_cache_size`
+
+**Type**: `int`
 **Default**: `1000`
-**CLI Flag**: `--min-frequency`
+**Environment**: `FRAISEQL_TURBO_ROUTER_CACHE_SIZE`
 
-Minimum queries per day to suggest optimization.
+Maximum number of prepared queries to cache for the fast-path router.
 
-```toml
-<!-- Code example in TOML -->
-[observability.analysis]
-min_frequency = 1000
-```text
-<!-- Code example in TEXT -->
-
-```bash
-<!-- Code example in BASH -->
-FraiseQL-cli analyze --min-frequency 500  # Override default
-```text
-<!-- Code example in TEXT -->
-
-**Guidelines**:
-
-| Threshold | Result | Use Case |
-|-----------|--------|----------|
-| 100 | Many suggestions | Development/testing |
-| 1000 (default) | High-impact only | Production |
-| 5000 | Critical paths only | High-traffic apps |
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    cache_ttl=300,
+    execution_timeout_ms=30000,
+    include_execution_metadata=False,
+    jsonb_field_limit_threshold=20,
+)
+```
 
 ---
 
-### `observability.analysis.min_speedup`
+## Security Settings
 
-**Type**: `float`
-**Default**: `5.0`
-**CLI Flag**: `--min-speedup`
+### Query Complexity
 
-Minimum speedup factor (e.g., 5.0 = 5x faster) to suggest optimization.
+| Field | Type | Default | Environment |
+|-------|------|---------|-------------|
+| `complexity_enabled` | bool | `true` | `FRAISEQL_COMPLEXITY_ENABLED` |
+| `complexity_max_score` | int | `1000` | `FRAISEQL_COMPLEXITY_MAX_SCORE` |
+| `complexity_max_depth` | int | `10` | `FRAISEQL_COMPLEXITY_MAX_DEPTH` |
+| `complexity_default_list_size` | int | `10` | `FRAISEQL_COMPLEXITY_DEFAULT_LIST_SIZE` |
+| `complexity_include_in_response` | bool | `false` | `FRAISEQL_COMPLEXITY_INCLUDE_IN_RESPONSE` |
 
-```toml
-<!-- Code example in TOML -->
-[observability.analysis]
-min_speedup = 5.0
-```text
-<!-- Code example in TEXT -->
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    complexity_enabled=True,
+    complexity_max_score=1000,
+    complexity_max_depth=10,
+)
+```
 
-```bash
-<!-- Code example in BASH -->
-FraiseQL-cli analyze --min-speedup 3.0  # Lower threshold
-```text
-<!-- Code example in TEXT -->
+### Rate Limiting
 
-**Guidelines**:
+| Field | Type | Default | Environment |
+|-------|------|---------|-------------|
+| `rate_limit_enabled` | bool | `true` | `FRAISEQL_RATE_LIMIT_ENABLED` |
+| `rate_limit_requests_per_minute` | int | `60` | `FRAISEQL_RATE_LIMIT_REQUESTS_PER_MINUTE` |
+| `rate_limit_requests_per_hour` | int | `1000` | `FRAISEQL_RATE_LIMIT_REQUESTS_PER_HOUR` |
+| `rate_limit_burst_size` | int | `10` | `FRAISEQL_RATE_LIMIT_BURST_SIZE` |
+| `rate_limit_window_type` | str | `"sliding"` | `FRAISEQL_RATE_LIMIT_WINDOW_TYPE` |
 
-| Threshold | Result | Trade-off |
-|-----------|--------|-----------|
-| 2.0 | Many suggestions | More noise, smaller gains |
-| 5.0 (default) | Clear wins | Conservative, high-impact |
-| 10.0 | Only huge gains | May miss good optimizations |
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    rate_limit_enabled=True,
+    rate_limit_requests_per_minute=120,
+    rate_limit_window_type="sliding",
+)
+```
+
+### CORS
+
+| Field | Type | Default | Environment |
+|-------|------|---------|-------------|
+| `cors_enabled` | bool | `false` | `FRAISEQL_CORS_ENABLED` |
+| `cors_origins` | list[str] | `[]` | `FRAISEQL_CORS_ORIGINS` |
+| `cors_methods` | list[str] | `["GET", "POST"]` | `FRAISEQL_CORS_METHODS` |
+| `cors_headers` | list[str] | `["Content-Type", "Authorization"]` | `FRAISEQL_CORS_HEADERS` |
+
+CORS is **disabled by default** — the recommended pattern is to handle CORS at the
+reverse proxy. If you enable it, set explicit origins; a wildcard `*` origin in
+production triggers a warning.
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    cors_enabled=True,
+    cors_origins=["https://app.example.com"],
+)
+```
 
 ---
 
-### `observability.analysis.min_selectivity`
+## Authentication Settings
 
-**Type**: `float` (0.0 - 1.0)
-**Default**: `0.1` (10%)
-**CLI Flag**: `--min-selectivity`
+| Field | Type | Default | Environment |
+|-------|------|---------|-------------|
+| `auth_enabled` | bool | `true` | `FRAISEQL_AUTH_ENABLED` |
+| `auth_provider` | `"auth0" \| "custom" \| "none"` | `"none"` | `FRAISEQL_AUTH_PROVIDER` |
+| `auth0_domain` | str \| None | `None` | `FRAISEQL_AUTH0_DOMAIN` |
+| `auth0_api_identifier` | str \| None | `None` | `FRAISEQL_AUTH0_API_IDENTIFIER` |
+| `auth0_algorithms` | list[str] | `["RS256"]` | `FRAISEQL_AUTH0_ALGORITHMS` |
+| `dev_auth_username` | str \| None | `"admin"` | `FRAISEQL_DEV_AUTH_USERNAME` |
+| `dev_auth_password` | str \| None | `None` | `FRAISEQL_DEV_AUTH_PASSWORD` |
 
-Minimum filter selectivity (% of rows filtered) for denormalization suggestions.
+Three provider modes exist: `"auth0"`, `"custom"`, and `"none"`. For Auth0,
+`auth0_domain` is required. For any other OIDC/JWT issuer, set
+`auth_provider="custom"` and implement an `AuthProvider` subclass (or front the
+issuer with Auth0). See the authentication guides for details.
 
-```toml
-<!-- Code example in TOML -->
-[observability.analysis]
-min_selectivity = 0.1  # 10% of rows filtered
-```text
-<!-- Code example in TEXT -->
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    auth_enabled=True,
+    auth_provider="auth0",
+    auth0_domain="myapp.auth0.com",
+    auth0_api_identifier="https://api.myapp.com",
+)
+```
 
-**Example**:
+---
+
+## Token Revocation Settings
+
+| Field | Type | Default | Environment |
+|-------|------|---------|-------------|
+| `revocation_enabled` | bool | `true` | `FRAISEQL_REVOCATION_ENABLED` |
+| `revocation_check_enabled` | bool | `true` | `FRAISEQL_REVOCATION_CHECK_ENABLED` |
+| `revocation_ttl` | int (seconds) | `86400` | `FRAISEQL_REVOCATION_TTL` |
+| `revocation_cleanup_interval` | int (seconds) | `3600` | `FRAISEQL_REVOCATION_CLEANUP_INTERVAL` |
+| `revocation_store_type` | str | `"memory"` | `FRAISEQL_REVOCATION_STORE_TYPE` |
+
+`revocation_store_type` accepts `"memory"` or `"redis"`. A PostgreSQL-backed
+revocation store is also available programmatically via
+`fraiseql.auth.token_revocation.PostgreSQLRevocationStore`.
+
+---
+
+## Automatic Persisted Queries (APQ)
+
+| Field | Type | Default | Environment |
+|-------|------|---------|-------------|
+| `apq_mode` | `"optional" \| "required" \| "disabled"` | `"optional"` | `FRAISEQL_APQ_MODE` |
+| `apq_storage_backend` | `"memory" \| "postgresql" \| "custom"` | `"memory"` | `FRAISEQL_APQ_STORAGE_BACKEND` |
+| `apq_cache_responses` | bool | `false` | `FRAISEQL_APQ_CACHE_RESPONSES` |
+| `apq_response_cache_ttl` | int (seconds) | `600` | `FRAISEQL_APQ_RESPONSE_CACHE_TTL` |
+| `apq_queries_dir` | str \| None | `None` | `FRAISEQL_APQ_QUERIES_DIR` |
+
+In `apq_mode="required"`, only persisted query hashes are accepted; arbitrary
+queries are rejected. Set `apq_queries_dir` to a directory of `.graphql`/`.gql`
+files to auto-register them at startup — useful for security-hardened
+deployments.
+
+---
+
+## Schema and Session Settings
+
+### Default schemas
+
+| Field | Type | Default | Environment |
+|-------|------|---------|-------------|
+| `default_query_schema` | str | `"public"` | `FRAISEQL_DEFAULT_QUERY_SCHEMA` |
+| `default_mutation_schema` | str | `"public"` | `FRAISEQL_DEFAULT_MUTATION_SCHEMA` |
+| `default_entity_schema` | str \| None | `None` | `FRAISEQL_DEFAULT_ENTITY_SCHEMA` |
+
+PostgreSQL schemas to use for query views, mutation functions, and `tb_*` entity
+tables when not specified on the decorator.
+
+### `coordinate_distance_method`
+
+**Type**: `"postgis" | "haversine" | "earthdistance"`
+**Default**: `"haversine"`
+**Environment**: `FRAISEQL_COORDINATE_DISTANCE_METHOD`
+
+How coordinate-distance filters are computed. `"haversine"` works without
+extensions; `"postgis"` is the most accurate but requires the PostGIS extension.
+
+### `default_string_collation`
+
+**Type**: `str | None`
+**Default**: `None` (use the database default)
+**Environment**: `FRAISEQL_DEFAULT_STRING_COLLATION`
+
+PostgreSQL collation applied to text `ORDER BY` clauses, e.g. `"fr_FR.utf8"` or
+`"C"`.
+
+### `session_variables`
+
+**Type**: `dict[str, str]`
+**Default**: `{}`
+
+Maps request-context keys to PostgreSQL session variable names that FraiseQL sets
+via `SET LOCAL` before each query/mutation. This is how request context reaches
+your views and Row-Level Security policies:
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    session_variables={"locale": "app.locale", "timezone": "app.timezone"},
+)
+```
+
+When `context["locale"] == "fr-FR"`, the connection executes
+`SET LOCAL app.locale = 'fr-FR'`, so a view can read it:
 
 ```sql
-<!-- Code example in SQL -->
--- High selectivity (15% of rows match) → Suggest denormalization
-WHERE JSON_VALUE(dimensions, '$.region') = 'US'  -- Returns 15,000 / 100,000 rows
-
--- Low selectivity (90% match) → Don't suggest (most rows match anyway)
-WHERE JSON_VALUE(dimensions, '$.active') = 'true'  -- Returns 90,000 / 100,000 rows
-```text
-<!-- Code example in TEXT -->
-
-**Guidelines**:
-
-| Threshold | Meaning | Use Case |
-|-----------|---------|----------|
-| 0.01 (1%) | Very selective | Rare filters (e.g., VIP users) |
-| 0.1 (10%) | Moderately selective | Default, balanced |
-| 0.5 (50%) | Low selectivity | Broad filters |
+WHERE code = COALESCE(current_setting('app.locale', true), 'fr-FR')
+```
 
 ---
 
-### `observability.analysis.window`
+## Metrics and Observability
 
-**Type**: `string` (duration)
-**Default**: `"7d"`
-**CLI Flag**: `--window`
+FraiseQL ships an optional Prometheus-based metrics integration in
+`fraiseql.monitoring`. It is **separate** from `FraiseQLConfig`: you configure it
+with a `MetricsConfig` dataclass and wire it into your FastAPI app with
+`setup_metrics(app, config)`.
 
-Time window for analysis.
+```python
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.monitoring import MetricsConfig, setup_metrics
 
-```toml
-<!-- Code example in TOML -->
-[observability.analysis]
-window = "7d"  # Last 7 days
+app = create_fraiseql_app(
+    database_url="postgresql://app:pass@localhost/myapp",
+    types=[User],
+    queries=[users],
+)
+
+metrics = setup_metrics(app, MetricsConfig(enabled=True))
+```
+
+`setup_metrics` installs request-timing middleware and mounts a Prometheus
+scrape endpoint (default `GET /metrics`).
+
+### `MetricsConfig` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable metrics collection |
+| `namespace` | str | `"fraiseql"` | Prefix for all metric names |
+| `metrics_path` | str | `"/metrics"` | URL path for the metrics endpoint |
+| `buckets` | list[float] | latency buckets `[0.005 … 10]` | Histogram bucket boundaries (seconds) |
+| `exclude_paths` | set[str] | `{"/metrics", "/health", "/ready", "/startup"}` | Paths excluded from HTTP metrics |
+| `labels` | dict[str, str] | `{}` | Extra labels applied to all metrics |
+
+```python
+from fraiseql.monitoring import MetricsConfig, setup_metrics
+
+config = MetricsConfig(
+    enabled=True,
+    namespace="myapp",
+    metrics_path="/metrics",
+    labels={"service": "graphql-api", "region": "eu-west-1"},
+)
+metrics = setup_metrics(app, config)
+```
+
+Prometheus exposes the metrics in the standard text format on the configured
+path:
+
 ```text
-<!-- Code example in TEXT -->
+# HELP fraiseql_graphql_queries_total Total GraphQL queries
+# TYPE fraiseql_graphql_queries_total counter
+fraiseql_graphql_queries_total 1
+# HELP fraiseql_graphql_query_duration_seconds Query duration
+# TYPE fraiseql_graphql_query_duration_seconds histogram
+fraiseql_graphql_query_duration_seconds_sum 0.01
+fraiseql_graphql_query_duration_seconds_count 1
+```
 
-```bash
-<!-- Code example in BASH -->
-FraiseQL-cli analyze --window 30d  # Last 30 days
-```text
-<!-- Code example in TEXT -->
+### Privacy
 
-**Supported Formats**:
+The metrics integration records query structure and timing only. It does **not**
+record query arguments/variables, user identifiers, PII, or actual data values.
 
-- `1d` - 1 day
-- `7d` - 7 days (default)
-- `30d` - 30 days
-- `90d` - 90 days
+### Health checks
 
-**Guidelines**:
+`fraiseql.monitoring` also provides health-check helpers you can mount in your
+app:
 
-| Window | Use Case | Trade-off |
-|--------|----------|-----------|
-| 1d | Quick check | May miss weekly patterns |
-| 7d (default) | Weekly patterns | Good balance |
-| 30d | Monthly trends | Includes seasonal traffic |
-| 90d | Long-term patterns | May include stale data |
+```python
+from fraiseql.monitoring import HealthCheck, check_database, check_pool_stats
 
----
+health = HealthCheck()
+health.add_check("database", check_database)
+health.add_check("pool", check_pool_stats)
 
-## Privacy and Security
-
-### `observability.privacy.collect_arguments`
-
-**Type**: `boolean`
-**Default**: `false` (NEVER enabled)
-**Environment**: N/A (hardcoded to false)
-
-Whether to collect query arguments (variables).
-
-**IMPORTANT**: This is **always false** and cannot be enabled. FraiseQL **never logs**:
-
-- ❌ Query arguments/variables
-- ❌ User IDs or identifiers
-- ❌ Personally Identifiable Information (PII)
-- ❌ Actual data values
-
-**What IS collected**:
-
-- ✅ Query structure (operation name)
-- ✅ Execution timing
-- ✅ JSON paths accessed (e.g., "dimensions.region")
-- ✅ Result set sizes
-- ✅ Cache hit/miss
-
----
-
-### `observability.security.metrics_table_permissions`
-
-**Recommendation**: Restrict metrics tables to observability service only.
-
-**PostgreSQL**:
-
-```sql
-<!-- Code example in SQL -->
--- Create dedicated metrics user
-CREATE USER fraiseql_metrics WITH PASSWORD 'secure_password';
-
--- Grant schema access
-GRANT USAGE ON SCHEMA fraiseql_metrics TO fraiseql_metrics;
-
--- Grant table permissions (INSERT only for collection)
-GRANT INSERT ON fraiseql_metrics.query_executions TO fraiseql_metrics;
-GRANT INSERT ON fraiseql_metrics.jsonb_accesses TO fraiseql_metrics;
-
--- Analysis user needs SELECT
-CREATE USER fraiseql_analyst WITH PASSWORD 'analyst_password';
-GRANT SELECT ON ALL TABLES IN SCHEMA fraiseql_metrics TO fraiseql_analyst;
-```text
-<!-- Code example in TEXT -->
-
-**SQL Server**:
-
-```sql
-<!-- Code example in SQL -->
--- Create dedicated login and user
-CREATE LOGIN fraiseql_metrics WITH PASSWORD = 'secure_password';
-CREATE USER fraiseql_metrics FOR LOGIN fraiseql_metrics;
-
--- Grant schema access
-GRANT SELECT, INSERT ON SCHEMA::fraiseql_metrics TO fraiseql_metrics;
-
--- Analysis user
-CREATE LOGIN fraiseql_analyst WITH PASSWORD = 'analyst_password';
-CREATE USER fraiseql_analyst FOR LOGIN fraiseql_analyst;
-GRANT SELECT ON SCHEMA::fraiseql_metrics TO fraiseql_analyst;
-```text
-<!-- Code example in TEXT -->
+result = await health.run_checks()
+```
 
 ---
 
 ## Production Configuration Examples
 
-### Small Application (< 100 qps)
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-enabled = true
-sample_rate = 1.0  # 100% sampling (low traffic)
-retention_days = 30
-
-[observability.metrics]
-buffer_size = 50
-flush_interval_secs = 30
-batch_size = 50
-
-[observability.analysis]
-min_frequency = 100  # Lower threshold (less traffic)
-min_speedup = 3.0
-min_selectivity = 0.1
-```text
-<!-- Code example in TEXT -->
-
----
-
-### Medium Application (100-1000 qps)
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-enabled = true
-sample_rate = 0.1  # 10% sampling (default)
-retention_days = 30
-
-[observability.metrics]
-buffer_size = 100
-flush_interval_secs = 60
-batch_size = 100
-
-[observability.database]
-# Separate database recommended
-url = "postgres://metrics:pass@metrics-db:5432/fraiseql_metrics"
-pool_size = 10
-
-[observability.analysis]
-min_frequency = 1000  # Default
-min_speedup = 5.0
-min_selectivity = 0.1
-```text
-<!-- Code example in TEXT -->
-
----
-
-### Large Application (> 1000 qps)
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-enabled = true
-sample_rate = 0.01  # 1% sampling (high traffic)
-retention_days = 14  # Shorter retention (lots of data)
-
-[observability.metrics]
-buffer_size = 200
-flush_interval_secs = 60
-batch_size = 500  # Larger batches for efficiency
-
-[observability.database]
-# Separate metrics cluster
-url = "postgres://metrics:pass@metrics-cluster.internal:5432/metrics"
-pool_size = 20
-timeout_secs = 30
-
-[observability.analysis]
-min_frequency = 5000  # High threshold
-min_speedup = 10.0  # Only huge wins
-min_selectivity = 0.05
-window = "30d"  # Longer window to capture patterns at 1% sampling
-```text
-<!-- Code example in TEXT -->
-
----
-
-### Multi-Database Configuration
-
-**PostgreSQL Primary + SQL Server Secondary**:
-
-```toml
-<!-- Code example in TOML -->
-[database]
-url = "postgres://app:pass@localhost:5432/myapp"
-
-[database.secondary]
-sql_server_url = "sqlserver://app:pass@sqlserver:1433/myapp"
-
-[observability]
-enabled = true
-sample_rate = 0.1
-
-# Metrics always go to PostgreSQL (best pg_stats support)
-[observability.database]
-url = "postgres://metrics:pass@metrics-db:5432/metrics"
-
-[observability.analysis]
-# Analyzer detects database type from query patterns
-# Generates appropriate SQL for each database
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Database Schema Setup
-
-### PostgreSQL
-
-The observability system automatically creates these tables on first run:
-
-```sql
-<!-- Code example in SQL -->
--- Create schema
-CREATE SCHEMA IF NOT EXISTS fraiseql_metrics;
-
--- Query execution metrics
-CREATE TABLE fraiseql_metrics.query_executions (
-    id BIGSERIAL PRIMARY KEY,
-    query_name TEXT NOT NULL,
-    execution_time_ms FLOAT NOT NULL,
-    sql_generation_time_ms FLOAT NOT NULL,
-    db_round_trip_time_ms FLOAT NOT NULL,
-    projection_time_ms FLOAT NOT NULL,
-    rows_returned INTEGER NOT NULL,
-    cache_hit BOOLEAN NOT NULL,
-    executed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
--- Index for time-series queries
-CREATE INDEX idx_query_executions_name_time
-    ON fraiseql_metrics.query_executions (query_name, executed_at DESC);
-
--- Index for analysis queries
-CREATE INDEX idx_query_executions_time
-    ON fraiseql_metrics.query_executions (executed_at DESC);
-
--- JSONB path access patterns
-CREATE TABLE fraiseql_metrics.jsonb_accesses (
-    id BIGSERIAL PRIMARY KEY,
-    table_name TEXT NOT NULL,
-    jsonb_column TEXT NOT NULL,
-    path TEXT NOT NULL,
-    access_type TEXT NOT NULL,  -- 'Filter', 'Sort', 'Project', 'Aggregate'
-    query_name TEXT NOT NULL,
-    selectivity FLOAT,
-    recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
--- Index for pattern analysis
-CREATE INDEX idx_jsonb_accesses_lookup
-    ON fraiseql_metrics.jsonb_accesses (table_name, jsonb_column, path);
-
--- Index for frequency counting
-CREATE INDEX idx_jsonb_accesses_time
-    ON fraiseql_metrics.jsonb_accesses (recorded_at DESC);
-
--- Aggregated statistics (updated periodically)
-CREATE TABLE fraiseql_metrics.query_stats (
-    query_name TEXT PRIMARY KEY,
-    total_executions BIGINT NOT NULL,
-    total_time_ms FLOAT NOT NULL,
-    p50_ms FLOAT,
-    p95_ms FLOAT,
-    p99_ms FLOAT,
-    avg_rows FLOAT,
-    last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-```text
-<!-- Code example in TEXT -->
-
----
-
-### SQL Server
-
-```sql
-<!-- Code example in SQL -->
--- Create schema
-CREATE SCHEMA fraiseql_metrics;
-GO
-
--- Query execution metrics
-CREATE TABLE fraiseql_metrics.query_executions (
-    id BIGINT IDENTITY(1,1) PRIMARY KEY,
-    query_name NVARCHAR(256) NOT NULL,
-    execution_time_ms FLOAT NOT NULL,
-    sql_generation_time_ms FLOAT NOT NULL,
-    db_round_trip_time_ms FLOAT NOT NULL,
-    projection_time_ms FLOAT NOT NULL,
-    rows_returned INT NOT NULL,
-    cache_hit BIT NOT NULL,
-    executed_at DATETIME2 NOT NULL DEFAULT GETDATE()
-);
-
--- Indexes
-CREATE NONCLUSTERED INDEX idx_query_executions_name_time
-    ON fraiseql_metrics.query_executions (query_name, executed_at DESC);
-
-CREATE NONCLUSTERED INDEX idx_query_executions_time
-    ON fraiseql_metrics.query_executions (executed_at DESC);
-
--- JSON path access patterns
-CREATE TABLE fraiseql_metrics.json_accesses (
-    id BIGINT IDENTITY(1,1) PRIMARY KEY,
-    table_name NVARCHAR(128) NOT NULL,
-    json_column NVARCHAR(128) NOT NULL,
-    path NVARCHAR(512) NOT NULL,
-    access_type NVARCHAR(50) NOT NULL,
-    query_name NVARCHAR(256) NOT NULL,
-    selectivity FLOAT,
-    recorded_at DATETIME2 NOT NULL DEFAULT GETDATE()
-);
-
--- Indexes
-CREATE NONCLUSTERED INDEX idx_json_accesses_lookup
-    ON fraiseql_metrics.json_accesses (table_name, json_column, path);
-
-CREATE NONCLUSTERED INDEX idx_json_accesses_time
-    ON fraiseql_metrics.json_accesses (recorded_at DESC);
-
--- Aggregated statistics
-CREATE TABLE fraiseql_metrics.query_stats (
-    query_name NVARCHAR(256) PRIMARY KEY,
-    total_executions BIGINT NOT NULL,
-    total_time_ms FLOAT NOT NULL,
-    p50_ms FLOAT,
-    p95_ms FLOAT,
-    p99_ms FLOAT,
-    avg_rows FLOAT,
-    last_updated DATETIME2 NOT NULL DEFAULT GETDATE()
-);
-GO
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Manual Schema Creation
-
-If auto-creation is disabled or fails:
-
-**PostgreSQL**:
-
-```bash
-<!-- Code example in BASH -->
-psql -U fraiseql_metrics -d fraiseql_metrics -f schema/postgres_metrics.sql
-```text
-<!-- Code example in TEXT -->
-
-**SQL Server**:
-
-```bash
-<!-- Code example in BASH -->
-sqlcmd -S localhost -U fraiseql_metrics -P password -i schema/sqlserver_metrics.sql
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Performance Tuning
-
-### High-Traffic Optimization
-
-For applications with > 10,000 qps:
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-sample_rate = 0.001  # 0.1% sampling
-
-[observability.metrics]
-buffer_size = 1000
-batch_size = 1000
-flush_interval_secs = 120  # Flush every 2 minutes
-
-[observability.database]
-pool_size = 50
-timeout_secs = 10  # Fail fast
-```text
-<!-- Code example in TEXT -->
-
-### Low-Latency Requirements
-
-For applications where every millisecond counts:
-
-```toml
-<!-- Code example in TOML -->
-[observability]
-sample_rate = 0.01  # 1% sampling
-
-[observability.metrics]
-# Async writes with minimal blocking
-buffer_size = 500
-flush_interval_secs = 30
-
-[observability.database]
-# Separate metrics database is critical
-url = "postgres://metrics:pass@async-metrics-db:5432/metrics"
-pool_size = 20
-timeout_secs = 5  # Drop metrics if DB is slow
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Monitoring Observability System
-
-### Metrics to Track
-
-**Application-Level** (via logs):
-
-```rust
-<!-- Code example in RUST -->
-// Log metrics collection health
-if metrics_buffer_full {
-    warn!("Metrics buffer full, dropping oldest entries");
-}
-
-if metrics_write_timeout {
-    warn!("Metrics write timed out after {}ms", timeout_ms);
-}
-
-// Periodic stats
-info!(
-    "Metrics: collected={}, flushed={}, dropped={}, buffer_size={}",
-    collected_count, flushed_count, dropped_count, buffer_len
-);
-```text
-<!-- Code example in TEXT -->
-
-**Database-Level** (query metrics tables):
-
-```sql
-<!-- Code example in SQL -->
--- PostgreSQL: Metrics collection rate
-SELECT
-    DATE_TRUNC('hour', executed_at) AS hour,
-    COUNT(*) AS metrics_collected
-FROM fraiseql_metrics.query_executions
-WHERE executed_at > NOW() - INTERVAL '24 hours'
-GROUP BY hour
-ORDER BY hour DESC;
-
--- SQL Server: Metrics collection rate
-SELECT
-    DATEPART(hour, executed_at) AS hour,
-    COUNT(*) AS metrics_collected
-FROM fraiseql_metrics.query_executions
-WHERE executed_at > DATEADD(hour, -24, GETDATE())
-GROUP BY DATEPART(hour, executed_at)
-ORDER BY hour DESC;
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Troubleshooting Configuration
-
-### Issue: Metrics Not Being Collected
-
-**Check**:
-
-1. Is observability enabled?
-
-   ```bash
-<!-- Code example in BASH -->
-   echo $FRAISEQL_OBSERVABILITY_ENABLED
-   # Should output: true
-   ```text
-<!-- Code example in TEXT -->
-
-2. Is sample rate too low?
-
-   ```bash
-<!-- Code example in BASH -->
-   echo $FRAISEQL_OBSERVABILITY_SAMPLE_RATE
-   # Should be > 0.0
-   ```text
-<!-- Code example in TEXT -->
-
-3. Check database connection:
-
-   ```bash
-<!-- Code example in BASH -->
-   psql $FRAISEQL_METRICS_DATABASE_URL -c "SELECT 1"
-   ```text
-<!-- Code example in TEXT -->
-
-4. Check application logs:
-
-   ```text
-<!-- Code example in TEXT -->
-   grep "observability" app.log
-   ```text
-<!-- Code example in TEXT -->
-
----
-
-### Issue: High Memory Usage
-
-**Symptoms**: Application memory grows over time
-
-**Cause**: Metrics buffer too large or not flushing
-
-**Solution**:
-
-```toml
-<!-- Code example in TOML -->
-[observability.metrics]
-buffer_size = 50          # Reduce from 100
-flush_interval_secs = 30  # Flush more frequently
-```text
-<!-- Code example in TEXT -->
-
----
-
-### Issue: Database Connection Errors
-
-**Symptoms**: "Failed to write metrics to database"
-
-**Solutions**:
-
-1. **Increase timeout**:
-
-   ```toml
-<!-- Code example in TOML -->
-   [observability.database]
-   timeout_secs = 60  # From 30
-   ```text
-<!-- Code example in TEXT -->
-
-2. **Increase pool size**:
-
-   ```toml
-<!-- Code example in TOML -->
-   [observability.database]
-   pool_size = 20  # From 10
-   ```text
-<!-- Code example in TEXT -->
-
-3. **Use separate database** (recommended):
-
-   ```toml
-<!-- Code example in TOML -->
-   [observability.database]
-   url = "postgres://metrics-only-db:5432/metrics"
-   ```text
-<!-- Code example in TEXT -->
-
----
-
-### Issue: Analysis Shows No Suggestions
-
-**Causes**:
-
-1. **Insufficient data**: Run application for 24-48 hours
-2. **Thresholds too high**: Lower them
-3. **No JSON usage**: Observability focuses on JSON/JSONB optimization
-
-**Solution**:
-
-```bash
-<!-- Code example in BASH -->
-# Lower thresholds temporarily
-FraiseQL-cli analyze \
-    --min-frequency 10 \
-    --min-speedup 2.0 \
-    --window 1d
-```text
-<!-- Code example in TEXT -->
-
----
-
-## Environment Variables Reference
-
-Complete list of all environment variables:
-
-| Variable | Type | Default | Description |
-|----------|------|---------|-------------|
-| `FRAISEQL_OBSERVABILITY_ENABLED` | bool | false | Enable observability |
-| `FRAISEQL_OBSERVABILITY_SAMPLE_RATE` | float | 0.1 | Sampling rate (0.0-1.0) |
-| `FRAISEQL_METRICS_DATABASE_URL` | string | (main DB) | Metrics database URL |
-| `FRAISEQL_METRICS_RETENTION_DAYS` | int | 30 | Metrics retention |
-| `FRAISEQL_METRICS_BUFFER_SIZE` | int | 100 | In-memory buffer size |
-| `FRAISEQL_METRICS_FLUSH_INTERVAL_SECS` | int | 60 | Flush interval |
-| `FRAISEQL_METRICS_BATCH_SIZE` | int | 100 | Batch insert size |
-| `FRAISEQL_METRICS_DB_POOL_SIZE` | int | 10 | Connection pool size |
-| `FRAISEQL_METRICS_DB_TIMEOUT_SECS` | int | 30 | Query timeout |
+### Small Application (< 100 rps)
+
+```python
+from fraiseql.fastapi import FraiseQLConfig
+
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    environment="production",
+    database_pool_size=5,
+    database_max_overflow=5,
+    cache_ttl=300,
+    rate_limit_enabled=True,
+    rate_limit_requests_per_minute=120,
+)
+```
+
+### Medium Application (100–1000 rps)
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@db-host:5432/myapp",
+    environment="production",
+    database_pool_size=20,
+    database_max_overflow=10,
+    cache_ttl=300,
+    complexity_enabled=True,
+    complexity_max_score=1000,
+    rate_limit_enabled=True,
+)
+```
+
+### Large Application (> 1000 rps)
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@db-cluster:5432/myapp",
+    environment="production",
+    database_pool_size=40,
+    database_max_overflow=20,
+    database_pool_timeout=10,        # fail fast under load
+    database_pool_recycle=1800,
+    cache_ttl=600,
+    execution_timeout_ms=15000,
+    complexity_enabled=True,
+    complexity_max_score=2000,
+    rate_limit_enabled=True,
+    rate_limit_requests_per_minute=600,
+)
+```
 
 ---
 
 ## Configuration Validation
 
-FraiseQL validates configuration on startup:
+`FraiseQLConfig` validates on construction (pydantic). For example, an invalid
+database URL or a missing `auth0_domain` when `auth_provider="auth0"` raises a
+`ValidationError` immediately at startup:
 
-```rust
-<!-- Code example in RUST -->
-// Invalid configuration example
-[observability]
-enabled = true
-sample_rate = 1.5  # ❌ ERROR: Must be 0.0-1.0
+```python
+from pydantic import ValidationError
+from fraiseql.fastapi import FraiseQLConfig
 
-// Validation error:
-// Error: Invalid observability configuration
-//   - sample_rate must be between 0.0 and 1.0 (got 1.5)
-```text
-<!-- Code example in TEXT -->
+try:
+    config = FraiseQLConfig(database_url="mysql://nope")  # not PostgreSQL
+except ValidationError as exc:
+    print(exc)
+    # Database URL must start with postgresql:// or postgres://
+```
 
-**Validation Rules**:
+Notable validation behavior:
 
-- `sample_rate`: 0.0 ≤ x ≤ 1.0
-- `retention_days`: > 0
-- `buffer_size`: > 0
-- `flush_interval_secs`: > 0
-- `batch_size`: > 0
-- `pool_size`: 1-100
-- `timeout_secs`: > 0
+- `database_url` must start with `postgresql://` or `postgres://` (Unix sockets
+  supported).
+- In `environment="production"`, introspection and the playground are disabled
+  unless explicitly re-enabled.
+- A wildcard `*` CORS origin in production logs a security warning.
+- `auth0_domain` is required when `auth_provider="auth0"`.
+- Collation and session-variable names are validated against SQL-injection
+  characters.
+
+---
+
+## Troubleshooting Configuration
+
+### Settings not taking effect
+
+1. Confirm the env var name is `FRAISEQL_`-prefixed and uppercase:
+
+   ```bash
+   echo $FRAISEQL_DATABASE_URL
+   ```
+
+2. Remember that explicit Python values passed to `FraiseQLConfig(...)` or
+   `create_fraiseql_app(...)` override env vars.
+
+3. If you use a `.env` file, make sure it sits in the process working directory.
+
+### Database connection errors
+
+1. Verify the URL works directly:
+
+   ```bash
+   psql "$FRAISEQL_DATABASE_URL" -c "SELECT 1"
+   ```
+
+2. Increase pool capacity if you see pool-timeout errors:
+
+   ```python
+   config = FraiseQLConfig(
+       database_url="postgresql://app:pass@localhost/myapp",
+       database_pool_size=40,
+       database_max_overflow=20,
+   )
+   ```
+
+### Inspecting generated SQL
+
+Turn on SQL echo in development to see what FraiseQL sends to PostgreSQL:
+
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://app:pass@localhost/myapp",
+    database_echo=True,
+)
+```
+
+For application logs, use standard Python logging (e.g. `LOG_LEVEL` in your own
+process configuration) and uvicorn's `--log-level` flag.
 
 ---
 
 ## Next Steps
 
-- **[Metrics Collection Guide](../observability/metrics-collection.md)** - What data is collected
-- **[Troubleshooting](../observability/troubleshooting.md)** - Common issues and solutions
-- **[Observability Guide](./observability.md)** - Complete observability setup
-
----
-
-*Last updated: 2026-01-12*
+- **[Observability Guide](./observability.md)** — metrics, health checks, and
+  error tracking
+- **[Authentication](../advanced/authentication.md)** — Auth0 and custom
+  providers
+- **[Deployment](../production/deployment.md)** — running the FastAPI app in production

--- a/docs/operations/distributed-tracing.md
+++ b/docs/operations/distributed-tracing.md
@@ -1,392 +1,259 @@
-<!-- Skip to main content -->
 ---
-
-title: Distributed Tracing in FraiseQL v2
-description: FraiseQL v2 provides comprehensive distributed tracing support for tracking requests across service boundaries. Built on W3C Trace Context standards, it enables
+title: Distributed Tracing in FraiseQL
+description: FraiseQL provides OpenTelemetry-based distributed tracing for tracking GraphQL requests across service boundaries. Built on W3C Trace Context standards, it enables end-to-end request correlation, performance analysis, and debugging.
 keywords: ["deployment", "scaling", "performance", "monitoring", "troubleshooting"]
 tags: ["documentation", "reference"]
 ---
 
-# Distributed Tracing in FraiseQL v2
+# Distributed Tracing in FraiseQL
 
 ## Overview
 
-FraiseQL v2 provides comprehensive distributed tracing support for tracking requests across service boundaries. Built on W3C Trace Context standards, it enables end-to-end request correlation, performance analysis, and debugging in microservice architectures.
+FraiseQL provides distributed tracing built on [OpenTelemetry](https://opentelemetry.io/). It instruments your FraiseQL application — running as a FastAPI app under `uvicorn` — so you can track GraphQL operations across the full request lifecycle: HTTP request, GraphQL execution, and the PostgreSQL queries underneath.
+
+Trace context propagates using the W3C Trace Context standard, so traces stitch together across service boundaries and into any backend you point at (Jaeger, Zipkin, or any OTLP collector).
 
 ## Key Features
 
+- **OpenTelemetry-based**: Standard SDK, standard exporters, no proprietary wire format
 - **W3C Trace Context Support**: Standard-compliant trace propagation across services
-- **Request Correlation**: Unique trace IDs for following requests through entire system
-- **Span Management**: Track individual operations within a trace
-- **Cross-cutting Context**: Baggage for sharing metadata across services
-- **Event Tracking**: Record significant events during request execution
-- **Status Tracking**: Track operation success, errors, and completion
-- **Zero External Dependencies**: No vendor lock-in, works with any tracing backend
+- **HTTP request tracing**: Each request gets a span via `TracingMiddleware`
+- **GraphQL operation tracing**: Query and mutation spans with operation type and name
+- **PostgreSQL auto-instrumentation**: psycopg queries are traced automatically
+- **Configurable sampling**: Trace a fraction of traffic in high-volume scenarios
+- **Path exclusion**: Skip health/metrics/docs endpoints from tracing
+- **Variable sanitization**: Redact sensitive GraphQL variables before they reach a span
 
-## Architecture
+## Installation
 
-### Core Components
+Tracing depends on the OpenTelemetry SDK and exporters. Install the tracing extra (and the exporter for your backend):
 
-#### TraceContext
+```bash
+# OpenTelemetry SDK + OTLP/Jaeger exporters and psycopg instrumentation
+pip install "fraiseql[tracing]"
 
-Main context for request propagation across service boundaries.
+# Or install the OpenTelemetry packages directly
+pip install opentelemetry-sdk \
+    opentelemetry-exporter-otlp \
+    opentelemetry-instrumentation-psycopg
+```
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
+If OpenTelemetry is not installed, FraiseQL's tracing degrades to a no-op: `setup_tracing` and the tracer still work, but no spans are emitted.
 
-// Create new trace
-let ctx = TraceContext::new();
-println!("Trace: {}", ctx.trace_id);
+## Quick Start
 
-// Create child context (for downstream service calls)
-let child = ctx.child_span();
-assert_eq!(child.trace_id, ctx.trace_id); // Same trace
-assert_ne!(child.span_id, ctx.span_id);   // Different span
+Create your app with `create_fraiseql_app`, then call `setup_tracing` on the returned FastAPI app:
 
-// Add cross-cutting context
-let ctx_with_baggage = ctx
-    .with_baggage("user_id".to_string(), "user123".to_string())
-    .with_baggage("tenant".to_string(), "acme".to_string());
+```python
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.tracing import setup_tracing, TracingConfig
 
-// Check baggage
-assert_eq!(ctx_with_baggage.baggage_item("user_id"), Some("user_id"));
-```text
-<!-- Code example in TEXT -->
-
-#### TraceSpan
-
-Individual operation within a trace.
-
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceSpan;
-
-let span = TraceSpan::new(
-    "trace-id".to_string(),
-    "GetUser".to_string()
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+    production=True,
 )
-.add_attribute("db.system".to_string(), "postgresql".to_string())
-.add_attribute("http.status_code".to_string(), "200".to_string());
 
-// Add events
-let event = TraceEvent::new("query_executed".to_string())
-    .with_attribute("rows".to_string(), "1".to_string());
+# Enable distributed tracing on the FastAPI app
+setup_tracing(
+    app,
+    TracingConfig(
+        service_name="my-graphql-api",
+        service_version="1.4.0",
+        deployment_environment="production",
+        export_format="otlp",
+        export_endpoint="http://otel-collector:4317",
+        sample_rate=1.0,
+    ),
+)
+```
 
-let span = span.add_event(event);
+Run it with `uvicorn`:
 
-// Mark as complete
-let mut span = span;
-span.finish();
-assert!(span.end_time_ms.is_some());
-```text
-<!-- Code example in TEXT -->
+```bash
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
 
-#### TraceEvent
+`setup_tracing(app, config)` adds `TracingMiddleware` to the app (when `config.enabled` is true) and returns a `FraiseQLTracer`. The middleware opens a SERVER span per request, extracts inbound W3C trace context from the request headers, and automatically instruments psycopg so each PostgreSQL query becomes a child span.
 
-Significant event during span execution.
+## Configuration
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceEvent;
+All configuration lives on the `TracingConfig` dataclass (`from fraiseql.tracing import TracingConfig`). These are the real, verified fields:
 
-let event = TraceEvent::new("cache_miss".to_string())
-    .with_attribute("cache_key".to_string(), "query:user:123".to_string())
-    .with_attribute("cache_type".to_string(), "redis".to_string());
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `True` | Master switch; when `False`, no middleware is added |
+| `service_name` | `str` | `"fraiseql"` | Reported as `service.name` on the OTel resource |
+| `service_version` | `str` | `"unknown"` | Reported as `service.version` |
+| `deployment_environment` | `str` | `"development"` | Reported as `deployment.environment` |
+| `sample_rate` | `float` | `1.0` | Fraction of traces to sample (`0.0`–`1.0`) |
+| `export_endpoint` | `str \| None` | `None` | Collector endpoint; no exporter is attached if unset |
+| `export_format` | `str` | `"otlp"` | One of `"otlp"`, `"jaeger"`, `"zipkin"` |
+| `export_timeout_ms` | `int` | `30000` | Export timeout in milliseconds |
+| `propagate_traces` | `bool` | `True` | Inject/extract W3C trace context on headers |
+| `exclude_paths` | `set[str]` | `{"/health", "/ready", "/metrics", "/docs", "/openapi.json"}` | Request paths skipped by the middleware |
+| `attributes` | `dict[str, Any]` | `{}` | Custom attributes added to every span and the resource |
 
-println!("Event: {} at {}", event.name, event.timestamp_ms);
-```text
-<!-- Code example in TEXT -->
+`sample_rate` must be between `0.0` and `1.0`, and `export_format` must be one of `otlp`, `jaeger`, `zipkin` — both are validated when the config is constructed.
 
-#### SpanStatus
+Example with custom resource attributes and a reduced sample rate:
 
-Status enumeration for span execution.
+```python
+from fraiseql.tracing import setup_tracing, TracingConfig
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::SpanStatus;
+config = TracingConfig(
+    service_name="orders-api",
+    service_version="2.1.0",
+    deployment_environment="production",
+    export_format="otlp",
+    export_endpoint="http://otel-collector:4317",
+    sample_rate=0.1,                       # sample 10% of traffic
+    exclude_paths={"/health", "/metrics"},  # override the default exclusions
+    attributes={"team": "payments", "region": "eu-west-1"},
+)
 
-// Successful execution
-let status = SpanStatus::Ok;
+setup_tracing(app, config)
+```
 
-// Error case
-let error_status = SpanStatus::Error {
-    message: "Database connection timeout".to_string()
-};
+## How It Works
 
-println!("Status: {}", error_status);
-```text
-<!-- Code example in TEXT -->
+### HTTP request spans
 
-## Usage Examples
+`TracingMiddleware` wraps every non-excluded request:
 
-### Basic Request Tracing
+1. Extracts inbound W3C trace context from the request headers (when `propagate_traces` is on).
+2. Starts a SERVER span named `"{method} {path}"`.
+3. Records HTTP attributes (`http.method`, `http.target`, `http.scheme`, `http.host`, `http.status_code`).
+4. Marks the span as an error and records the exception if the handler raises or returns a 4xx/5xx status.
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
+### PostgreSQL query spans
 
-// Incoming request
-let trace_ctx = TraceContext::new();
-println!("Trace ID: {}", trace_ctx.trace_id);
-println!("Span ID: {}", trace_ctx.span_id);
+When tracing is enabled and OpenTelemetry is installed, `FraiseQLTracer` calls `PsycopgInstrumentor().instrument()` once. From then on, every PostgreSQL query issued through psycopg — including the reads against your `v_`/`tv_` views and the `fn_` function calls behind mutations — is captured as a CLIENT span with `db.system = "postgresql"` and the SQL statement attached.
 
-// Log with tracing context
-tracing::info!(
-    trace_id = %trace_ctx.trace_id,
-    span_id = %trace_ctx.span_id,
-    "Processing GraphQL query"
-);
-```text
-<!-- Code example in TEXT -->
+### GraphQL operation spans
 
-### W3C Trace Context Headers
+`get_tracer()` returns the global `FraiseQLTracer`. Its context managers let you wrap GraphQL work explicitly:
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
+```python
+from fraiseql.tracing import get_tracer
 
-// Create trace
-let trace = TraceContext::new();
+tracer = get_tracer()
 
-// Generate W3C traceparent header for HTTP requests
-let header = trace.to_w3c_traceparent();
-println!("traceparent: {}", header);
-// Output: "traceparent: 00-abc123def456789012345678901234ab-fedcba9876543210-01"
+# Trace a query operation
+with tracer.trace_graphql_query("GetUser", query_text, variables):
+    result = await execute_query()
 
-// Send downstream
-// GET /api/users HTTP/1.1
-// traceparent: 00-abc123def456789012345678901234ab-fedcba9876543210-01
+# Trace a mutation operation
+with tracer.trace_graphql_mutation("CreateUser", query_text, variables):
+    result = await execute_mutation()
 
-// Parse incoming header
-let incoming_header = "00-abc123def456789012345678901234ab-fedcba9876543210-01";
-let downstream_trace = TraceContext::from_w3c_traceparent(incoming_header)
-    .expect("Valid traceparent header");
+# Trace a database operation directly
+with tracer.trace_database_query("SELECT", "v_user", sql):
+    rows = await run_sql(sql)
+```
 
-// Same trace, different span
-assert_eq!(downstream_trace.trace_id, trace.trace_id);
-assert_eq!(downstream_trace.parent_span_id, Some(trace.span_id));
-```text
-<!-- Code example in TEXT -->
+Each manager sets the relevant attributes (`graphql.operation.type`, `graphql.operation.name`, `graphql.document`, or `db.system`/`db.table`/`db.statement`), records exceptions, and sets an error status on failure.
 
-### Baggage for Cross-cutting Context
+### Decorator helpers
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
+`trace_graphql_operation` and `trace_database_query` are decorators for wrapping your own functions. They work on both sync and async callables and reuse the global tracer:
 
-// Add authentication and organizational context
-let trace = TraceContext::new()
-    .with_baggage("user_id".to_string(), "user_456".to_string())
-    .with_baggage("tenant_id".to_string(), "tenant_789".to_string())
-    .with_baggage("request_priority".to_string(), "high".to_string());
+```python
+from fraiseql.tracing import trace_graphql_operation, trace_database_query
 
-// Access baggage
-println!("User: {}", trace.baggage_item("user_id").unwrap_or("unknown"));
+@trace_graphql_operation("query", "ListUsers")
+async def list_users(query: str = "", variables: dict | None = None) -> list[User]:
+    ...
 
-// Baggage inherited by child spans
-let child = trace.child_span();
-assert_eq!(child.baggage_item("user_id"), Some("user_456"));
-assert_eq!(child.baggage_item("tenant_id"), Some("tenant_789"));
-```text
-<!-- Code example in TEXT -->
+@trace_database_query("SELECT", "v_user")
+async def fetch_users(sql: str) -> list[dict]:
+    ...
+```
 
-### Span Lifecycle
+### GraphQL-aware tracing and variable sanitization
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::{TraceSpan, SpanStatus, TraceEvent};
+For finer GraphQL tracing — operation-type detection, query truncation, and per-resolver spans — use `GraphQLTracer` with its own `GraphQLTracingConfig`:
 
-let trace_id = "trace-12345".to_string();
+```python
+from fraiseql.tracing import GraphQLTracer, GraphQLTracingConfig
 
-// Create span
-let mut span = TraceSpan::new(trace_id, "ExecuteQuery".to_string())
-    .with_parent_span("parent-span-id".to_string())
-    .add_attribute("query_type".to_string(), "SELECT".to_string());
+gql_tracer = GraphQLTracer(
+    GraphQLTracingConfig(
+        trace_resolvers=True,
+        include_variables=False,    # keep variables out of spans by default
+        sanitize_variables=True,    # redact sensitive values if included
+        max_query_length=1000,      # truncate long query documents
+    )
+)
 
-// Record events during execution
-span = span.add_event(
-    TraceEvent::new("parse_complete".to_string())
-);
+with gql_tracer.trace_query("GetUser", query_text, variables):
+    result = await execute_query()
+```
 
-span = span.add_event(
-    TraceEvent::new("validation_complete".to_string())
-);
+When `include_variables` is enabled, values whose keys match the sanitize patterns (`password`, `token`, `secret`, `key`, `auth`, `credential`, `api_key`, `apikey`, `session`, `cookie`, `authorization`) are replaced with `[REDACTED]` before being recorded.
 
-span = span.add_event(
-    TraceEvent::new("execution_start".to_string())
-        .with_attribute("row_count".to_string(), "42".to_string())
-);
+## Integration with Tracing Backends
 
-// Mark completion
-span.finish();
-println!("Duration: {:?}ms", span.duration_ms());
+FraiseQL exports through standard OpenTelemetry exporters. Pick a backend by setting `export_format` and pointing `export_endpoint` at the right collector.
 
-// Success status
-span = span.set_ok();
-```text
-<!-- Code example in TEXT -->
+### OTLP collector (recommended)
 
-### Error Tracking in Traces
+```python
+from fraiseql.tracing import setup_tracing, TracingConfig
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::{TraceSpan, SpanStatus};
+setup_tracing(
+    app,
+    TracingConfig(
+        service_name="my-api",
+        export_format="otlp",
+        export_endpoint="http://otel-collector:4317",
+    ),
+)
+```
 
-let mut span = TraceSpan::new("trace-123".to_string(), "DatabaseQuery".to_string());
+An OTLP collector can fan traces out to Jaeger, Tempo, Datadog, Honeycomb, or any OTLP-compatible backend without changing your application code.
 
-// Something fails
-let error_result = "SELECT * FROM nonexistent_table".parse::<String>();
+### Jaeger
 
-if let Err(e) = error_result {
-    // Record error in span
-    span = span.set_error(format!("SQL Parse Error: {}", e));
-}
+```python
+from fraiseql.tracing import setup_tracing, TracingConfig
 
-span.finish();
+setup_tracing(
+    app,
+    TracingConfig(
+        service_name="my-api",
+        export_format="jaeger",
+        export_endpoint="jaeger-agent:6831",  # host:port
+    ),
+)
+```
 
-// Check status
-match &span.status {
-    SpanStatus::Error { message } => {
-        println!("Query failed: {}", message);
-    },
-    _ => println!("Unexpected status")
-}
-```text
-<!-- Code example in TEXT -->
-
-### Request Context Integration
-
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::{TraceContext, RequestContext, RequestId};
-
-// Create request-scoped context
-let trace = TraceContext::new();
-let mut request_ctx = RequestContext::new()
-    .with_operation("GetUser".to_string())
-    .with_user_id("user123".to_string());
-
-// Correlate trace and request
-tracing::info!(
-    trace_id = %trace.trace_id,
-    span_id = %trace.span_id,
-    operation = %request_ctx.operation.as_ref().unwrap_or(&"unknown".to_string()),
-    user_id = %request_ctx.user_id.as_ref().unwrap_or(&"unknown".to_string()),
-    "Query initiated"
-);
-```text
-<!-- Code example in TEXT -->
-
-## Integration with Tracing Systems
-
-### Jaeger (OpenTelemetry)
-
-Export trace context to Jaeger:
-
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
-
-let trace = TraceContext::new();
-
-// Send to Jaeger collector
-// POST http://jaeger-collector:14268/api/traces
-let payload = serde_json::json!({
-    "traceID": trace.trace_id,
-    "spans": [
-        {
-            "spanID": trace.span_id,
-            "operationName": "GraphQLQuery",
-            "startTime": chrono::Utc::now().timestamp_millis(),
-            "tags": [
-                {"key": "span.kind", "vStr": "internal"},
-                {"key": "component", "vStr": "FraiseQL"}
-            ]
-        }
-    ]
-});
-```text
-<!-- Code example in TEXT -->
+For `jaeger`, the endpoint is parsed as `host:port` for the Jaeger agent.
 
 ### Zipkin
 
-Export to Zipkin:
+```python
+from fraiseql.tracing import setup_tracing, TracingConfig
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
+setup_tracing(
+    app,
+    TracingConfig(
+        service_name="my-api",
+        export_format="zipkin",
+        export_endpoint="http://zipkin:9411/api/v2/spans",
+    ),
+)
+```
 
-let trace = TraceContext::new();
-
-// Format for Zipkin v2 API
-let span = serde_json::json!({
-    "traceId": trace.trace_id,
-    "id": trace.span_id,
-    "name": "query",
-    "timestamp": chrono::Utc::now().timestamp_micros(),
-    "tags": {
-        "http.status_code": "200",
-        "span.kind": "SPAN_KIND_INTERNAL"
-    }
-});
-```text
-<!-- Code example in TEXT -->
-
-### Datadog
-
-Integrate with Datadog:
-
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
-
-let trace = TraceContext::new();
-
-// Use as correlation ID in Datadog
-tracing::info!(
-    dd_trace_id = %trace.trace_id,
-    dd_span_id = %trace.span_id,
-    "Event for Datadog correlation"
-);
-```text
-<!-- Code example in TEXT -->
-
-### Custom Backend
-
-Implement custom trace exporter:
-
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::{TraceContext, TraceSpan};
-
-pub struct CustomTraceExporter;
-
-impl CustomTraceExporter {
-    pub async fn export_span(span: TraceSpan) -> Result<(), String> {
-        // Convert to your backend format
-        let payload = serde_json::json!({
-            "trace_id": span.trace_id,
-            "span_id": span.span_id,
-            "operation": span.operation,
-            "duration_ms": span.duration_ms(),
-            "status": span.status.to_string(),
-        });
-
-        // Send to backend
-        // POST to custom collector
-        Ok(())
-    }
-}
-```text
-<!-- Code example in TEXT -->
+The Zipkin exporter is optional. If it is not installed, FraiseQL logs a warning and falls back to no exporter — install a compatible `opentelemetry-exporter-zipkin` to enable it.
 
 ## W3C Trace Context Format
 
-FraiseQL uses the W3C Trace Context standard for interoperability:
+FraiseQL relies on OpenTelemetry's default W3C Trace Context propagation for interoperability. Downstream and upstream services exchange the `traceparent` header:
 
 ```text
-<!-- Code example in TEXT -->
 Header: traceparent
 Format: version-traceid-spanid-traceflags
 
@@ -395,109 +262,80 @@ traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 
 Components:
 
-- 00: Version (always 00 for current version)
+- 00: Version (always 00 for the current version)
 - 0af7651916cd43dd8448eb211c80319c: Trace ID (32 hex digits)
 - b7ad6b7169203331: Span ID (16 hex digits)
 - 01: Trace flags (2 hex digits)
   - 0x01: Sampled
   - 0x00: Not sampled
-```text
-<!-- Code example in TEXT -->
+```
+
+When `propagate_traces` is enabled, the middleware extracts this header on inbound requests, and the tracer can inject it on outbound calls via `tracer.inject_context(headers)`.
 
 ## Sampling Strategy
 
-Control trace sampling for high-volume scenarios:
+Control trace volume with `sample_rate`. FraiseQL uses OpenTelemetry's `TraceIdRatioBased` sampler under the hood:
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
+```python
+from fraiseql.tracing import TracingConfig
 
-// Sample all traces
-let trace = TraceContext::new();
-assert!(trace.is_sampled());
+# Sample everything (development / low traffic)
+TracingConfig(sample_rate=1.0)
 
-// Disable sampling
-let mut trace = TraceContext::new();
-trace.set_sampled(false);
-assert!(!trace.is_sampled());
+# Sample 10% of traffic (high-volume production)
+TracingConfig(sample_rate=0.1)
 
-// Implement sampling policy
-fn should_sample(user_id: Option<&str>, priority: Option<&str>) -> bool {
-    // Always sample authenticated users
-    if user_id.is_some() {
-        return true;
-    }
+# Disable tracing entirely
+TracingConfig(enabled=False)
+```
 
-    // Always sample high-priority requests
-    if priority == Some("high") {
-        return true;
-    }
-
-    // Sample 10% of other requests
-    rand::random::<f64>() < 0.1
-}
-```text
-<!-- Code example in TEXT -->
+Start at `1.0` in development and lower the rate as traffic grows. Because the sampler is trace-ID based, a sampling decision is consistent across all services that share a trace.
 
 ## Performance Considerations
 
-### Memory Usage
-
-- TraceContext: ~400 bytes (including baggage)
-- TraceSpan: ~600 bytes (with events)
-- Negligible overhead per request
-
-### CPU Usage
-
-- Trace ID generation: < 1 microsecond
-- Header parsing: < 5 microseconds
-- No blocking operations
+- **PostgreSQL spans** are produced by the standard psycopg instrumentation; overhead is dominated by export, not capture.
+- **Sampling** is the primary lever for high-volume systems — lower `sample_rate` to reduce both CPU and export cost.
+- **Batched export**: spans are flushed through a `BatchSpanProcessor`, so export happens off the request path.
+- **Excluded paths** (`exclude_paths`) keep health checks and metrics scrapes out of your trace data.
 
 ## Best Practices
 
-1. **Always Create Traces**: Every request should have a trace ID
-2. **Propagate Headers**: Forward W3C headers to downstream services
-3. **Add Context**: Use baggage for authentication and organizational data
-4. **Record Events**: Document significant operations in spans
-5. **Monitor Sampling**: Adjust sampling based on traffic patterns
-6. **Correlate Logs**: Include trace ID in all log entries
-7. **Set Timeouts**: Configure appropriate spans timeouts
-8. **Handle Errors**: Record error details in span status
+1. **Name your service**: set `service_name`, `service_version`, and `deployment_environment` so traces are easy to filter.
+2. **Use an OTLP collector**: export via OTLP and let the collector route to your backend(s).
+3. **Tune sampling**: lower `sample_rate` as traffic grows; keep `1.0` in development.
+4. **Exclude noise**: keep health/metrics/docs paths in `exclude_paths`.
+5. **Never leak secrets**: keep `include_variables=False` (or `sanitize_variables=True`) so credentials never reach a span.
+6. **Propagate context**: leave `propagate_traces=True` so multi-service requests correlate end to end.
+7. **Correlate logs**: include the trace ID in your structured log records.
 
 ## Troubleshooting
 
-### Trace Not Appearing
+### No traces appearing
 
-- Verify trace ID propagation across services
-- Check W3C header format: `00-{32-hex}-{16-hex}-{2-hex}`
-- Ensure sampled flag is set correctly
-- Verify backend collector is receiving traces
+- Confirm OpenTelemetry is installed (`pip install "fraiseql[tracing]"`); without it, tracing is a no-op.
+- Confirm `enabled=True` and that `export_endpoint` points at a reachable collector.
+- Check the request path is not in `exclude_paths`.
+- Verify `sample_rate` is greater than `0.0`.
 
-### Missing Span Context
+### Missing PostgreSQL query spans
 
-- Check if TraceContext was created before span
-- Verify parent_span_id is set correctly
-- Ensure baggage is preserved across service boundaries
+- Ensure the psycopg instrumentation package is installed.
+- Confirm `setup_tracing` ran (psycopg is instrumented when the tracer initializes with `enabled=True`).
+
+### Broken cross-service correlation
+
+- Verify `propagate_traces=True` on both services.
+- Check the `traceparent` header is forwarded by any proxy in front of the app.
+- Confirm the header format: `00-{32-hex}-{16-hex}-{2-hex}`.
 
 ## Testing
 
-All tracing components are fully tested:
+Tracing has full unit coverage. Run the tracing tests with pytest:
 
 ```bash
-<!-- Code example in BASH -->
-# Run tracing tests
-cargo test -p FraiseQL-server --lib tracing
+# Run the tracing tests
+uv run pytest tests/ -k tracing
 
-# Run all tests
-cargo test -p FraiseQL-server --lib
-```text
-<!-- Code example in TEXT -->
-
-## Future Enhancements
-
-- OpenTelemetry integration
-- Automatic instrumentation
-- Metrics export from traces
-- Performance profiling via traces
-- Distributed sampling strategies
-- Automatic error grouping
+# Run the full test suite
+uv run pytest tests/
+```

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,17 +1,17 @@
-<!-- Skip to main content -->
 ---
-
-title: FraiseQL v2 Observability & Monitoring Guide
-description: FraiseQL v2 provides a comprehensive, production-ready observability stack that enables real-time monitoring, performance analysis, debugging, and operational e
+title: FraiseQL v1 Observability & Monitoring Guide
+description: FraiseQL v1 provides a Python observability toolkit — Prometheus metrics, OpenTelemetry tracing, health/readiness checks, query statistics, PostgreSQL-native error tracking, and security audit logging — wired into your FastAPI app.
 keywords: ["deployment", "scaling", "performance", "monitoring", "troubleshooting"]
 tags: ["documentation", "reference"]
 ---
 
-# FraiseQL v2 Observability & Monitoring Guide
+# FraiseQL v1 Observability & Monitoring Guide
 
 ## Overview
 
-FraiseQL v2 provides a comprehensive, production-ready observability stack that enables real-time monitoring, performance analysis, debugging, and operational excellence. The observability system integrates Prometheus metrics, structured JSON logging, distributed tracing, and performance monitoring into a cohesive platform.
+FraiseQL v1 ships a Python observability toolkit that you compose onto the FastAPI app returned by `create_fraiseql_app(...)`. It integrates Prometheus metrics, OpenTelemetry distributed tracing, composable health checks (with built-in `/health` and `/ready` endpoints), `pg_stat_statements`-backed query statistics, PostgreSQL-native error tracking, and structured security audit logging.
+
+Everything runs **inside your FastAPI/uvicorn process** — there is no separate server and no build step. You import helpers from `fraiseql.monitoring`, `fraiseql.tracing`, and `fraiseql.audit`, then call them on the app at startup.
 
 ## Table of Contents
 
@@ -28,443 +28,459 @@ FraiseQL v2 provides a comprehensive, production-ready observability stack that 
 
 ### Minimal Setup
 
-```bash
-<!-- Code example in BASH -->
-# 1. Start FraiseQL Server
-RUST_LOG=info cargo run -p FraiseQL-server
+Wire metrics and tracing onto the FastAPI app, then run it with uvicorn:
 
-# 2. Access metrics endpoint
+```python
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.monitoring import setup_metrics, MetricsConfig
+from fraiseql.tracing import setup_tracing, TracingConfig
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+    production=True,
+)
+
+# Prometheus metrics + /metrics endpoint
+setup_metrics(app, MetricsConfig(namespace="fraiseql"))
+
+# OpenTelemetry distributed tracing
+setup_tracing(app, TracingConfig(service_name="fraiseql"))
+```
+
+```bash
+# Run the app
+uvicorn myapp:app --host 0.0.0.0 --port 8000
+
+# Scrape Prometheus metrics
 curl http://localhost:8000/metrics
 
-# 3. Access health check
+# Liveness probe
 curl http://localhost:8000/health
 
-# 4. View introspection schema
-curl http://localhost:8000/introspection
-```text
-<!-- Code example in TEXT -->
+# Readiness probe (checks the database + schema)
+curl http://localhost:8000/ready
+```
+
+The `/health` and `/ready` endpoints are added automatically by `create_fraiseql_app`. `setup_metrics` adds the `/metrics` endpoint (path configurable via `MetricsConfig.metrics_path`).
 
 ### With Prometheus + Grafana
 
 ```bash
-<!-- Code example in BASH -->
-# 1. Start Docker services
-docker-compose -f docker-compose.yml up -d
+# 1. Start Docker services (app + Prometheus + Grafana)
+docker compose up -d
 
-# 2. Access Grafana
+# 2. Open Grafana
 open http://localhost:3000
 
-# 3. Add Prometheus datasource
-# - URL: http://prometheus:9090
-# - Default
+# 3. Add a Prometheus datasource
+#    - URL: http://prometheus:9090
+#    - Set as default
 
-# 4. Import dashboard
-# - URL: file://monitoring/grafana-dashboard.json
-```text
-<!-- Code example in TEXT -->
+# 4. Build dashboards from the fraiseql_* metric series
+```
 
 ### Accessing Metrics
 
 ```bash
-<!-- Code example in BASH -->
-# Prometheus text format (scrape by Prometheus)
+# Prometheus text exposition format (scraped by Prometheus)
 curl http://localhost:8000/metrics
+```
 
-# JSON format (for dashboards/APIs)
-curl http://localhost:8000/metrics/json
+The response is standard Prometheus text. With the default `namespace="fraiseql"` you will see series such as:
 
-# Example response:
-# {
-#   "queries_total": 1250,
-#   "queries_success": 1200,
-#   "queries_error": 50,
-#   "avg_query_duration_ms": 23.5,
-#   "cache_hit_ratio": 0.65
-# }
 ```text
-<!-- Code example in TEXT -->
+# HELP fraiseql_graphql_queries_total Total number of GraphQL queries
+# TYPE fraiseql_graphql_queries_total counter
+fraiseql_graphql_queries_total{operation_type="query",operation_name="users"} 1250
+# HELP fraiseql_graphql_query_duration_seconds GraphQL query execution time in seconds
+# TYPE fraiseql_graphql_query_duration_seconds histogram
+fraiseql_graphql_query_duration_seconds_sum{operation_type="query",operation_name="users"} 29.4
+fraiseql_graphql_query_duration_seconds_count{operation_type="query",operation_name="users"} 1250
+```
+
+> Metrics collection requires the optional `prometheus_client` dependency. If it is not installed, `setup_metrics` degrades gracefully and the `/metrics` endpoint returns placeholder output.
 
 ## OpenTelemetry Integration
 
 ### Initialization
 
-FraiseQL v2 provides full **OpenTelemetry** integration for distributed tracing and observability:
+FraiseQL v1 provides OpenTelemetry distributed tracing through `setup_tracing(app, config)`. It installs a `TracingMiddleware` on the FastAPI app and (when the OpenTelemetry SDK is available) auto-instruments psycopg so database calls become child spans:
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::observability;
+```python
+from fraiseql.tracing import setup_tracing, TracingConfig
 
-// Initialize OpenTelemetry at startup
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Initialize tracer, metrics, and logging
-    observability::init_observability()?;
+tracer = setup_tracing(
+    app,
+    TracingConfig(
+        service_name="fraiseql",
+        service_version="1.0.0",
+        deployment_environment="production",
+        sample_rate=1.0,                      # 1.0 = 100% sampling
+        export_format="otlp",                 # "otlp", "jaeger", or "zipkin"
+        export_endpoint="http://otel-collector:4317",
+    ),
+)
+```
 
-    // Now all requests will be automatically traced
-    start_server().await
-}
-```text
-<!-- Code example in TEXT -->
+`TracingConfig` validates that `sample_rate` is between `0.0` and `1.0` and that `export_format` is one of `otlp`, `jaeger`, or `zipkin`. Paths in `exclude_paths` (`/health`, `/ready`, `/metrics`, `/docs`, `/openapi.json`) are not traced.
 
-### W3C Trace Context Format
-
-FraiseQL uses the **W3C Trace Context** standard for cross-service tracing:
-
-```text
-<!-- Code example in TEXT -->
-traceparent: 00-{trace-id}-{span-id}-{trace-flags}
-            └──────────┬──────────┘
-            Example: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
-```text
-<!-- Code example in TEXT -->
-
-**Components**:
-
-- **Version** (2 hex digits): `00` (v1)
-- **Trace ID** (32 hex digits): Unique request identifier across all services
-  - Generated: `uuid()` as 32-char hex (e.g., `4bf92f3577b34da6a3ce929d0e0e4736`)
-- **Span ID** (16 hex digits): Unique operation within trace
-  - Generated: `uuid()` as 16-char hex (e.g., `00f067aa0ba902b7`)
-- **Trace Flags** (2 hex digits): `01` = sampled, `00` = not sampled
+> Tracing requires the optional OpenTelemetry packages. When they are not installed, the tracer becomes a no-op and the middleware passes requests through untouched.
 
 ### Trace Context Propagation
 
-Automatic trace context propagation across service boundaries:
+The tracer propagates context using the standard W3C `traceparent` header. The `TracingMiddleware` extracts incoming context from request headers; you can inject the current context into outgoing requests:
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::observability::context::{TraceContext, get_context, set_context};
+```python
+from fraiseql.tracing import get_tracer
 
-// In request handler
-let incoming_traceparent = req.headers().get("traceparent")?;
-let trace_ctx = TraceContext::from_traceparent(incoming_traceparent)?;
+tracer = get_tracer()
 
-// Store in thread-local context
-set_context(trace_ctx.clone());
+# Propagate the current trace into a downstream HTTP call
+headers = tracer.inject_context({})
+# headers now contains a "traceparent" entry when propagation is enabled
+```
 
-// Execute query (trace ID automatically included in all logs/spans)
-let result = execute_query(query).await?;
+The W3C `traceparent` format is:
 
-// Create child span for downstream call
-let child_span = trace_ctx.child();
-let downstream_traceparent = child_span.traceparent_header();
-
-// Call downstream service with trace propagation
-client.call(service, request)
-    .header("traceparent", downstream_traceparent)
-    .await?;
-
-// Clear context after request
-clear_context();
 ```text
-<!-- Code example in TEXT -->
+traceparent: 00-{32-hex-trace-id}-{16-hex-span-id}-{trace-flags}
+            Example: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+```
+
+**Components**:
+
+- **Version** (2 hex digits): `00`
+- **Trace ID** (32 hex digits): unique request identifier across services
+- **Span ID** (16 hex digits): unique operation within the trace
+- **Trace Flags** (2 hex digits): `01` = sampled, `00` = not sampled
 
 ### Span Creation and Management
 
-Use the **SpanBuilder** pattern for creating instrumentation:
+The `FraiseQLTracer` exposes context managers for instrumenting work explicitly. Each is a no-op when tracing is disabled:
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::observability::tracing::{SpanBuilder, SpanStatus};
+```python
+from fraiseql.tracing import get_tracer
 
-// Create a span with attributes
-let span = SpanBuilder::new("execute_query")
-    .with_attribute("operation", "GetUser")
-    .with_attribute("database", "postgres")
-    .with_attribute("cache", "hit")
-    .build();
+tracer = get_tracer()
 
-// Status after execution
-if query_succeeded {
-    span.set_status(SpanStatus::Ok);
-} else {
-    span.set_status(SpanStatus::Error);
-}
-```text
-<!-- Code example in TEXT -->
+# Trace a database query (sets db.system=postgresql, db.statement, etc.)
+with tracer.trace_database_query("SELECT", "v_user", "SELECT data FROM v_user"):
+    rows = await db.find("v_user")
 
-### Structured Logging with Trace Correlation
+# Trace a GraphQL operation
+with tracer.trace_graphql_query("GetUser", query_text, variables):
+    result = await execute(query_text, variables)
+```
 
-All logs automatically include trace context:
+Decorator helpers are also exported for convenience:
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::observability::logging::{LogEntry, LogLevel};
+```python
+from fraiseql.tracing import trace_graphql_operation, trace_database_query
 
-let entry = LogEntry::new(LogLevel::Info, "Query executed")
-    .with_duration_ms(45.2)
-    .with_field("operation", "GetUser")
-    .with_field("rows", "142");
+@trace_graphql_operation("query", "GetUser")
+async def run_get_user(query: str, variables: dict | None = None) -> dict:
+    ...
 
-// Automatically includes:
-// - timestamp
-// - level (INFO)
-// - message
-// - trace_id (from context)
-// - span_id (from context)
-// - all custom fields
-// Output: JSON to stdout
-```text
-<!-- Code example in TEXT -->
+@trace_database_query("SELECT", "v_user")
+async def load_users(sql: str) -> list[dict]:
+    ...
+```
 
-**Example JSON Output**:
+### Recording Custom Metrics
 
-```json
-<!-- Code example in JSON -->
-{
-  "timestamp": "2026-01-31T12:34:56.789Z",
-  "level": "INFO",
-  "message": "Query executed",
-  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
-  "span_id": "00f067aa0ba902b7",
-  "duration_ms": 45.2,
-  "operation": "GetUser",
-  "rows": 142
-}
-```text
-<!-- Code example in TEXT -->
+The Prometheus collector returned by `setup_metrics` (also reachable via `get_metrics()`) records GraphQL, mutation, database, cache, and error metrics:
 
-### Metrics Collection
+```python
+from fraiseql.monitoring import get_metrics
 
-Metrics automatically tracked for:
+metrics = get_metrics()
+if metrics is not None:
+    metrics.record_query(
+        operation_type="query",
+        operation_name="GetUser",
+        duration_ms=45.0,
+        success=True,
+    )
+    metrics.record_db_query(query_type="SELECT", table_name="v_user", duration_ms=12.0)
+    metrics.record_cache_hit(cache_type="result")
+```
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::observability::metrics::MetricsCollector;
-
-let collector = MetricsCollector::new();
-
-// Record each request
-collector.record_request(
-    duration_ms: 45,
-    is_error: false
-);
-
-// Get summary with Prometheus format
-let summary = collector.summary();
-// Output includes:
-// - graphql_requests_total {count}
-// - graphql_errors_total {count}
-// - graphql_duration_ms {average}
-```text
-<!-- Code example in TEXT -->
+The `with_metrics(...)` decorator records timing and success/failure automatically for `"query"` / `"mutation"` operation types.
 
 ---
 
 ## Architecture
 
-### Three-Layer Observability Stack
+### Three Observability Layers
 
 ```text
-<!-- Code example in TEXT -->
 ┌─────────────────────────────────────────────────────────────┐
 │                    Visualization Layer                       │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
-│  │    Grafana   │  │   Kibana     │  │   DataDog    │      │
-│  └──────────────┘  └──────────────┘  └──────────────┘      │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐        │
+│  │    Grafana   │  │   Kibana     │  │   DataDog    │        │
+│  └──────────────┘  └──────────────┘  └──────────────┘        │
 └─────────────────────────────────────────────────────────────┘
                             ↑
 ┌─────────────────────────────────────────────────────────────┐
 │                   Backend/Aggregation Layer                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
-│  │  Prometheus  │  │ Elasticsearch│  │   Jaeger     │      │
-│  └──────────────┘  └──────────────┘  └──────────────┘      │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐        │
+│  │  Prometheus  │  │ Elasticsearch│  │  Jaeger/OTLP │        │
+│  └──────────────┘  └──────────────┘  └──────────────┘        │
 └─────────────────────────────────────────────────────────────┘
                             ↑
 ┌─────────────────────────────────────────────────────────────┐
-│              FraiseQL Server Observability                   │
+│            FraiseQL FastAPI App (Python)                     │
 │  ┌──────────────────────────────────────────────────────┐   │
-│  │             Metrics                                  │   │
-│  │  - Query execution time, throughput, errors          │   │
-│  │  - Database performance, connection pools            │   │
-│  │  - Cache hit rates and efficiency                    │   │
+│  │  Metrics — setup_metrics(app, MetricsConfig(...))     │   │
+│  │  - GraphQL query/mutation count, duration, errors     │   │
+│  │  - Database query + connection-pool gauges            │   │
+│  │  - Cache hits/misses, HTTP request metrics            │   │
 │  └──────────────────────────────────────────────────────┘   │
 │  ┌──────────────────────────────────────────────────────┐   │
-│  │          Structured JSON Logging                      │   │
-│  │  - Request context and correlation                   │   │
-│  │  - Performance metrics in every log entry            │   │
-│  │  - Error details with stack traces                   │   │
+│  │  Tracing — setup_tracing(app, TracingConfig(...))     │   │
+│  │  - W3C traceparent propagation                        │   │
+│  │  - Auto-instrumented psycopg spans                    │   │
+│  │  - GraphQL operation / DB / cache span helpers        │   │
 │  └──────────────────────────────────────────────────────┘   │
 │  ┌──────────────────────────────────────────────────────┐   │
-│  │         Distributed Tracing (W3C)                     │   │
-│  │  - Request correlation across services               │   │
-│  │  - Span tracking and event recording                 │   │
-│  │  - Cross-cutting context via baggage                 │   │
+│  │  Health — HealthCheck + built-in /health & /ready     │   │
+│  │  - check_database / check_pool_stats / check_query_…  │   │
 │  └──────────────────────────────────────────────────────┘   │
 │  ┌──────────────────────────────────────────────────────┐   │
-│  │         Performance Monitoring                        │   │
-│  │  - Slow query detection and analysis                 │   │
-│  │  - Operation profiling                               │   │
-│  │  - Cache efficiency tracking                         │   │
+│  │  Performance + Audit                                  │   │
+│  │  - QueryStatsCollector (pg_stat_statements)           │   │
+│  │  - PostgreSQLErrorTracker (Sentry replacement)        │   │
+│  │  - SecurityLogger (security audit events)             │   │
 │  └──────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────┘
-```text
-<!-- Code example in TEXT -->
+```
 
 ## Monitoring Stack Components
 
 ### 1. Prometheus Metrics
 
-**Purpose**: Real-time metric collection and time-series analysis
+**Purpose**: Real-time metric collection and time-series analysis.
 
-**Key Metrics**:
+**Setup**: `setup_metrics(app, MetricsConfig(...))`. The `namespace` (default `"fraiseql"`) prefixes every metric name. Configuration lives in `MetricsConfig`:
 
-- `fraiseql_graphql_queries_total`: Total queries executed
-- `fraiseql_graphql_queries_success`: Successful queries
-- `fraiseql_graphql_queries_error`: Failed queries
-- `fraiseql_graphql_query_duration_ms`: Average query duration
-- `fraiseql_database_queries_total`: Database operations
-- `fraiseql_cache_hit_ratio`: Cache efficiency (0-1)
-- `fraiseql_validation_errors_total`: Schema validation errors
-- `fraiseql_parse_errors_total`: Query parse errors
-- `fraiseql_execution_errors_total`: Execution errors
+```python
+from fraiseql.monitoring import MetricsConfig
 
-**Endpoints**:
+config = MetricsConfig(
+    enabled=True,
+    namespace="fraiseql",
+    metrics_path="/metrics",
+    exclude_paths={"/metrics", "/health", "/ready", "/startup"},
+)
+```
 
-- `/metrics` - Prometheus text format (for scraping)
-- `/metrics/json` - JSON format (for dashboards)
+**Key metrics** (shown with the default `fraiseql` namespace):
 
-**See Also**: [Metrics Reference](./reference/metrics.md) for detailed metrics
+- `fraiseql_graphql_queries_total` — total GraphQL queries (labels: `operation_type`, `operation_name`)
+- `fraiseql_graphql_queries_success` / `fraiseql_graphql_queries_errors` — query outcomes
+- `fraiseql_graphql_query_duration_seconds` — query duration histogram
+- `fraiseql_graphql_mutations_total` / `..._success` / `..._errors` — mutation counters
+- `fraiseql_db_queries_total` / `fraiseql_db_query_duration_seconds` — database operations
+- `fraiseql_db_connections_active` / `..._idle` / `..._total` — connection-pool gauges
+- `fraiseql_cache_hits_total` / `fraiseql_cache_misses_total` — cache efficiency
+- `fraiseql_errors_total` — errors (labels: `error_type`, `error_code`, `operation`)
+- `fraiseql_http_requests_total` / `fraiseql_http_request_duration_seconds` — HTTP metrics
 
-### 2. Structured JSON Logging
+**Endpoint**: `/metrics` (Prometheus text exposition format).
 
-**Purpose**: Contextual logging for debugging and analysis
+### 2. Structured Logging
 
-**Log Entry Structure**:
+**Purpose**: Contextual logging for debugging and analysis.
+
+FraiseQL emits standard Python `logging` records. Configure JSON output (for example with `python-json-logger`) so each line carries request context and timing:
 
 ```json
-<!-- Code example in JSON -->
 {
-  "timestamp": "2024-01-16T15:30:45.123Z",
+  "timestamp": "2026-01-16T15:30:45.123Z",
   "level": "INFO",
   "message": "GraphQL query executed",
-  "request_context": {
-    "request_id": "550e8400-e29b-41d4-a716-446655440000",
-    "operation": "GetUser",
-    "user_id": "user123",
-    "client_ip": "203.0.113.42"
-  },
-  "metrics": {
-    "duration_ms": 23.5,
-    "db_queries": 2,
-    "cache_hit": true
-  },
-  "error": null
+  "operation": "GetUser",
+  "user_id": "user123",
+  "duration_ms": 23.5,
+  "db_queries": 2,
+  "cache_hit": true
 }
-```text
-<!-- Code example in TEXT -->
+```
 
-**See Also**: [Structured Logging Guide](./structured-logging.md)
+Set the level via `logging.basicConfig(level=...)` or your logging config. Security-relevant events are emitted as structured JSON by the security audit logger (see [Security Audit Logging](#5-security-audit-logging)).
 
 ### 3. Distributed Tracing
 
-**Purpose**: Request correlation across service boundaries
+**Purpose**: Request correlation across service boundaries.
 
-**W3C Trace Context Header Format**:
+Enabled with `setup_tracing(app, TracingConfig(...))`. Uses the W3C `traceparent` header for propagation and exports spans via OTLP, Jaeger, or Zipkin.
 
-```text
-<!-- Code example in TEXT -->
-traceparent: 00-{32-hex-trace-id}-{16-hex-span-id}-{trace-flags}
-```text
-<!-- Code example in TEXT -->
+**Key features**:
 
-**Key Features**:
-
-- Automatic trace ID generation
-- Parent-child span relationships
-- Cross-cutting context via baggage
-- W3C standard compliant
-
-**See Also**: [Distributed Tracing Guide](./distributed-tracing.md)
+- Automatic W3C trace context extraction and propagation
+- Auto-instrumented psycopg database spans
+- Per-operation span helpers (`trace_graphql_query`, `trace_database_query`, `trace_cache_operation`)
+- Configurable sampling via `sample_rate`
 
 ### 4. Performance Monitoring
 
-**Purpose**: Detailed performance analysis and optimization
+**Purpose**: Detailed performance analysis and optimization.
 
-**Tracking**:
+FraiseQL surfaces PostgreSQL query statistics through the `QueryStatsCollector`, which reads the `v_query_stats` view backed by the `pg_stat_statements` extension:
 
-- Query execution phases (parse, validation, DB, formatting)
-- Slow query detection and analysis
-- Cache efficiency analysis
-- Operation-specific profiling
-- Database query performance
+```python
+from fraiseql.monitoring import init_query_stats
 
-**See Also**: [Observability Architecture](./observability-architecture.md)
+# At startup, with your psycopg AsyncConnectionPool
+collector = init_query_stats(pool)
+
+# Later — top queries by total execution time
+stats = await collector.get_stats(top_n=20, order_by="total_exec_time")
+for s in stats:
+    print(f"{s.query_preview[:60]}  calls={s.calls}  mean={s.mean_exec_time_ms}ms")
+```
+
+Valid `order_by` values: `total_exec_time`, `mean_exec_time`, `calls`, `cache_hit_ratio`. The collector degrades gracefully (returns an empty list) when `pg_stat_statements` is not installed. The companion health check `check_query_stats` reports whether the extension is available.
+
+### 5. Security Audit Logging
+
+**Purpose**: Record authentication, authorization, rate-limiting, and query-security events.
+
+The security logger (`fraiseql.audit`) writes structured `SecurityEvent` records to stdout and/or a file:
+
+```python
+from fraiseql.audit import get_security_logger, SecurityEventType
+
+security = get_security_logger()
+
+security.log_auth_failure(
+    reason="invalid_token",
+    ip_address="203.0.113.42",
+    attempted_username="alice",
+)
+
+security.log_authorization_denied(
+    user_id="user123",
+    resource="Order",
+    action="read",
+    reason="missing role",
+)
+```
+
+`SecurityEventType` covers authentication (`AUTH_SUCCESS`, `AUTH_FAILURE`, …), authorization (`AUTHZ_DENIED`, `AUTHZ_FIELD_DENIED`, …), rate limiting, CSRF, query security (complexity/depth/timeout), and system events. The log file path defaults to `security_events.log` and can be overridden with `FRAISEQL_SECURITY_LOG_PATH`.
+
+### 6. Error Tracking (PostgreSQL-native)
+
+**Purpose**: Capture exceptions with full context — a Sentry replacement using your own database.
+
+```python
+from fraiseql.monitoring import init_error_tracker
+
+# At startup, with your psycopg AsyncConnectionPool
+tracker = init_error_tracker(pool, environment="production", release_version="1.0.0")
+
+# Capture an exception with context
+try:
+    await risky_operation()
+except Exception as exc:
+    await tracker.capture_exception(exc, context={"request": request_data})
+```
+
+Errors are grouped by fingerprint, store full stack traces and request/user context, and can be correlated with OpenTelemetry `trace_id`/`span_id`.
+
+### 7. Health and Readiness Checks
+
+**Purpose**: Kubernetes liveness/readiness probes.
+
+`create_fraiseql_app` registers two endpoints automatically:
+
+- `GET /health` — liveness probe; returns `{"status": "healthy", "service": "fraiseql"}` while the process is up.
+- `GET /ready` — readiness probe; validates the database pool, runs a `SELECT`, and confirms the schema is loaded. Returns `503` when not ready.
+
+For richer composite checks, use the `HealthCheck` runner with the pre-built check functions:
+
+```python
+from fraiseql.monitoring import (
+    HealthCheck,
+    check_database,
+    check_pool_stats,
+    check_query_stats,
+)
+
+health = HealthCheck()
+health.add_check("database", check_database)
+health.add_check("pool", check_pool_stats)
+health.add_check("query_stats", check_query_stats)
+
+result = await health.run_checks()
+# {"status": "healthy" | "degraded", "checks": {...}}
+```
+
+`check_database` and `check_pool_stats` read the app's connection pool via `fraiseql.fastapi.dependencies.get_db_pool`. You can expose `health.run_checks()` from a custom FastAPI route if you want a single aggregated report.
 
 ## Integration Patterns
 
-### Pattern 1: Request Lifecycle Tracing
+### Pattern 1: Compose the full stack at startup
 
-Track a single request through the entire execution pipeline:
-
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::{
-    TraceContext, RequestContext, PerformanceMonitor,
-    StructuredLogEntry, LogLevel, LogMetrics
-};
-
-// 1. Create trace context (at entry point)
-let trace = TraceContext::new();
-let request_ctx = RequestContext::new()
-    .with_operation("GetUser".to_string());
-
-// 2. Create performance monitor
-let perf_monitor = PerformanceMonitor::new(100.0); // 100ms threshold
-
-// 3. Execute query
-let query_perf = execute_query(...);
-perf_monitor.record_query(query_perf.clone());
-
-// 4. Log with all context
-let entry = StructuredLogEntry::new(
-    LogLevel::Info,
-    "Query executed successfully".to_string()
+```python
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.monitoring import (
+    setup_metrics, MetricsConfig,
+    init_query_stats, init_error_tracker,
 )
-.with_request_context(request_ctx)
-.with_metrics(LogMetrics::new()
-    .with_duration_ms(query_perf.duration_us as f64 / 1000.0)
-    .with_db_queries(query_perf.db_queries)
-    .with_cache_hit(query_perf.cached));
+from fraiseql.tracing import setup_tracing, TracingConfig
+from fraiseql.fastapi.dependencies import get_db_pool
 
-tracing::info!("{}", entry.to_json_string());
-```text
-<!-- Code example in TEXT -->
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+    production=True,
+)
 
-### Pattern 2: Service-to-Service Tracing
+setup_metrics(app, MetricsConfig(namespace="fraiseql"))
+setup_tracing(app, TracingConfig(service_name="fraiseql", deployment_environment="production"))
 
-Propagate trace context across service boundaries:
 
-```rust
-<!-- Code example in RUST -->
-use fraiseql_server::TraceContext;
+@app.on_event("startup")
+async def init_observability() -> None:
+    pool = get_db_pool()
+    init_query_stats(pool)
+    init_error_tracker(pool, environment="production")
+```
 
-// Upstream service receives request with trace
-let incoming_header = req.headers().get("traceparent").unwrap();
-let trace = TraceContext::from_w3c_traceparent(incoming_header)?;
+### Pattern 2: Capture and correlate errors
 
-// Add baggage for downstream
-let trace_with_context = trace
-    .with_baggage("user_id".to_string(), user.id.clone())
-    .with_baggage("tenant".to_string(), user.tenant.clone());
+```python
+from fraiseql.monitoring import get_error_tracker, get_metrics
 
-// Downstream call
-let child_trace = trace_with_context.child_span();
-downstream_service.call(
-    client,
-    request,
-    headers.insert("traceparent", child_trace.to_w3c_traceparent())
-)?;
-```text
-<!-- Code example in TEXT -->
+async def handle_operation(operation_name: str) -> None:
+    metrics = get_metrics()
+    tracker = get_error_tracker()
+    try:
+        await do_work()
+    except Exception as exc:
+        if metrics is not None:
+            metrics.record_error(
+                error_type=type(exc).__name__,
+                error_code="HANDLER_ERROR",
+                operation=operation_name,
+            )
+        if tracker is not None:
+            await tracker.capture_exception(exc, context={"operation": operation_name})
+        raise
+```
 
-### Pattern 3: Performance Analysis Dashboard
+### Pattern 3: Performance analysis dashboard
 
 Real-time monitoring with Grafana:
 
 ```bash
-<!-- Code example in BASH -->
-# 1. Configure Grafana datasource
+# 1. Configure the Grafana datasource
 curl -X POST http://localhost:3000/api/datasources \
   -H "Content-Type: application/json" \
   -d '{
@@ -475,65 +491,56 @@ curl -X POST http://localhost:3000/api/datasources \
     "isDefault": true
   }'
 
-# 2. Import dashboard
-curl -X POST http://localhost:3000/api/dashboards/db \
-  -H "Content-Type: application/json" \
-  -d @monitoring/grafana-dashboard.json
-```text
-<!-- Code example in TEXT -->
+# 2. Build panels from fraiseql_* series, e.g.:
+#    rate(fraiseql_graphql_queries_total[5m])
+#    histogram_quantile(0.95, rate(fraiseql_graphql_query_duration_seconds_bucket[5m]))
+```
 
-### Pattern 4: Alerting Rules
+### Pattern 4: Alerting rules
 
-Set up Prometheus alerting:
+Set up Prometheus alerting against the `fraiseql_*` series:
 
 ```yaml
-<!-- Code example in YAML -->
 # prometheus/alerts.yml
 groups:
-  - name: FraiseQL
+  - name: fraiseql
     rules:
       # High error rate
       - alert: HighErrorRate
         expr: |
-          (rate(fraiseql_graphql_queries_error[5m]) /
+          (rate(fraiseql_graphql_queries_errors[5m]) /
            rate(fraiseql_graphql_queries_total[5m])) > 0.05
         annotations:
-          summary: "Error rate above 5%"
+          summary: "GraphQL error rate above 5%"
 
-      # High latency
+      # High latency (p95)
       - alert: HighLatency
-        expr: fraiseql_graphql_query_duration_ms > 500
+        expr: |
+          histogram_quantile(0.95,
+            rate(fraiseql_graphql_query_duration_seconds_bucket[5m])) > 0.5
         annotations:
-          summary: "Query latency above 500ms"
-
-      # Low cache hit rate
-      - alert: LowCacheHitRate
-        expr: fraiseql_cache_hit_ratio < 0.50
-        annotations:
-          summary: "Cache hit rate below 50%"
-```text
-<!-- Code example in TEXT -->
+          summary: "p95 query latency above 500ms"
+```
 
 ## Deployment Configuration
 
 ### Docker Compose (Development)
 
 ```yaml
-<!-- Code example in YAML -->
-version: '3.8'
 services:
-  FraiseQL:
-    image: FraiseQL-server:latest
+  app:
+    build: .
+    command: uvicorn myapp:app --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
     environment:
       DATABASE_URL: postgresql://user:pass@postgres:5432/db
-      RUST_LOG: info
+      FRAISEQL_ENVIRONMENT: development
     depends_on:
       - postgres
 
   postgres:
-    image: postgres:15
+    image: postgres:16
     environment:
       POSTGRES_PASSWORD: password
     volumes:
@@ -557,61 +564,66 @@ services:
 
 volumes:
   postgres_data:
-```text
-<!-- Code example in TEXT -->
+```
+
+`prometheus.yml` should scrape the app's `/metrics` endpoint:
+
+```yaml
+scrape_configs:
+  - job_name: fraiseql
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["app:8000"]
+```
 
 ### Kubernetes (Production)
 
-```yaml
-<!-- Code example in YAML -->
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: FraiseQL-config
-data:
-  config.toml: |
-    bind_addr = "0.0.0.0:8000"
-    database_url = "postgresql://..."
-    pool_min_size = 5
-    pool_max_size = 20
+Run the app with uvicorn and wire the probes to the built-in endpoints:
 
----
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: FraiseQL-server
+  name: fraiseql
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: FraiseQL
+      app: fraiseql
   template:
     metadata:
       labels:
-        app: FraiseQL
+        app: fraiseql
     spec:
       containers:
-      - name: FraiseQL
-        image: FraiseQL-server:latest
-        ports:
-        - containerPort: 8000
-        env:
-        - name: RUST_LOG
-          value: info
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 10
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 5
-```text
-<!-- Code example in TEXT -->
+        - name: app
+          image: my-fraiseql-app:latest
+          command: ["uvicorn", "myapp:app", "--host", "0.0.0.0", "--port", "8000"]
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: fraiseql-secrets
+                  key: database-url
+            - name: FRAISEQL_ENVIRONMENT
+              value: production
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+```
+
+Configuration is supplied through `create_fraiseql_app(...)` keyword arguments, `FraiseQLConfig`, or `FRAISEQL_`-prefixed environment variables — there is no TOML config file.
 
 ## Alerting and SLOs
 
@@ -624,16 +636,15 @@ spec:
 | Query Latency p95 | > 200ms | Warning | Analyze |
 | Query Latency p95 | > 1s | Critical | Page on-call |
 | Cache Hit Rate | < 50% | Warning | Review caching |
-| Database Time % | > 80% | Warning | Optimize queries |
+| DB Pool Utilization | > 90% | Warning | Scale pool/replicas |
 | Server Error Rate | > 1% | Critical | Page on-call |
 
 ### Sample SLOs
 
 ```text
-<!-- Code example in TEXT -->
-Service Level Objectives for FraiseQL v2:
+Service Level Objectives:
 
-1. Availability SLO: 99.95% (4 hours/month downtime)
+1. Availability SLO: 99.95% (about 4 hours/month downtime)
    - Alert if: error_rate > 0.5% for 5 minutes
 
 2. Latency SLO: 95th percentile < 200ms
@@ -644,21 +655,20 @@ Service Level Objectives for FraiseQL v2:
 
 4. Query Success: > 99.9%
    - Alert if: success_rate < 99% for 5 minutes
-```text
-<!-- Code example in TEXT -->
+```
 
 ## Best Practices
 
 ### 1. Logging Best Practices
 
-✅ **DO:**
+DO:
 
-- Include request IDs in all log entries
+- Include request IDs in log entries
 - Log at appropriate levels (DEBUG/TRACE only in development)
-- Include business context (user_id, operation, tenant)
-- Use structured JSON format
+- Include business context (`user_id`, `operation`, `tenant_id`)
+- Use structured JSON output
 
-❌ **DON'T:**
+DON'T:
 
 - Log sensitive data (passwords, tokens, PII)
 - Use vague error messages
@@ -667,49 +677,49 @@ Service Level Objectives for FraiseQL v2:
 
 ### 2. Metrics Best Practices
 
-✅ **DO:**
+DO:
 
-- Use consistent metric names
-- Export metrics every 30-60 seconds
+- Keep the default `fraiseql` namespace consistent across services
 - Track both success and error cases
-- Monitor resource usage (CPU, memory, connections)
+- Monitor resource usage (connections, CPU, memory)
+- Use histograms (`*_duration_seconds_bucket`) for percentiles
 
-❌ **DON'T:**
+DON'T:
 
-- Create unbounded cardinality metrics
-- Export sensitive information
-- Change metric names without versioning
+- Create unbounded label cardinality (e.g., raw IDs as labels)
+- Export sensitive information in labels
+- Change metric names without versioning dashboards
 - Track PII in metrics
 
 ### 3. Tracing Best Practices
 
-✅ **DO:**
+DO:
 
-- Create traces at system boundaries
-- Propagate trace IDs across services
-- Sample appropriately for traffic volume
-- Set meaningful span names
+- Create spans at system boundaries
+- Propagate the `traceparent` header across services
+- Sample appropriately for traffic volume (`sample_rate`)
+- Set meaningful span/operation names
 
-❌ **DON'T:**
+DON'T:
 
-- Create traces for every operation
-- Store sensitive data in baggage
-- Forget to finish spans
-- Use verbose log messages in spans
+- Trace every trivial operation at 100% under heavy load
+- Store sensitive data in span attributes
+- Forget to close manual spans (use the context managers)
+- Trace the excluded probe/health paths
 
 ### 4. Performance Monitoring
 
-✅ **DO:**
+DO:
 
-- Monitor slow query rate
+- Install `pg_stat_statements` and review `QueryStatsCollector` output
 - Track cache efficiency
-- Analyze database performance
-- Use performance data for optimization
+- Analyze database performance against the pool gauges
+- Use percentiles, not just averages
 
-❌ **DON'T:**
+DON'T:
 
 - Ignore performance trends
-- Rely on averages alone (use percentiles)
+- Rely on averages alone
 - Skip error analysis
 - Assume caching is always beneficial
 
@@ -717,60 +727,71 @@ Service Level Objectives for FraiseQL v2:
 
 ### Metrics Not Appearing in Prometheus
 
-**Symptoms**: `/metrics` endpoint works but Prometheus scrape fails
+**Symptoms**: `/metrics` works but Prometheus scrape fails.
 
 **Solutions**:
 
-1. Check Prometheus configuration: `curl http://prometheus:9090/-/healthy`
-2. Verify target is reachable: `telnet FraiseQL 8000`
-3. Check scrape interval: Default is 15 seconds
-4. Look for errors in Prometheus logs
+1. Confirm `setup_metrics(app, ...)` runs before the app serves traffic.
+2. Verify the target is reachable: `curl http://app:8000/metrics`.
+3. Check Prometheus health: `curl http://prometheus:9090/-/healthy`.
+4. Ensure `prometheus_client` is installed (otherwise output is placeholder data).
+5. Check the scrape `metrics_path` matches `MetricsConfig.metrics_path`.
 
 ### Missing Log Entries
 
-**Symptoms**: Some requests not logged
+**Symptoms**: Some requests are not logged.
 
 **Solutions**:
 
-1. Check log level: Set `RUST_LOG=debug` for verbose logging
-2. Verify sink is configured correctly
-3. Check for log buffering: May have 1-2 second delay
-4. Ensure application isn't crashing silently
+1. Set the log level: `logging.basicConfig(level=logging.DEBUG)`.
+2. Verify your logging handler/formatter is configured.
+3. Check for log buffering (may add a small delay).
+4. Ensure the application is not crashing silently.
 
 ### Trace Context Lost Between Services
 
-**Symptoms**: Trace IDs not propagating
+**Symptoms**: Trace IDs not propagating.
 
 **Solutions**:
 
-1. Verify `traceparent` header is being set
-2. Check header format: `00-{32-hex}-{16-hex}-{2-hex}`
-3. Ensure services parse and propagate headers
-4. Check for header case sensitivity
+1. Verify `setup_tracing` ran and the OpenTelemetry SDK is installed.
+2. Confirm the `traceparent` header is set on outgoing calls (use `tracer.inject_context(...)`).
+3. Check the header format: `00-{32-hex}-{16-hex}-{2-hex}`.
+4. Ensure downstream services parse and re-propagate the header.
 
-### High Memory Usage
+### `/ready` Returns 503
 
-**Symptoms**: Server memory grows over time
+**Symptoms**: Readiness probe fails while `/health` succeeds.
 
 **Solutions**:
 
-1. Check for trace context leaks
-2. Monitor baggage size (should be < 1KB per request)
-3. Verify metrics aren't accumulating unbounded
-4. Enable profile memory: `RUST_BACKTRACE=1`
+1. Confirm `DATABASE_URL` is correct and PostgreSQL is reachable.
+2. Inspect the JSON body — the `checks` map names the failing dependency.
+3. Verify the connection pool initialized at startup.
+4. Confirm the GraphQL schema built without errors.
+
+### Empty Query Statistics
+
+**Symptoms**: `QueryStatsCollector.get_stats()` returns an empty list.
+
+**Solutions**:
+
+1. Install the extension: `CREATE EXTENSION pg_stat_statements;`.
+2. Add `pg_stat_statements` to `shared_preload_libraries` and restart PostgreSQL.
+3. Run `check_query_stats` to confirm availability.
+4. Ensure the database role can read the stats views.
 
 ## Additional Resources
 
-- [Metrics Reference](./reference/metrics.md)
-- [Structured Logging Guide](./structured-logging.md)
 - [Distributed Tracing Guide](./distributed-tracing.md)
-- [Observability Architecture](./observability-architecture.md)
+- [Configuration Reference](./configuration.md)
+- [Production Deployment](../production/deployment.md)
 
 ## Support
 
-For issues or questions about observability in FraiseQL v2:
+For issues or questions about observability in FraiseQL v1:
 
-- Check [troubleshooting section](#troubleshooting)
-- Review logs with `RUST_LOG=debug`
+- Check the [troubleshooting section](#troubleshooting)
+- Raise the log level to `DEBUG` for verbose output
 - Enable tracing for detailed execution flow
 - File an issue with metrics/logs/traces attached

--- a/docs/operations/performance-tuning-runbook.md
+++ b/docs/operations/performance-tuning-runbook.md
@@ -1,6 +1,4 @@
-<!-- Skip to main content -->
 ---
-
 title: Performance Tuning Runbook
 description: Operational procedures for diagnosing and optimizing FraiseQL query performance in production.
 keywords: ["deployment", "scaling", "performance", "monitoring", "troubleshooting"]
@@ -9,12 +7,17 @@ tags: ["documentation", "reference"]
 
 # Performance Tuning Runbook
 
-**Status:** ✅ Production Ready
+**Status:** Production Ready
 **Audience:** DevOps, Database Administrators, Performance Engineers
 **Reading Time:** 30-40 minutes
-**Last Updated:** 2026-02-05
 
 Operational procedures for diagnosing and optimizing FraiseQL query performance in production.
+
+FraiseQL v1 is a Python runtime GraphQL framework that serves a PostgreSQL database over
+FastAPI. Queries read `v_`/`tv_` views, mutations call `fn_` PostgreSQL functions, and the
+GraphQL schema is built in memory at application startup. Almost all performance work
+therefore happens in two places: **your PostgreSQL database** (indexes, statistics, views)
+and **the FastAPI app** (connection pool, caching). This runbook covers both.
 
 ---
 
@@ -32,7 +35,6 @@ This runbook provides **diagnosis workflows** and **remediation steps** for comm
 ## Quick Diagnosis Tree
 
 ```text
-<!-- Code example in TEXT -->
 Is performance issue...
 
 1. NEW: Slow since deployment?
@@ -49,8 +51,7 @@ Is performance issue...
 
 5. BROAD: Many queries slow?
    → Go to: DATABASE TUNING or NETWORK LATENCY
-```text
-<!-- Code example in TEXT -->
+```
 
 ---
 
@@ -60,44 +61,40 @@ Is performance issue...
 
 ### Diagnosis Step 1: Enable Query Logging
 
+FraiseQL is a Python/FastAPI application. Turn up Python logging to see the SQL it issues
+against your views and functions. Set the logger level via standard Python logging (or the
+`FRAISEQL_` environment, e.g. `FRAISEQL_DATABASE_ECHO=true` to echo SQL).
+
+```python
+# In your app entry point, before create_fraiseql_app(...)
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("fraiseql").setLevel(logging.DEBUG)
+```
+
 ```bash
-<!-- Code example in BASH -->
-# Set environment variable
-export RUST_LOG=FraiseQL=debug
-
-# Restart server
-systemctl restart FraiseQL
-
-# Watch logs
-tail -f /var/log/FraiseQL.log | grep "QUERY"
-```text
-<!-- Code example in TEXT -->
+# Run the app with uvicorn and watch the logs
+uvicorn app:app --host 0.0.0.0 --port 8000 2>&1 | grep -i "query\|select"
+```
 
 **Look for:**
 
 - Query execution time
-- SQL generation time
+- The generated SQL against your `v_`/`tv_` views
 - Database roundtrip time
-- Result transformation time
+- Result transformation time (JSONB shaping, done by the optional `fraiseql_rs` extension)
 
 ### Diagnosis Step 2: Get Query Plan from Database
 
+Take the SQL FraiseQL logged (a `SELECT ... FROM v_...`) and run `EXPLAIN ANALYZE` against
+PostgreSQL:
+
 ```sql
-<!-- Code example in SQL -->
 -- PostgreSQL
 EXPLAIN ANALYZE
-SELECT ... FROM ... WHERE ...;
-
--- MySQL
-EXPLAIN FORMAT=JSON
-SELECT ... FROM ... WHERE ...;
-
--- SQL Server
-SET STATISTICS IO ON;
-SET STATISTICS TIME ON;
-SELECT ... FROM ... WHERE ...;
-```text
-<!-- Code example in TEXT -->
+SELECT ... FROM v_user WHERE ...;
+```
 
 **Interpret output:**
 
@@ -109,8 +106,7 @@ SELECT ... FROM ... WHERE ...;
 ### Diagnosis Step 3: Check for Missing Indexes
 
 ```sql
-<!-- Code example in SQL -->
--- PostgreSQL: Find tables without indexes
+-- Find tables without indexes
 SELECT schemaname, tablename
 FROM pg_tables
 WHERE schemaname = 'public'
@@ -120,83 +116,92 @@ FROM pg_indexes
 WHERE schemaname = 'public'
 ORDER BY tablename;
 
--- Check most common WHERE columns in slow queries
-SELECT query FROM pg_stat_statements
-WHERE mean_time > 100
-ORDER BY mean_time DESC LIMIT 5;
+-- Check the most expensive queries (requires the pg_stat_statements extension)
+SELECT query, mean_exec_time, calls
+FROM pg_stat_statements
+WHERE mean_exec_time > 100
+ORDER BY mean_exec_time DESC
+LIMIT 5;
 
--- Example output: "SELECT * FROM users WHERE created_at >= ..."
+-- Example output: "SELECT ... FROM tb_user WHERE created_at >= ..."
 -- → Need index on created_at
-```text
-<!-- Code example in TEXT -->
+```
+
+> Enable `pg_stat_statements` by adding it to `shared_preload_libraries` in
+> `postgresql.conf` and running `CREATE EXTENSION pg_stat_statements;`.
 
 ### Solutions
 
 **Solution 1: Add Missing Index**
 
 ```sql
-<!-- Code example in SQL -->
 -- Identify filter columns from EXPLAIN output
-CREATE INDEX idx_user_created_at ON users(created_at);
+CREATE INDEX idx_user_created_at ON tb_user(created_at);
 
--- Verify index is used
-EXPLAIN SELECT * FROM users WHERE created_at >= '2026-01-01';
+-- Verify the index is used
+EXPLAIN SELECT * FROM tb_user WHERE created_at >= '2026-01-01';
 -- Should show "Index Scan" not "Seq Scan"
-```text
-<!-- Code example in TEXT -->
+```
 
-**Syntax per database:**
+**Concurrent index creation (doesn't lock the table):**
 
 ```sql
-<!-- Code example in SQL -->
--- PostgreSQL: Concurrent index creation (doesn't lock table)
-CREATE INDEX CONCURRENTLY idx_user_created_at ON users(created_at);
+-- Build the index without blocking writes (recommended in production)
+CREATE INDEX CONCURRENTLY idx_user_created_at ON tb_user(created_at);
+```
 
--- MySQL: Online index creation (5.7+)
-ALTER TABLE users ADD INDEX idx_created_at (created_at), ALGORITHM=INPLACE;
+Because read views build a `data` JSONB column, you often want indexes on the JSONB
+expressions you filter on:
 
--- SQL Server: Online index creation
-CREATE INDEX idx_created_at ON users(created_at) WITH (ONLINE=ON);
-```text
-<!-- Code example in TEXT -->
+```sql
+-- Index on a value extracted from the JSONB data column
+CREATE INDEX idx_user_email
+    ON tb_user ((data->>'email'));
+
+-- GIN index for containment / key-existence queries on the whole JSONB document
+CREATE INDEX idx_user_data_gin ON tb_user USING gin (data);
+```
 
 **Solution 2: Composite Indexes for Common Filter Combinations**
 
 ```sql
-<!-- Code example in SQL -->
 -- If queries often filter by both tenant and status:
--- CREATE INDEX idx_user_tenant_status ON users(tenant_id, status);
+CREATE INDEX idx_user_tenant_status ON tb_user(tenant_id, status);
 -- Covers WHERE tenant_id = X AND status = 'active'
 
--- If queries filter by range, put range column last:
--- CREATE INDEX idx_posts_user_date ON posts(user_id, created_at);
--- Covers WHERE user_id = X AND created_at >= Y
-```text
-<!-- Code example in TEXT -->
+-- If queries filter by range, put the range column last:
+CREATE INDEX idx_posts_user_date ON tb_post(fk_user, created_at);
+-- Covers WHERE fk_user = X AND created_at >= Y
+```
 
-**Solution 3: Switch to Materialized View (tv_*)**
+**Solution 3: Switch to a Table-Backed Projection View (`tv_*`)**
 
-If index doesn't help (aggregation or complex join):
+If indexing a logical `v_` view doesn't help (heavy aggregation or deep nested joins),
+move to a **table-backed projection view** (`tv_`): a real table that holds the
+pre-composed `data` JSONB, refreshed by your `fn_` functions or triggers. Reads then hit
+a pre-built, indexable table instead of recomputing JSONB per request.
 
 ```python
-<!-- Code example in Python -->
-# Before: Logical view (computed per query)
-@type
-class UserStats:
-    post_count: int = field(computed="COUNT(SELECT ...)")
+import fraiseql
+from fraiseql.types import ID
 
-# After: Table-backed view (materialized daily)
-@type
+# Logical view: data JSONB computed per query (good for small/simple reads)
+@fraiseql.type(sql_source="v_user_stats", jsonb_column="data")
 class UserStats:
-    post_count: int  # Pre-computed, indexed
-```text
-<!-- Code example in TEXT -->
+    id: ID
+    post_count: int
+
+# Table-backed projection view: data pre-composed and refreshed by fn_/triggers
+@fraiseql.type(sql_source="tv_user_stats", jsonb_column="data")
+class UserStatsFast:
+    id: ID
+    post_count: int  # Pre-computed in tv_user_stats, indexable
+```
 
 **Solution 4: Reduce Query Scope**
 
 ```graphql
-<!-- Code example in GraphQL -->
-# Before: Fetching too much
+# Before: fetching too much
 query {
   users {  # Gets all 10M users!
     id
@@ -205,7 +210,7 @@ query {
   }
 }
 
-# After: Add filters
+# After: add filters (WHERE operators are generated against the view)
 query {
   users(where: { created_at: { gte: "2026-01-01" } }) {
     id
@@ -213,14 +218,13 @@ query {
     posts { id title }
   }
 }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Prevention
 
-- [ ] Monitor slow queries: `max_query_time > 500ms`
-- [ ] Weekly index review: Check for missing indexes on filtered columns
-- [ ] Query profiling in staging: Profile all new queries before deploying
+- [ ] Monitor slow queries via `pg_stat_statements` (alert if `mean_exec_time > 500ms`)
+- [ ] Weekly index review: check for missing indexes on filtered columns / JSONB expressions
+- [ ] Query profiling in staging: profile new queries with `EXPLAIN ANALYZE` before deploying
 - [ ] Document expected performance: "Query X should run in < 100ms"
 
 ---
@@ -229,54 +233,83 @@ query {
 
 ### Symptom: "Too Many Connections" or "Connection Timeout"
 
+FraiseQL maintains an async connection pool inside the FastAPI app. The effective maximum
+number of database connections is `connection_pool_size + connection_pool_max_overflow`.
+
 ### Diagnosis
 
 ```sql
-<!-- Code example in SQL -->
--- PostgreSQL: Check active connections
+-- Check active connections
 SELECT COUNT(*) FROM pg_stat_activity;
-SELECT max_conn FROM pg_settings WHERE name = 'max_connections';
+SELECT setting FROM pg_settings WHERE name = 'max_connections';
 
--- Example: 100 max connections, 95 active → Almost exhausted
+-- Example: 100 max connections, 95 active → almost exhausted
 
--- Find slow connections
+-- Find slow / non-idle connections
 SELECT pid, usename, state, query_start, query
 FROM pg_stat_activity
 WHERE state != 'idle'
 ORDER BY query_start;
-
--- MySQL: Check connection count
-SHOW PROCESSLIST;
-SHOW VARIABLES LIKE 'max_connections';
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Solutions
 
 **Solution 1: Increase Pool Size**
 
-```toml
-<!-- Code example in TOML -->
-# FraiseQL.toml
-[database]
-pool_size = 50  # Was 10, increase to 50
-```text
-<!-- Code example in TEXT -->
+Tune the pool through `create_fraiseql_app(...)` kwargs:
 
-**Maximum safe values:**
+```python
+from fraiseql.fastapi import create_fraiseql_app
 
-- PostgreSQL max_connections: Usually 200-1000 (depends on server)
-- MySQL max_connections: Usually 500-10000
-- SQLite: Not applicable (single connection)
+app = create_fraiseql_app(
+    database_url="postgresql://user:pass@localhost/mydb",
+    types=[User],
+    queries=[users, user],
+    connection_pool_size=30,        # base connections held open
+    connection_pool_max_overflow=20,  # extra connections under load
+    connection_pool_timeout=30.0,   # seconds to wait for a free connection
+    connection_pool_recycle=3600,   # seconds before recycling idle connections
+)
+```
 
-**Solution 2: Enable Connection Pooling at Database Level**
+Equivalently, via `FraiseQLConfig` (or the `FRAISEQL_` environment variables it reads):
+
+```python
+from fraiseql.fastapi import FraiseQLConfig
+
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+    database_pool_size=30,
+    database_max_overflow=20,
+    database_pool_timeout=30,
+    database_pool_recycle=3600,
+)
+```
 
 ```bash
-<!-- Code example in BASH -->
-# PostgreSQL: Use PgBouncer
-sudo apt install pgbouncer
+# Or set them from the environment (FRAISEQL_ prefix, case-insensitive)
+export FRAISEQL_DATABASE_POOL_SIZE=30
+export FRAISEQL_DATABASE_MAX_OVERFLOW=20
+export FRAISEQL_DATABASE_POOL_TIMEOUT=30
+export FRAISEQL_DATABASE_POOL_RECYCLE=3600
+```
 
-# Configure /etc/pgbouncer/pgbouncer.ini
+**Sizing guidance:**
+
+- Keep `pool_size + max_overflow` comfortably below PostgreSQL's `max_connections`
+  (commonly 100-500, depending on the server).
+- Account for **every** app instance/worker: total DB connections = per-instance pool max
+  × number of instances. Three instances with `30 + 20` can open 150 connections.
+
+**Solution 2: Add a Connection Pooler in Front of PostgreSQL**
+
+```bash
+# Use PgBouncer when many app instances would otherwise exhaust max_connections
+sudo apt install pgbouncer
+```
+
+```ini
+; /etc/pgbouncer/pgbouncer.ini
 [databases]
 mydb = host=localhost port=5432 dbname=mydb
 
@@ -284,40 +317,37 @@ mydb = host=localhost port=5432 dbname=mydb
 pool_mode = transaction
 max_client_conn = 1000
 default_pool_size = 25
-```text
-<!-- Code example in TEXT -->
+```
 
 **Solution 3: Kill Slow/Idle Connections**
 
 ```sql
-<!-- Code example in SQL -->
--- PostgreSQL: Kill connections idle > 5 minutes
+-- Kill connections idle > 5 minutes
 SELECT pg_terminate_backend(pid)
 FROM pg_stat_activity
 WHERE state = 'idle'
 AND query_start < now() - interval '5 minutes';
 
--- MySQL: Kill long-running connections
-KILL QUERY process_id;
-```text
-<!-- Code example in TEXT -->
+-- Set a server-side idle timeout instead of killing manually
+ALTER DATABASE mydb SET idle_in_transaction_session_timeout = '60s';
+```
 
-**Solution 4: Set Connection Timeout**
+**Solution 4: Set Connection and Query Timeouts**
 
-```toml
-<!-- Code example in TOML -->
-[database]
-connection_timeout_seconds = 10  # Wait max 10s for connection
-query_timeout_seconds = 30       # Abort query after 30s
-```text
-<!-- Code example in TEXT -->
+`connection_pool_timeout` bounds how long FraiseQL waits for a free pool slot. Bound the
+query itself in PostgreSQL with `statement_timeout`:
+
+```sql
+-- Abort any statement running longer than 30 seconds (per role or per database)
+ALTER ROLE fraiseql_user SET statement_timeout = '30s';
+```
 
 ### Prevention
 
-- [ ] Monitor pool usage: Alert at 80% capacity
-- [ ] Set max_client_conn based on peak load
+- [ ] Monitor pool usage: alert at 80% capacity
+- [ ] Size `pool_size + max_overflow` against `max_connections` and instance count
 - [ ] Regular connection review (weekly)
-- [ ] Implement query timeouts
+- [ ] Implement statement timeouts
 - [ ] Close subscriptions on disconnect
 
 ---
@@ -329,68 +359,59 @@ query_timeout_seconds = 30       # Abort query after 30s
 ### Diagnosis
 
 ```sql
-<!-- Code example in SQL -->
--- PostgreSQL: Check index bloat
-SELECT schemaname, tablename, indexname, idx_scan
+-- Find unused indexes (candidates for removal) and large indexes
+SELECT schemaname, tablename, indexrelname, idx_scan,
+       pg_size_pretty(pg_relation_size(indexrelid)) AS index_size
 FROM pg_stat_user_indexes
 WHERE idx_scan = 0
 ORDER BY pg_relation_size(indexrelid) DESC;
 
--- MySQL: Check index fragmentation
-SELECT object_schema, object_name, count_read, count_write
-FROM performance_schema.table_io_waits_summary_by_index_usage
-WHERE count_read > 0
-ORDER BY count_read DESC;
-```text
-<!-- Code example in TEXT -->
+-- Estimate table/index bloat (requires the pgstattuple extension)
+CREATE EXTENSION IF NOT EXISTS pgstattuple;
+SELECT * FROM pgstattuple('idx_user_created_at');
+```
 
 ### Solutions
 
-**Solution 1: Reindex (PostgreSQL)**
+**Solution 1: Reindex**
 
 ```sql
-<!-- Code example in SQL -->
--- Reindex single index (requires lock)
+-- Reindex a single index (takes a lock)
 REINDEX INDEX idx_user_created_at;
 
--- Reindex entire table (rebuilds all indexes)
-REINDEX TABLE users;
+-- Reindex an entire table (rebuilds all its indexes)
+REINDEX TABLE tb_user;
 
--- Concurrent reindex (no lock, v12+)
+-- Concurrent reindex (no exclusive lock, PostgreSQL 12+)
 REINDEX INDEX CONCURRENTLY idx_user_created_at;
-```text
-<!-- Code example in TEXT -->
+```
 
-**Solution 2: Optimize Table (MySQL)**
+**Solution 2: VACUUM to Reclaim Dead Tuples**
 
 ```sql
-<!-- Code example in SQL -->
--- Defragment and rebuild indexes
-OPTIMIZE TABLE users;
+-- Reclaim space and update visibility map (does not lock for normal VACUUM)
+VACUUM (ANALYZE) tb_user;
 
--- Analyze statistics
-ANALYZE TABLE users;
-```text
-<!-- Code example in TEXT -->
+-- VACUUM FULL rewrites the table compactly but takes an exclusive lock
+VACUUM FULL tb_user;
+```
 
 **Solution 3: Regular Maintenance Schedule**
 
 ```bash
-<!-- Code example in BASH -->
-# Weekly index maintenance
-0 2 * * 0 FraiseQL-maintenance reindex --tables all
+# Weekly concurrent reindex of a hot table (PostgreSQL 12+)
+0 2 * * 0 psql -d "$DATABASE_URL" -c "REINDEX TABLE CONCURRENTLY tb_user;"
 
-# Monthly full optimization
-0 2 1 * * FraiseQL-maintenance optimize --full
-```text
-<!-- Code example in TEXT -->
+# Daily vacuum + analyze of heavily modified tables
+0 3 * * * psql -d "$DATABASE_URL" -c "VACUUM (ANALYZE) tb_user; VACUUM (ANALYZE) tb_post;"
+```
 
 ### Prevention
 
-- [ ] Schedule weekly index maintenance
-- [ ] Monitor index bloat: Alert if > 20% bloat
-- [ ] Use concurrent indexing operations
-- [ ] Regular ANALYZE to update statistics
+- [ ] Schedule periodic concurrent reindexing of hot tables
+- [ ] Monitor index bloat with `pgstattuple` (alert if > 20% bloat)
+- [ ] Use concurrent indexing operations to avoid downtime
+- [ ] Rely on autovacuum, and run manual `ANALYZE` after large bulk loads
 
 ---
 
@@ -401,70 +422,54 @@ ANALYZE TABLE users;
 ### Diagnosis
 
 ```sql
-<!-- Code example in SQL -->
--- PostgreSQL: Check when statistics were last updated
-SELECT schemaname, tablename, last_vacuum, last_analyze
+-- Check when statistics were last updated and autovacuum/analyze ran
+SELECT schemaname, tablename, last_vacuum, last_autovacuum,
+       last_analyze, last_autoanalyze, n_dead_tup
 FROM pg_stat_user_tables
-ORDER BY last_analyze;
+ORDER BY last_analyze NULLS FIRST;
 
--- If last_analyze is very old → Update statistics
-
--- MySQL: Check table statistics
-SELECT object_schema, object_name, count_insert, count_update, count_delete
-FROM performance_schema.table_io_waits_summary_by_table
-WHERE count_insert > 10000 OR count_update > 10000
-ORDER BY count_insert DESC;
-```text
-<!-- Code example in TEXT -->
+-- If last_analyze / last_autoanalyze is very old → update statistics
+```
 
 ### Solutions
 
 **Solution 1: Update Statistics (ANALYZE)**
 
 ```sql
-<!-- Code example in SQL -->
--- PostgreSQL
-ANALYZE users;
-ANALYZE;  -- All tables
+ANALYZE tb_user;
+ANALYZE;  -- All tables in the current database
+```
 
--- MySQL
-ANALYZE TABLE users;
-
--- SQL Server
-UPDATE STATISTICS users;
-```text
-<!-- Code example in TEXT -->
-
-**Solution 2: Auto-Vacuum Configuration (PostgreSQL)**
+**Solution 2: Autovacuum Configuration**
 
 ```sql
-<!-- Code example in SQL -->
 -- Check autovacuum settings
 SELECT name, setting FROM pg_settings WHERE name LIKE 'autovacuum%';
 
--- Increase frequency if needed
-ALTER DATABASE mydb SET autovacuum_naptime = '30s';  -- Default 60s
-```text
-<!-- Code example in TEXT -->
+-- Make autovacuum more aggressive globally
+ALTER SYSTEM SET autovacuum_naptime = '30s';  -- Default 60s
+SELECT pg_reload_conf();
+
+-- Or tune a single high-churn table
+ALTER TABLE tb_post SET (autovacuum_analyze_scale_factor = 0.02);
+```
 
 **Solution 3: Schedule Regular ANALYZE**
 
 ```bash
-<!-- Code example in BASH -->
 # Hourly analysis of heavily modified tables
-0 * * * * psql -d $DATABASE -c "ANALYZE users; ANALYZE posts;"
+0 * * * * psql -d "$DATABASE_URL" -c "ANALYZE tb_user; ANALYZE tb_post;"
 
-# Daily full database analysis
-0 2 * * * psql -d $DATABASE -c "ANALYZE;"
-```text
-<!-- Code example in TEXT -->
+# Daily full-database analysis
+0 2 * * * psql -d "$DATABASE_URL" -c "ANALYZE;"
+```
 
 ### Prevention
 
-- [ ] Enable autovacuum (PostgreSQL)
-- [ ] Schedule regular ANALYZE: Daily for OLTP, Hourly for heavily modified tables
-- [ ] Monitor last_analyze timestamp
-- [ ] Alert if statistics > 24 hours old
+- [ ] Keep autovacuum enabled (it is on by default)
+- [ ] Schedule regular `ANALYZE`: daily for OLTP, hourly for heavily modified tables
+- [ ] Monitor `last_analyze` / `last_autoanalyze` timestamps
+- [ ] Alert if statistics are > 24 hours old on a busy table
 
 ---
 
@@ -472,90 +477,92 @@ ALTER DATABASE mydb SET autovacuum_naptime = '30s';  -- Default 60s
 
 ### Symptom: GROUP BY or COUNT(DISTINCT) Queries Taking > 10 Seconds
 
+FraiseQL supports **runtime auto-aggregation**: when a GraphQL query selects aggregate
+fields on a view-backed type, FraiseQL derives `GROUP BY` + aggregate SQL automatically
+(allowed functions: `SUM`, `AVG`, `COUNT`, `MIN`, `MAX`, `ARRAY_AGG`, `STRING_AGG`,
+`BOOL_AND`, `BOOL_OR`, `JSON_AGG`, `JSONB_AGG`). That derived SQL still runs against your
+PostgreSQL views, so the tuning below applies. Functions outside the allowlist (e.g.
+`STDDEV`, `VARIANCE`) must be written by hand in the view SQL.
+
 ### Diagnosis
 
 ```sql
-<!-- Code example in SQL -->
--- Identify aggregation queries
-SELECT query FROM pg_stat_statements
-WHERE query LIKE '%COUNT%' OR query LIKE '%GROUP BY%'
-ORDER BY mean_time DESC LIMIT 5;
+-- Identify aggregation queries (requires pg_stat_statements)
+SELECT query, mean_exec_time
+FROM pg_stat_statements
+WHERE query ILIKE '%count%' OR query ILIKE '%group by%'
+ORDER BY mean_exec_time DESC
+LIMIT 5;
 
--- Check if they use indexes
-EXPLAIN SELECT COUNT(DISTINCT user_id) FROM posts;
+-- Check whether they use indexes
+EXPLAIN ANALYZE SELECT COUNT(DISTINCT fk_user) FROM tb_post;
 -- Look for "Seq Scan" (bad) vs "Index Only Scan" (good)
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Solutions
 
-**Solution 1: Add Index for Aggregation Column**
+**Solution 1: Add Index for the Aggregation Column**
 
 ```sql
-<!-- Code example in SQL -->
--- For: COUNT(DISTINCT user_id)
-CREATE INDEX idx_posts_user_id ON posts(user_id);
+-- For: COUNT(DISTINCT fk_user)
+CREATE INDEX idx_post_user ON tb_post(fk_user);
 
 -- For: GROUP BY status
-CREATE INDEX idx_orders_status ON orders(status);
+CREATE INDEX idx_order_status ON tb_order(status);
 
--- For: Multiple columns in GROUP BY
-CREATE INDEX idx_user_org_status ON users(organization_id, status);
-```text
-<!-- Code example in TEXT -->
+-- For: multiple GROUP BY columns
+CREATE INDEX idx_user_org_status ON tb_user(fk_organization, status);
+```
 
-**Solution 2: Pre-Compute with Materialized View**
+**Solution 2: Pre-Compute with a Table-Backed Projection View**
+
+Move the aggregation out of the request path. Compute it into a `tv_` table refreshed by a
+`fn_` function or trigger, and expose the `tv_` as the read source:
 
 ```python
-<!-- Code example in Python -->
-# Before: Slow query in every request
-@FraiseQL.query
-def user_stats():
-    # SELECT user_id, COUNT(*) as post_count FROM posts GROUP BY user_id
-    # Takes 10+ seconds on 100M rows!
+import fraiseql
+from fraiseql.types import ID, DateTime
 
-# After: Use table-backed view
-@type
+# Aggregation is pre-computed in tv_user_stats and refreshed on a schedule;
+# reads no longer run COUNT/GROUP BY on every request.
+@fraiseql.type(sql_source="tv_user_stats", jsonb_column="data")
 class UserStats:
-    user_id: ID
-    post_count: int  # Pre-computed, updated hourly
+    id: ID
+    post_count: int   # pre-computed
     updated_at: DateTime
-```text
-<!-- Code example in TEXT -->
+```
 
-**Solution 3: Approximate Aggregations**
-
-For very large datasets where approximate values acceptable:
-
-```python
-<!-- Code example in Python -->
-# Use HyperLogLog instead of COUNT(DISTINCT)
-@type
-class PostStats:
-    unique_users_approx: int  # HyperLogLog count
-    # 5% error but 100x faster
-```text
-<!-- Code example in TEXT -->
-
-**Solution 4: Partition Large Tables**
+You can implement the same idea with a PostgreSQL **materialized view** refreshed
+periodically:
 
 ```sql
-<!-- Code example in SQL -->
--- PostgreSQL: Partition posts table by date
-CREATE TABLE posts_2026_01 PARTITION OF posts
+CREATE MATERIALIZED VIEW mv_user_post_counts AS
+SELECT fk_user, COUNT(*) AS post_count
+FROM tb_post
+GROUP BY fk_user;
+
+-- Refresh without blocking readers (requires a unique index on the MV)
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_user_post_counts;
+```
+
+**Solution 3: Partition Large Tables**
+
+```sql
+-- Partition the post table by date
+CREATE TABLE tb_post_2026_01 PARTITION OF tb_post
     FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
 
--- Aggregation on monthly partition is much faster
-SELECT COUNT(*) FROM posts_2026_01;
-```text
-<!-- Code example in TEXT -->
+-- Aggregation on a single monthly partition is much faster (partition pruning)
+SELECT COUNT(*) FROM tb_post WHERE created_at >= '2026-01-01'
+                              AND created_at <  '2026-02-01';
+```
 
 ### Prevention
 
-- [ ] Profile GROUP BY queries before deploying
+- [ ] Profile `GROUP BY` queries before deploying
 - [ ] Create indexes on aggregation columns
-- [ ] Use materialized views for complex aggregations
-- [ ] Monitor query time: Alert if > 5 seconds
+- [ ] Use `tv_` projection tables or materialized views for heavy aggregations
+- [ ] Monitor query time: alert if > 5 seconds
 
 ---
 
@@ -565,89 +572,87 @@ SELECT COUNT(*) FROM posts_2026_01;
 
 ### Diagnosis
 
-```bash
-<!-- Code example in BASH -->
-# Enable FraiseQL query logging
-export RUST_LOG=fraiseql_core=debug
+Turn up FraiseQL's Python logging and count the SQL statements issued for a single request.
 
-# Run problematic query
-# Look for: "Executing SELECT..." repeated for each parent record
-
-# Example: Query 100 users, then 100 queries for posts = 101 queries!
-```text
-<!-- Code example in TEXT -->
-
-**Count queries:**
+```python
+import logging
+logging.getLogger("fraiseql").setLevel(logging.DEBUG)
+```
 
 ```bash
-<!-- Code example in BASH -->
-grep -c "Executing SELECT" logs.txt
-# 101 queries → N+1 problem!
-```text
-<!-- Code example in TEXT -->
+# Run the request, capture the app logs, then count SELECTs
+uvicorn app:app 2>&1 | tee logs.txt
+grep -c -i "select" logs.txt
+# ~101 statements for 100 parents → N+1 problem
+```
 
 ### Solutions
 
-**Solution 1: FraiseQL Auto-Batching**
+**Solution 1: Compose the Nested Data Inside the View**
 
-```graphql
-<!-- Code example in GraphQL -->
-# FraiseQL automatically batches nested queries:
-query {
-  users(first: 100) {
-    id
-    posts(first: 50) {  # Batched automatically!
-      id
-      title
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
+The most reliable fix is to build the nested data directly into the `data` JSONB of a
+`v_`/`tv_` view using `jsonb_build_object` / `jsonb_agg`, so one read returns everything:
 
-**Result:** ~2 queries total (users + batched posts)
-
-**Solution 2: Use Table-Backed View with Pre-Fetched Data**
+```sql
+-- v_user_with_posts: posts embedded in the user's data JSONB (one query, no N+1)
+CREATE VIEW v_user_with_posts AS
+SELECT
+    u.id,
+    jsonb_build_object(
+        'id', u.id,
+        'name', u.data->>'name',
+        'posts', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('id', p.id, 'title', p.data->>'title'))
+            FROM tb_post p
+            WHERE p.fk_user = u.pk_user
+        ), '[]'::jsonb)
+    ) AS data
+FROM tb_user u;
+```
 
 ```python
-<!-- Code example in Python -->
-@type
+import fraiseql
+from fraiseql.types import ID
+
+@fraiseql.type(sql_source="v_user_with_posts", jsonb_column="data")
 class UserWithPosts:
-    """Denormalized view with posts pre-fetched."""
     id: ID
     name: str
-    posts_json: List[Post]  # Fetched in view definition
-```text
-<!-- Code example in TEXT -->
+    posts: list["Post"]  # fetched in the view definition, no per-row query
+```
 
-**Solution 3: Flatten Query Structure**
+**Solution 2: Batch a Field with a DataLoader**
 
-Instead of:
+For computed/related fields resolved in Python, batch them with `@fraiseql.dataloader_field`
+to collapse N lookups into one:
+
+```python
+import fraiseql
+
+@fraiseql.dataloader_field
+async def author(post: "Post", info) -> "User":
+    # Loaded in a single batched query for all posts in the result set.
+    ...
+```
+
+**Solution 3: Flatten the Query Structure**
+
+If deep nesting is unavoidable on a slow path, split it into separate queries the client
+joins client-side:
 
 ```graphql
-<!-- Code example in GraphQL -->
-query {
-  users { id posts { id comments { id } } }
-}
-```text
-<!-- Code example in TEXT -->
-
-Do separate queries:
-
-```graphql
-<!-- Code example in GraphQL -->
 query { users { id } }
 query { posts { id userId } }
 query { comments { id postId } }
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Prevention
 
-- [ ] Monitor query count per request: Alert if > 10 queries per request
+- [ ] Monitor query count per request: alert if > 10 queries per request
 - [ ] Load test with large datasets (1000+ records)
-- [ ] Profile queries in staging: Identify N+1 before deploying
-- [ ] Test queries with `EXPLAIN` to see execution plan
+- [ ] Prefer view-composed nested data over per-field resolvers on hot paths
+- [ ] Use `@fraiseql.dataloader_field` for Python-resolved relations
+- [ ] Test queries with `EXPLAIN ANALYZE` to see the execution plan
 
 ---
 
@@ -658,69 +663,53 @@ query { comments { id postId } }
 ### Diagnosis
 
 ```bash
-<!-- Code example in BASH -->
-# Measure latency to database
+# Measure latency to the database host
 ping -c 10 database-host
-# Normal: 1-10ms
-# High: > 50ms indicates network issue
+# Normal: 1-10ms; High: > 50ms indicates a network issue
 
-# Measure database response time
-time psql -h database-host -d mydb -c "SELECT COUNT(*) FROM users;"
-# Split time into:
-# - Connection time (first line of output)
-# - Query execution time
+# Measure end-to-end database response time
+time psql -h database-host -d mydb -c "SELECT COUNT(*) FROM tb_user;"
 
-# Check network path
+# Inspect the network path
 traceroute database-host
 # Look for high latency at any hop
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Solutions
 
 **Solution 1: Reduce Network Roundtrips**
 
-```python
-<!-- Code example in Python -->
-# Before: Multiple separate queries
-user = await db.query("SELECT * FROM users WHERE id = ?", [user_id])
-posts = await db.query("SELECT * FROM posts WHERE user_id = ?", [user_id])
+Compose related data in the view (see Section 6) so a request makes one roundtrip instead
+of several. Inside views, prefer a single joined `SELECT` over multiple subqueries:
 
-# After: Single joined query
-result = await db.query("""
-    SELECT u.*, p.*
-    FROM users u
-    LEFT JOIN posts p ON u.id = p.user_id
-    WHERE u.id = ?
-""", [user_id])
-```text
-<!-- Code example in TEXT -->
+```sql
+-- One roundtrip: join user and posts in the view's SELECT
+SELECT u.id,
+       jsonb_build_object('user', u.data, 'posts', jsonb_agg(p.data)) AS data
+FROM tb_user u
+LEFT JOIN tb_post p ON p.fk_user = u.pk_user
+WHERE u.id = $1
+GROUP BY u.id, u.data;
+```
 
-**Solution 2: Use Connection Pooling Closer to App**
+**Solution 2: Co-locate the Pooler / Database with the App**
 
 ```bash
-<!-- Code example in BASH -->
-# Deploy PgBouncer/ProxySQL on same host as FraiseQL
-# Reduces network roundtrips from 100ms to 1ms
-```text
-<!-- Code example in TEXT -->
+# Deploy PgBouncer on the same host (or same AZ) as the FastAPI app
+# to cut per-connection roundtrip overhead.
+```
 
 **Solution 3: Cache Frequently Accessed Data**
 
-```toml
-<!-- Code example in TOML -->
-[FraiseQL.caching]
-enabled = true
-ttl_seconds = 300  # Cache query results 5 minutes
-```text
-<!-- Code example in TEXT -->
+Use FraiseQL's PostgreSQL-backed result cache (see Section 9) for read-heavy, slow-changing
+data. Also deploy the database in the same availability zone as the application.
 
 ### Prevention
 
-- [ ] Monitor network latency: Alert if > 50ms
-- [ ] Deploy database close to application (same AZ)
+- [ ] Monitor network latency: alert if > 50ms
+- [ ] Deploy database close to the application (same AZ)
 - [ ] Use connection pooling
-- [ ] Batch queries to reduce roundtrips
+- [ ] Compose nested data in views to reduce roundtrips
 
 ---
 
@@ -731,73 +720,74 @@ ttl_seconds = 300  # Cache query results 5 minutes
 ### Diagnosis
 
 ```bash
-<!-- Code example in BASH -->
-# Monitor memory usage
-top -p <fraiseql_pid>
-# Look at RES (resident set size)
-# Should be stable, not growing
+# Find the uvicorn / app process and watch resident memory
+ps aux | grep uvicorn
+top -p <app_pid>          # watch RES (resident set size) — should be stable
 
-# Check for open file handles
-lsof -p <fraiseql_pid> | wc -l
-# If growing → File handle leak
+# Check for open file handles (growing → handle leak)
+lsof -p <app_pid> | wc -l
+```
 
-# Check for unclosed database connections
+```sql
+-- Check for unclosed database connections from the app role
 SELECT count(*) FROM pg_stat_activity WHERE usename = 'fraiseql_user';
-# Should not grow over time
-
-# Check subscription connections
-SELECT count(*) FROM websocket_connections;
-```text
-<!-- Code example in TEXT -->
+-- Should stay near the configured pool size, not grow unbounded
+```
 
 ### Solutions
 
-**Solution 1: Check for Unclosed Resources**
+**Solution 1: Ensure Resources Are Released**
+
+The CQRS repository borrows pool connections per request and returns them automatically.
+For long-lived async generators (subscriptions), make sure the generator is closed:
 
 ```python
-<!-- Code example in Python -->
-# Ensure subscriptions are closed
-try:
-    async for event in subscription:
-        process_event(event)
-finally:
-    subscription.close()  # Always close
+# Subscriptions are async generators; ensure cleanup on disconnect
+@fraiseql.subscription
+async def task_updates(info, project_id):
+    try:
+        async for task in watch_project_tasks(project_id):
+            yield task
+    finally:
+        # release any external resources you opened in the generator
+        ...
+```
 
-# Ensure database connections returned to pool
-async with pool.acquire() as conn:
-    # Connection automatically returned when block exits
-```text
-<!-- Code example in TEXT -->
+**Solution 2: Bound Concurrency and Query Cost**
 
-**Solution 2: Set Resource Limits**
+Limit query depth/complexity and request load through `FraiseQLConfig` rather than
+unbounded execution:
 
-```toml
-<!-- Code example in TOML -->
-[FraiseQL.limits]
-max_concurrent_queries = 1000
-max_subscription_connections = 5000
-max_result_size_bytes = 10485760  # 10MB
-```text
-<!-- Code example in TEXT -->
+```python
+from fraiseql.fastapi import FraiseQLConfig
 
-**Solution 3: Regular Memory Profiling**
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+    complexity_enabled=True,
+    complexity_max_depth=10,
+    complexity_max_score=1000,
+    rate_limit_enabled=True,
+    rate_limit_requests_per_minute=60,
+    execution_timeout_ms=30000,
+)
+```
+
+**Solution 3: Profile and Recycle**
 
 ```bash
-<!-- Code example in BASH -->
-# Use memory profiler (if supported)
-cargo profiling memory --duration 60s
+# Profile a Python process with a sampling profiler such as py-spy
+py-spy top --pid <app_pid>
 
-# Restart after 24 hours if needed
-systemctl restart FraiseQL
-```text
-<!-- Code example in TEXT -->
+# As a stop-gap, recycle workers periodically (uvicorn/gunicorn)
+gunicorn app:app -k uvicorn.workers.UvicornWorker --max-requests 10000 --max-requests-jitter 1000
+```
 
 ### Prevention
 
-- [ ] Monitor memory: Alert if growth > 10%/day
-- [ ] Regular service restarts: Daily or weekly
-- [ ] Subscribe to all resource cleanup
-- [ ] Set timeouts on all connections
+- [ ] Monitor memory: alert if growth > 10%/day
+- [ ] Recycle workers periodically (`--max-requests`)
+- [ ] Ensure subscription generators clean up on disconnect
+- [ ] Set complexity, rate-limit, and execution timeouts
 
 ---
 
@@ -805,104 +795,117 @@ systemctl restart FraiseQL
 
 ### Symptom: Query Results Seem Stale or Caching Not Working
 
+FraiseQL ships a PostgreSQL-backed result cache in `fraiseql.caching`. The key pieces:
+
+- `PostgresCache` — a cache backend stored in an `UNLOGGED` PostgreSQL table (shared across
+  app instances, fast, cleared on crash — acceptable for cache data).
+- `ResultCache` + `CacheConfig` — the cache itself and its settings (`enabled`,
+  `default_ttl`, `max_ttl`, `cache_errors`, `key_prefix`). `CacheStats` exposes `hits`,
+  `misses`, and `hit_rate`.
+- `CachedRepository` — wraps the CQRS repository so `db.find(...)` is cached transparently
+  (with per-tenant key isolation), accepting `skip_cache=` and `cache_ttl=` per call.
+- `CascadeRule` + `SchemaAnalyzer` + `setup_auto_cascade_rules` — derive invalidation rules
+  from your GraphQL schema so changing one type invalidates dependent caches.
+- `cached_query` — a decorator for caching the result of an individual resolver.
+
 ### Diagnosis
 
-```bash
-<!-- Code example in BASH -->
-# Check cache configuration
-curl http://localhost:5000/health/cache
-# Returns: cache hits, misses, size
+```python
+# Inspect cache statistics from a ResultCache instance
+print(result_cache.stats.hits, result_cache.stats.misses, result_cache.stats.hit_rate)
+```
 
-# Enable cache logging
-export RUST_LOG=fraiseql_cache=debug
-
-# Run same query twice
-curl -X POST http://localhost:5000/graphql \
-  -d '{"query": "{ users { id } }"}'
-curl -X POST http://localhost:5000/graphql \
-  -d '{"query": "{ users { id } }"}'
-
-# Check logs for "cache hit" vs "cache miss"
-```text
-<!-- Code example in TEXT -->
+```python
+# Turn on cache logging
+import logging
+logging.getLogger("fraiseql.caching").setLevel(logging.DEBUG)
+# Then run the same query twice and look for "Cache hit" vs "Cache miss"
+```
 
 ### Solutions
 
 **Solution 1: Enable Query Caching**
 
-```toml
-<!-- Code example in TOML -->
-[FraiseQL.caching]
-enabled = true
-default_ttl_seconds = 300  # Cache 5 minutes
-```text
-<!-- Code example in TEXT -->
+```python
+from fraiseql.caching import PostgresCache, ResultCache, CacheConfig, CachedRepository
 
-**Solution 2: Invalidate Cache on Mutation**
+# Backend: an UNLOGGED PostgreSQL table shared across instances
+backend = PostgresCache(connection_pool=pool, table_name="fraiseql_cache")
 
-```graphql
-<!-- Code example in GraphQL -->
-mutation {
-  createUser(name: "Alice") @cache(invalidate: ["users"]) {
-    id
-    name
-  }
-}
-```text
-<!-- Code example in TEXT -->
+# Cache with a 5-minute default TTL
+cache = ResultCache(backend, CacheConfig(enabled=True, default_ttl=300, max_ttl=3600))
 
-**Solution 3: Adjust TTL Based on Data Freshness**
+# Wrap the repository so reads are cached transparently
+cached_repo = CachedRepository(base_repository=repo, cache=cache)
+```
+
+**Solution 2: Invalidate the Cache on Writes (Cascade Rules)**
 
 ```python
-<!-- Code example in Python -->
-@FraiseQL.type
-class User:
-    # Cache for 5 minutes (user data doesn't change often)
-    id: ID
-    name: str
+from fraiseql.caching import setup_auto_cascade_rules
 
-@FraiseQL.type
-class InventoryLevel:
-    # Don't cache (inventory changes constantly)
-    quantity: int = field(cache=False)
-```text
-<!-- Code example in TEXT -->
+# Analyze the schema and register CASCADE invalidation rules so that, e.g.,
+# changing a User invalidates cached Posts that reference it.
+await setup_auto_cascade_rules(schema=schema, cache=cache)
+```
+
+```python
+from fraiseql.caching import CascadeRule
+
+# Or declare a rule explicitly: when "user" changes, invalidate "post" caches.
+rule = CascadeRule(source_domain="user", target_domain="post")
+```
+
+**Solution 3: Tune TTL Per Read or Bypass When Needed**
+
+`CachedRepository.find` accepts a per-call TTL and a cache bypass:
+
+```python
+# Slow-changing reference data: cache longer
+users = await cached_repo.find("v_user", cache_ttl=900)
+
+# Volatile data (e.g. inventory): bypass the cache for a fresh read
+levels = await cached_repo.find("v_inventory_level", skip_cache=True)
+```
+
+> The optional `fraiseql_rs` extension accelerates JSONB transformation on the read path;
+> it complements, but does not replace, the result cache above.
 
 ### Prevention
 
-- [ ] Monitor cache effectiveness: Alert if hit rate < 30%
-- [ ] Set appropriate TTL for each data type
-- [ ] Implement cache invalidation on mutations
-- [ ] Profile cache performance: Expected hit rate?
+- [ ] Monitor cache effectiveness via `CacheStats.hit_rate` (alert if hit rate < 30%)
+- [ ] Set an appropriate TTL per data type (`cache_ttl` / `CacheConfig`)
+- [ ] Register cascade invalidation rules so mutations don't serve stale reads
+- [ ] Profile cache performance against an expected hit rate
 
 ---
 
 ## 10. Production Response Checklist
 
-**When performance issue reported:**
+**When a performance issue is reported:**
 
 1. **Immediately:**
-   - [ ] Check error logs for exceptions
-   - [ ] Verify database connectivity
+   - [ ] Check application logs for exceptions
+   - [ ] Verify database connectivity and pool health
    - [ ] Check if it's a known issue
 
 2. **Within 5 minutes:**
-   - [ ] Identify affected queries
-   - [ ] Check query count: Normal load?
-   - [ ] Run EXPLAIN on slow query
+   - [ ] Identify affected queries (`pg_stat_statements`, app logs)
+   - [ ] Check request rate: normal load?
+   - [ ] Run `EXPLAIN ANALYZE` on the slow view query
    - [ ] Check for missing indexes
 
 3. **Within 15 minutes:**
-   - [ ] Apply temporary mitigation (cache, timeout, index)
+   - [ ] Apply temporary mitigation (cache, statement timeout, index)
    - [ ] Monitor for improvement
-   - [ ] Communicate status to team
+   - [ ] Communicate status to the team
 
 4. **Later:**
    - [ ] Root cause analysis
-   - [ ] Implement permanent fix
+   - [ ] Implement permanent fix (index, view rewrite, projection table, cache rule)
    - [ ] Deploy to staging first
    - [ ] Gradual rollout to production
-   - [ ] Document in runbook
+   - [ ] Document in the runbook
 
 ---
 
@@ -913,15 +916,8 @@ class InventoryLevel:
 - **[Schema Design Best Practices](../guides/schema-design-best-practices.md)** — Designing for performance
 - **[Common Gotchas](../guides/common-gotchas.md)** — Avoid performance pitfalls
 - **[Monitoring & Observability](../guides/monitoring.md)** — Setting up performance metrics
-- **[View Selection Guide](../guides/view-selection-performance-testing.md)** — Testing view performance
+- **[View Selection Guide](../architecture/database/view-selection-guide.md)** — Choosing `v_` vs `tv_` for performance
 
-**Architecture & Database:**
+**Operations:**
 
-- **[Database Targeting](../architecture/database/database-targeting.md)** — Database-specific optimization
-- **[Arrow Plane Architecture](../architecture/database/arrow-plane.md)** — Columnar query optimization
-- **[Observability Architecture](./observability-architecture.md)** — Runtime performance monitoring
-
----
-
-**Last Updated:** 2026-02-05
-**Version:** v2.0.0-alpha.1
+- **[Observability & Monitoring](./observability.md)** — Runtime performance monitoring


### PR DESCRIPTION
Phase 2 of the docs v2-contamination cleanup — the **Operations** nav section (5 files).

Reframes `docs/operations/` around operating a FraiseQL v1 Python/FastAPI app on PostgreSQL, with every API **verified against `src/`**.

## What changed
- **README.md** — reframed index; removed the `../integrations/federation/` link, the `Version: v2.0.0` stamp, and all dead links to Phase-1-removed files.
- **configuration.md** — replaced the fictional v2 `fraiseql.toml [observability]` / `fraiseql-cli analyze` / multi-DB config subsystem with the real `FraiseQLConfig` (pydantic) + `FRAISEQL_` env + `create_fraiseql_app(...)` kwargs reference (every field verified in `src/fraiseql/fastapi/config.py`).
- **distributed-tracing.md** — replaced the Rust `fraiseql_server` tracing API with the real `setup_tracing(app, TracingConfig(...))` / `get_tracer` / trace decorators (`src/fraiseql/tracing/`).
- **observability.md** — replaced the Rust observability API with `setup_metrics`/`MetricsConfig`, `setup_tracing`, `HealthCheck` + built-in `/health`&`/ready`, `QueryStatsCollector`, `init_error_tracker`, and the security audit logger.
- **performance-tuning-runbook.md** — PostgreSQL-only tuning runbook (`pg_stat_*`, EXPLAIN, pool kwargs, real `fraiseql.caching` API); removed v2.0.0/RUST_LOG/MySQL/SQL Server/`fraiseql.toml`.

## Verification
- ✅ 0 v2 tokens, 0 broken relative links, balanced fences, no stray markup
- ✅ Every asserted metrics/tracing/health/config/caching API verified against `src/`
- ✅ `mkdocs build` introduces no new warnings from these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)