### PR TITLE
docs(configuration): rewrite the Configuration section for v1 (FraiseQLConfig/FRAISEQL_ env)

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -1,4 +1,3 @@
-<!-- Skip to main content -->
 ---
 
 title: Configuration Guide
@@ -11,25 +10,59 @@ tags: ["documentation", "reference"]
 
 Complete configuration reference for FraiseQL security, networking, and operational settings.
 
+FraiseQL v1 is a Python runtime framework. Configuration is plain Python and environment
+variables — there is **no `fraiseql.toml`** and **no compile step**. Settings are resolved
+at app startup by `FraiseQLConfig`, a `pydantic-settings` model, and applied when you call
+`create_fraiseql_app(...)`.
+
 ## Quick Navigation
 
 ### Security Configuration
 
-- **[Security Configuration](security-configuration.md)** — Overview of all security settings
 - **[TLS/SSL Configuration](tls-configuration.md)** — Configure HTTPS and mutual TLS
 - **[Rate Limiting](rate-limiting.md)** — Brute-force protection and request throttling
-- **[Runtime Security Initialization](security-runtime-initialization.md)** — Initialize security subsystems at startup
 
 ### Database Configuration
 
 - **[PostgreSQL Authentication](postgresql-authentication.md)** — PostgreSQL connection and authentication
 
+## Configuration Sources
+
+FraiseQL reads settings from three places:
+
+1. **`create_fraiseql_app(...)` keyword arguments** — passed directly in Python.
+2. **A `FraiseQLConfig` instance** — a `pydantic-settings` model you can build and pass
+   via `create_fraiseql_app(config=...)`.
+3. **`FRAISEQL_`-prefixed environment variables** (and a `.env` file) — read automatically
+   by `FraiseQLConfig` (`env_prefix="FRAISEQL_"`, `env_file=".env"`).
+
+```python
+import fraiseql
+from fraiseql.fastapi import FraiseQLConfig, create_fraiseql_app
+
+config = FraiseQLConfig(
+    database_url="postgresql://user:pass@localhost/mydb",
+)
+
+app = create_fraiseql_app(
+    config=config,
+    types=[...],
+    queries=[...],
+    production=True,
+)
+```
+
 ## Environment Variables
 
-FraiseQL uses `FRAISEQL_` prefixed environment variables:
+`FraiseQLConfig` reads any `FRAISEQL_`-prefixed environment variable (or matching key in a
+local `.env` file):
 
 ```bash
-<!-- Code example in BASH -->
+# Database
+FRAISEQL_DATABASE_URL=postgresql://user:pass@localhost/db
+FRAISEQL_DATABASE_POOL_SIZE=20
+FRAISEQL_DATABASE_POOL_TIMEOUT=30
+
 # Security
 FRAISEQL_ENABLE_TLS=true
 FRAISEQL_TLS_CERT=/path/to/cert.pem
@@ -38,19 +71,16 @@ FRAISEQL_TLS_KEY=/path/to/key.pem
 # Rate Limiting
 FRAISEQL_RATE_LIMIT_ENABLED=true
 FRAISEQL_RATE_LIMIT_REQUESTS_PER_MINUTE=100
-
-# Database
-FRAISEQL_DATABASE_URL=postgresql://user:pass@localhost/db
-FRAISEQL_DATABASE_POOL_SIZE=20
-FRAISEQL_DATABASE_POOL_TIMEOUT=30
-```text
-<!-- Code example in TEXT -->
+```
 
 ## Configuration Priority
 
-1. **Compiled schema** (`schema.compiled.json` security section) — Default values
-2. **Config file** (`FraiseQL.toml`) — Override defaults
-3. **Environment variables** — Override config file (for production secrets)
+Later sources win, so explicit code overrides ambient configuration:
+
+1. **Defaults** — built into `FraiseQLConfig`.
+2. **`FRAISEQL_` environment variables / `.env`** — override defaults (handy for secrets).
+3. **A `FraiseQLConfig` instance** — overrides env-derived values you set explicitly.
+4. **`create_fraiseql_app(...)` keyword arguments** — override everything else.
 
 ## Common Scenarios
 
@@ -58,24 +88,19 @@ FRAISEQL_DATABASE_POOL_TIMEOUT=30
 
 1. Enable TLS: [TLS Configuration](tls-configuration.md)
 2. Set rate limits: [Rate Limiting](rate-limiting.md)
-3. Configure security: [Security Configuration](security-configuration.md)
-4. Database connection: [PostgreSQL Authentication](postgresql-authentication.md)
+3. Configure the database connection: [PostgreSQL Authentication](postgresql-authentication.md)
+4. Pass `production=True` to `create_fraiseql_app(...)` to disable the GraphQL playground
 
 ### Development Setup
 
 1. Disable TLS (use HTTP)
 2. Increase rate limits for testing
 3. Use minimal security hardening
-4. Local database connection
+4. Local database connection, with `production=False` to enable the playground
 
 ### Enterprise Deployment
 
 1. mTLS for service-to-service communication
 2. Strict rate limiting
 3. Security audit logging enabled
-4. KMS for field-level encryption
-
----
-
-**Version**: v2.0.0-alpha.1
-**Last Updated**: February 5, 2026
+4. PostgreSQL connection hardening (`sslmode`, `pg_hba.conf`)

--- a/docs/configuration/postgresql-authentication.md
+++ b/docs/configuration/postgresql-authentication.md
@@ -1,15 +1,15 @@
-<!-- Skip to main content -->
 ---
-
 title: PostgreSQL Authentication Guide
-description: FraiseQL requires secure authentication with PostgreSQL using SCRAM-based mechanisms. This guide covers supported authentication methods and version requirement
+description: How FraiseQL connects to PostgreSQL securely using SCRAM-based authentication. This guide covers PostgreSQL connection authentication methods, pg_hba.conf, and version requirements.
 keywords: []
 tags: ["documentation", "reference"]
 ---
 
 # PostgreSQL Authentication Guide
 
-FraiseQL requires secure authentication with PostgreSQL using SCRAM-based mechanisms. This guide covers supported authentication methods and version requirements.
+FraiseQL connects to PostgreSQL through psycopg (the libpq-based driver). Authentication to the database is handled by PostgreSQL itself — FraiseQL does not implement its own wire-protocol authentication. This guide covers how to configure PostgreSQL for secure SCRAM-based authentication and how FraiseQL's connection string negotiates it.
+
+When FraiseQL opens a connection, the psycopg/libpq client and the PostgreSQL server negotiate the authentication method dictated by `pg_hba.conf` (typically `scram-sha-256`). You configure the credentials and TLS settings in your `database_url`; everything else happens in PostgreSQL.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ FraiseQL requires secure authentication with PostgreSQL using SCRAM-based mechan
 
 **Required Software:**
 
-- FraiseQL v2.0.0-alpha.1 or later
+- FraiseQL (current release)
 - PostgreSQL 10+ (for SCRAM-SHA-256 support)
 - psql command-line client (usually included with PostgreSQL)
 - OpenSSL 1.1.1+ (for certificate generation)
@@ -34,7 +34,7 @@ FraiseQL requires secure authentication with PostgreSQL using SCRAM-based mechan
 
 - PostgreSQL 10 or later instance (local or remote)
 - PostgreSQL superuser or admin account for user creation
-- FraiseQL server instance
+- The host running your FraiseQL FastAPI application
 - Network connectivity between FraiseQL and PostgreSQL
 - For TLS: PostgreSQL compiled with SSL support
 
@@ -50,13 +50,19 @@ FraiseQL requires secure authentication with PostgreSQL using SCRAM-based mechan
 
 ## Overview
 
-PostgreSQL authentication in FraiseQL uses the SCRAM (Salted Challenge Response Authentication Mechanism) family of authentication protocols. These are cryptographically secure alternatives to older MD5-based authentication.
+PostgreSQL connection authentication uses the SCRAM (Salted Challenge Response Authentication Mechanism) family of protocols. These are cryptographically secure alternatives to older MD5-based authentication.
+
+FraiseQL itself does not choose the authentication method — the PostgreSQL server's `pg_hba.conf` does. The psycopg/libpq client transparently performs SCRAM-SHA-256 (or MD5, or channel binding) on FraiseQL's behalf based on the `database_url` you provide. Your job is to:
+
+1. Configure PostgreSQL to require SCRAM (`password_encryption = scram-sha-256`).
+2. Create a least-privilege role for FraiseQL.
+3. Point FraiseQL at it with a connection URL (and TLS settings).
 
 ## Supported Authentication Methods
 
 ### SCRAM-SHA-256 (Recommended)
 
-**Status**: ✅ Recommended for production
+**Status**: Recommended for production
 
 SCRAM-SHA-256 is a salted challenge-response authentication mechanism defined in RFC 5802. It provides:
 
@@ -68,28 +74,40 @@ SCRAM-SHA-256 is a salted challenge-response authentication mechanism defined in
 **Requirements**:
 
 - PostgreSQL 10 or later
-- User password must be set using SCRAM-SHA-256
+- User password must be stored using SCRAM-SHA-256
+- `pg_hba.conf` entry using the `scram-sha-256` auth method
 
 **Configuration**:
 
-```toml
-<!-- Code example in TOML -->
-[database]
-url = "postgresql://username:password@localhost:5432/FraiseQL"
-```text
-<!-- Code example in TEXT -->
+Pass the connection URL to FraiseQL via the `database_url` argument or the `FRAISEQL_DATABASE_URL` environment variable. psycopg/libpq negotiates SCRAM-SHA-256 automatically:
+
+```python
+from fraiseql.fastapi import create_fraiseql_app
+
+app = create_fraiseql_app(
+    database_url="postgresql://fraiseql_user:secure_password@localhost:5432/mydb",
+    types=[...],
+    queries=[...],
+)
+```
+
+Or via environment variable:
+
+```bash
+export FRAISEQL_DATABASE_URL="postgresql://fraiseql_user:secure_password@localhost:5432/mydb"
+```
 
 ### SCRAM-SHA-256-PLUS (Channel Binding)
 
-**Status**: ✅ Best for highly sensitive deployments
+**Status**: Best for highly sensitive deployments
 
-SCRAM-SHA-256-PLUS adds channel binding to SCRAM-SHA-256, providing additional protection by binding the authentication to the TLS connection itself.
+SCRAM-SHA-256-PLUS adds channel binding to SCRAM-SHA-256, providing additional protection by binding the authentication to the TLS connection itself. With a TLS connection, libpq negotiates channel binding automatically when both client and server support it.
 
 **Requirements**:
 
 - PostgreSQL 11 or later
 - TLS connection required
-- Explicit channel binding support in driver
+- Channel binding support in libpq (PostgreSQL 11+ client libraries)
 
 **When to use**:
 
@@ -99,26 +117,31 @@ SCRAM-SHA-256-PLUS adds channel binding to SCRAM-SHA-256, providing additional p
 
 **Configuration**:
 
-```toml
-<!-- Code example in TOML -->
-[database]
-url = "postgresql://username:password@localhost:5432/FraiseQL?sslmode=require"
-```text
-<!-- Code example in TEXT -->
+Require TLS by adding `sslmode=require` (or stronger) to the connection URL:
+
+```python
+from fraiseql.fastapi import create_fraiseql_app
+
+app = create_fraiseql_app(
+    database_url="postgresql://fraiseql_user:secure_password@localhost:5432/mydb?sslmode=require",
+    types=[...],
+    queries=[...],
+)
+```
 
 ## PostgreSQL Version Requirements
 
 | Version | SCRAM-SHA-256 | SCRAM-SHA-256-PLUS | Notes |
 |---------|---------------|--------------------|-------|
-| < 10    | ❌ Not supported | ❌ Not supported | **Upgrade required** - MD5 only |
-| 10-10.x | ✅ Supported | ❌ Not supported | Minimum version for SCRAM |
-| 11+     | ✅ Supported | ✅ Supported | **Recommended** |
-| 12+     | ✅ Supported | ✅ Supported | Current stable branch |
-| 13+     | ✅ Supported | ✅ Supported | Current stable branch |
-| 14+     | ✅ Supported | ✅ Supported | Current stable branch |
-| 15+     | ✅ Supported | ✅ Supported | Current stable branch |
-| 16+     | ✅ Supported | ✅ Supported | Current stable branch |
-| 17+     | ✅ Supported | ✅ Supported | Current stable branch |
+| < 10    | Not supported | Not supported | **Upgrade required** - MD5 only |
+| 10-10.x | Supported | Not supported | Minimum version for SCRAM |
+| 11+     | Supported | Supported | **Recommended** |
+| 12+     | Supported | Supported | Current stable branch |
+| 13+     | Supported | Supported | Current stable branch |
+| 14+     | Supported | Supported | Current stable branch |
+| 15+     | Supported | Supported | Current stable branch |
+| 16+     | Supported | Supported | Current stable branch |
+| 17+     | Supported | Supported | Current stable branch |
 
 ## Migration from MD5
 
@@ -129,7 +152,6 @@ If you're currently using older PostgreSQL versions with MD5 authentication, fol
 Upgrade to PostgreSQL 10 or later:
 
 ```bash
-<!-- Code example in BASH -->
 # Check current version
 psql --version
 
@@ -139,91 +161,103 @@ sudo apt-get install postgresql-11  # or newer version
 
 # For macOS with Homebrew
 brew upgrade postgresql
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Step 2: Configure SCRAM Authentication
 
-Update PostgreSQL configuration to enforce SCRAM:
+Update PostgreSQL configuration to enforce SCRAM.
 
 **PostgreSQL Server Configuration** (`postgresql.conf`):
 
 ```ini
-<!-- Code example in INI -->
-# Enforce SCRAM for all new connections
-password_encryption = 'scram-sha256'
-```text
-<!-- Code example in TEXT -->
+# Enforce SCRAM for all new password hashes
+password_encryption = scram-sha-256
+```
+
+**Host-Based Authentication** (`pg_hba.conf`) — set the auth method to `scram-sha-256` for the FraiseQL connections:
+
+```conf
+# TYPE  DATABASE   USER            ADDRESS         METHOD
+host    mydb       fraiseql_user   0.0.0.0/0       scram-sha-256
+hostssl mydb       fraiseql_user   0.0.0.0/0       scram-sha-256
+```
+
+Reload PostgreSQL after editing `pg_hba.conf`:
+
+```bash
+sudo systemctl reload postgresql
+# or, from psql:
+# SELECT pg_reload_conf();
+```
 
 ### Step 3: Reset User Passwords
 
-PostgreSQL stores password hashes. To update existing users to SCRAM:
+PostgreSQL stores password hashes. Existing passwords hashed under MD5 are not automatically re-hashed — you must set the password again after enabling `scram-sha-256` so a new SCRAM hash is created:
 
 ```sql
-<!-- Code example in SQL -->
--- Reset password for FraiseQL user (this will create SCRAM-SHA-256 hash)
+-- Reset password for FraiseQL user (creates a SCRAM-SHA-256 hash)
 ALTER USER fraiseql_user WITH PASSWORD 'new_secure_password';
 
--- For new users, this is automatic with password_encryption = 'scram-sha256'
+-- For new users, this is automatic with password_encryption = scram-sha-256
 CREATE USER fraiseql_user WITH PASSWORD 'secure_password';
-```text
-<!-- Code example in TEXT -->
+```
 
-### Step 4: Update Connection String
+### Step 4: Update the Connection URL
 
-Update your FraiseQL configuration:
+Point FraiseQL at the database with the new credentials. Set it via the `FRAISEQL_DATABASE_URL` environment variable or pass it to `create_fraiseql_app(database_url=...)`:
 
-```toml
-<!-- Code example in TOML -->
-[database]
+```bash
 # Old (MD5 - deprecated)
-# url = "postgresql://fraiseql_user:password@localhost:5432/FraiseQL"
+# FRAISEQL_DATABASE_URL="postgresql://fraiseql_user:password@localhost:5432/mydb"
 
-# New (SCRAM-SHA-256)
-url = "postgresql://fraiseql_user:secure_password@localhost:5432/FraiseQL"
-```text
-<!-- Code example in TEXT -->
+# New (SCRAM-SHA-256 negotiated automatically by psycopg/libpq)
+export FRAISEQL_DATABASE_URL="postgresql://fraiseql_user:secure_password@localhost:5432/mydb"
+```
+
+No code change is required to switch from MD5 to SCRAM — the negotiation is handled by the client library based on `pg_hba.conf`.
 
 ## Verifying SCRAM Authentication
 
 ### Check PostgreSQL Server Configuration
 
 ```sql
-<!-- Code example in SQL -->
 -- Check password encryption method
 SHOW password_encryption;
--- Should output: scram-sha256
+-- Should output: scram-sha-256
 
 -- Check authentication method in pg_hba.conf
 SELECT * FROM pg_hba_file_rules WHERE auth_method LIKE 'scram%';
-```text
-<!-- Code example in TEXT -->
+```
 
 ### Check User Authentication Method
 
 ```sql
-<!-- Code example in SQL -->
--- Check a specific user's password hash (only visible to superusers)
+-- Check a specific user (only visible to superusers)
 SELECT usename, usesuper FROM pg_user WHERE usename = 'fraiseql_user';
 
 -- The password is stored as a SCRAM hash, not MD5
-SELECT substring(rolpassword, 1, 10) as hash_prefix
+SELECT substring(rolpassword, 1, 13) AS hash_prefix
 FROM pg_authid WHERE rolname = 'fraiseql_user';
 -- Should start with "SCRAM-SHA-256" not "md5"
-```text
-<!-- Code example in TEXT -->
+```
 
-### Test Connection from FraiseQL
+### Test the Connection
+
+Use `psql` with the same credentials FraiseQL will use to confirm SCRAM negotiation succeeds before starting the app:
 
 ```bash
-<!-- Code example in BASH -->
-# Test the connection with verbose logging
-RUST_LOG=debug FraiseQL-server start
+# Connect as the FraiseQL role
+psql "postgresql://fraiseql_user:secure_password@localhost:5432/mydb"
+# A successful connection means SCRAM-SHA-256 was negotiated per pg_hba.conf
+```
 
-# Look for successful SCRAM-SHA-256 authentication in logs
-# Should see: "Successfully authenticated using SCRAM-SHA-256"
-```text
-<!-- Code example in TEXT -->
+You can also start the FraiseQL FastAPI app and confirm it connects:
+
+```bash
+# Run the FastAPI app (uvicorn). A successful startup means the pool
+# authenticated to PostgreSQL via SCRAM-SHA-256.
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
 
 ## Troubleshooting
 
@@ -233,21 +267,21 @@ RUST_LOG=debug FraiseQL-server start
 
 **Solution**:
 
-1. Verify the password is correct
+1. Verify the password in your `database_url` is correct
 2. Check PostgreSQL server is using SCRAM: `SHOW password_encryption;`
 3. Reset the password: `ALTER USER fraiseql_user WITH PASSWORD 'password';`
-4. Verify connection string format
+4. Verify the connection URL format
 
 ### "SCRAM authentication required but not available"
 
-**Cause**: PostgreSQL version < 10 or MD5-only configuration
+**Cause**: PostgreSQL version < 10, MD5-only configuration, or a stale MD5 password hash
 
 **Solution**:
 
 1. Upgrade PostgreSQL to 10+
 2. Update `password_encryption` in `postgresql.conf`
-3. Restart PostgreSQL: `sudo systemctl restart postgresql`
-4. Reset passwords for all users
+3. Reload PostgreSQL: `sudo systemctl reload postgresql`
+4. Re-set passwords so SCRAM hashes are generated for all roles
 
 ### "SCRAM-SHA-256-PLUS not supported"
 
@@ -256,61 +290,65 @@ RUST_LOG=debug FraiseQL-server start
 **Solution**:
 
 1. For SCRAM-SHA-256-PLUS, upgrade to PostgreSQL 11+
-2. Enable TLS: Add `sslmode=require` to connection string
+2. Enable TLS: add `sslmode=require` to the connection URL
 3. Verify TLS certificates are valid
-4. Check PostgreSQL compiled with OpenSSL support: `SELECT ssl FROM pg_config();`
+4. Check PostgreSQL was compiled with OpenSSL support: `SELECT setting FROM pg_settings WHERE name = 'ssl';`
 
 ## Best Practices
 
 1. **Always use SCRAM**: Migrate away from MD5 authentication
 2. **Use Strong Passwords**: Generate cryptographically random passwords (16+ characters)
-3. **Enable TLS**: Always encrypt the connection wire
-4. **Separate Credentials**: Use dedicated database users for each application
+3. **Enable TLS**: Always encrypt the connection wire (`sslmode=require` or stronger)
+4. **Separate Credentials**: Use a dedicated, least-privilege PostgreSQL role for FraiseQL
 5. **Rotate Passwords**: Rotate database passwords regularly (quarterly or as per policy)
 6. **Monitor Authentication**: Monitor failed authentication attempts in PostgreSQL logs
-7. **Use Secrets Management**: Store passwords in a secrets manager, not in plaintext config
+7. **Use Secrets Management**: Store the `database_url` / password in a secrets manager, not in plaintext config
 
 ## Example: Complete Setup
 
 ```bash
-<!-- Code example in BASH -->
 #!/bin/bash
 # Complete PostgreSQL SCRAM setup for FraiseQL
 
 # 1. Connect as PostgreSQL superuser
 sudo -u postgres psql
+```
 
-# In psql:
+In `psql`:
 
+```sql
 -- Enable SCRAM for future password changes
-ALTER SYSTEM SET password_encryption = 'scram-sha256';
+ALTER SYSTEM SET password_encryption = 'scram-sha-256';
 
--- Create dedicated FraiseQL user
+-- Create a dedicated, least-privilege FraiseQL role
 CREATE USER fraiseql_user WITH PASSWORD 'your_secure_password_here';
 
--- Grant necessary permissions
-GRANT CONNECT ON DATABASE FraiseQL TO fraiseql_user;
+-- Grant only the privileges FraiseQL needs.
+-- Reads happen through v_/tv_ views; writes happen through fn_ functions.
+GRANT CONNECT ON DATABASE mydb TO fraiseql_user;
 GRANT USAGE ON SCHEMA public TO fraiseql_user;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO fraiseql_user;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO fraiseql_user;
 
 -- Reload configuration
 SELECT pg_reload_conf();
+```
 
--- Exit psql
-\q
-
-# 2. Restart PostgreSQL to apply changes
+```bash
+# Exit psql (\q), then restart PostgreSQL to apply ALTER SYSTEM
 sudo systemctl restart postgresql
 
-# 3. Verify SCRAM is enabled
+# 2. Verify SCRAM is enabled
 sudo -u postgres psql -c "SHOW password_encryption;"
-# Should output: scram-sha256
+# Should output: scram-sha-256
 
-# 4. Test connection from FraiseQL
-psql -h localhost -U fraiseql_user -d FraiseQL
-# Should successfully authenticate with SCRAM-SHA-256
-```text
-<!-- Code example in TEXT -->
+# 3. Test the connection with the FraiseQL credentials
+psql "postgresql://fraiseql_user:your_secure_password_here@localhost:5432/mydb"
+# Should authenticate via SCRAM-SHA-256
+
+# 4. Point FraiseQL at the database
+export FRAISEQL_DATABASE_URL="postgresql://fraiseql_user:your_secure_password_here@localhost:5432/mydb"
+```
 
 ## Security Implications
 
@@ -321,21 +359,22 @@ psql -h localhost -U fraiseql_user -d FraiseQL
 | **Rainbow Table Resistant** | No | Yes | Yes |
 | **Channel Binding** | N/A | None | TLS-bound |
 | **MitM Protection** | Low | Medium | High |
-| **Recommended** | ❌ Never | ✅ Production | ✅✅ Sensitive |
+| **Recommended** | Never | Production | Sensitive |
 
 ## References
 
 - [PostgreSQL Authentication Documentation](https://www.postgresql.org/docs/current/auth-methods.html)
+- [PostgreSQL pg_hba.conf](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
 - [RFC 5802 - SCRAM](https://tools.ietf.org/html/rfc5802)
 - [PostgreSQL password_encryption Parameter](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-PASSWORD-ENCRYPTION)
-- [PostgreSQL Security](https://www.postgresql.org/docs/current/sql-syntax.html)
+- [psycopg Connection Strings](https://www.psycopg.org/psycopg3/docs/api/connections.html)
 
 ## Support Matrix
 
 | Component | PostgreSQL 10 | PostgreSQL 11+ | Notes |
 |-----------|---------------|----------------|-------|
-| FraiseQL Core | ✅ Supported | ✅ Recommended | Min version for SCRAM |
-| SCRAM-SHA-256 | ✅ Yes | ✅ Yes | Recommended auth |
-| SCRAM-SHA-256-PLUS | ❌ No | ✅ Yes | Best security |
-| Connection Pooling | ✅ Yes | ✅ Yes | Via pgBouncer |
-| Replication | ✅ Yes | ✅ Yes | Streaming replication |
+| FraiseQL Core | Supported | Recommended | Min version for SCRAM |
+| SCRAM-SHA-256 | Yes | Yes | Recommended auth |
+| SCRAM-SHA-256-PLUS | No | Yes | Best security |
+| Connection Pooling | Yes | Yes | Via pgBouncer |
+| Replication | Yes | Yes | Streaming replication |

--- a/docs/configuration/rate-limiting.md
+++ b/docs/configuration/rate-limiting.md
@@ -16,73 +16,167 @@ FraiseQL implements request rate limiting to prevent denial-of-service (DoS) att
 **Required Knowledge:**
 
 - HTTP request fundamentals (status codes, headers)
-- Rate limiting algorithms (token bucket, leaky bucket)
-- TOML configuration file syntax
+- Rate limiting strategies (fixed window, sliding window, token bucket)
+- Python and FastAPI basics
 - Authentication concepts (IP-based vs user-based rate limiting)
 - DoS attack patterns and mitigation strategies
 
 **Required Software:**
 
-- FraiseQL v2.0.0-alpha.1 or later
-- A text editor for `FraiseQL.toml` configuration
+- FraiseQL v1 (PostgreSQL)
+- Python 3.13+
 - curl or Postman (for testing rate limit headers)
-- Bash or similar shell for configuration management
 
 **Required Infrastructure:**
 
-- FraiseQL server instance (configured with rate limiting enabled)
-- PostgreSQL or similar database (for storing rate limit state)
-- Network connectivity to test HTTP endpoints
+- A FraiseQL FastAPI application (built with `create_fraiseql_app`)
+- PostgreSQL (FraiseQL's database)
+- Redis (optional, for shared rate limit state across multiple app instances)
 
 **Optional but Recommended:**
 
 - Monitoring tools (Prometheus, Grafana) to track rate limit violations
 - API gateway (Kong, Tyk) for additional rate limiting at proxy level
-- Distributed rate limiting backend (Redis) for multi-instance deployments
+- Redis for distributed rate limiting in multi-instance deployments
 - Logging aggregation (ELK, Splunk) for rate limit event analysis
 
 **Time Estimate:** 15-30 minutes for basic configuration, 1-2 hours for production tuning
 
 ## Overview
 
-Rate limiting is implemented using a token bucket algorithm with support for:
+Rate limiting in FraiseQL is implemented as FastAPI middleware
+(`fraiseql.security.RateLimitMiddleware`). It supports:
 
-- **Per-IP rate limiting**: Limits requests from individual client IPs
-- **Per-user rate limiting**: Limits requests from authenticated users
-- **Configurable burst capacity**: Allows temporary traffic spikes
-- **Response headers**: Clients can check remaining quota via HTTP headers
+- **Per-IP rate limiting**: limits requests from individual client IPs
+- **Per-user rate limiting**: limits requests from authenticated users (keyed on
+  `request.state.user_id` when set by the auth layer, falling back to IP)
+- **Multiple strategies**: fixed window, sliding window, and token bucket
+- **GraphQL-aware limits**: separate limits per operation type (query / mutation /
+  subscription) and per estimated query complexity
+- **Response headers**: clients can check their quota via HTTP headers
+- **Pluggable stores**: in-memory by default, or Redis for shared state
 
 ## Configuration
 
-Rate limiting configuration is defined in your server configuration file:
+The simplest way to enable rate limiting is through `FraiseQLConfig`. Settings can be
+provided in code or via `FRAISEQL_`-prefixed environment variables, then passed to
+`create_fraiseql_app(config=...)`.
 
-```toml
-<!-- Code example in TOML -->
-[rate_limit]
-# Enable/disable rate limiting
-enabled = true
+```python
+from fraiseql.fastapi import FraiseQLConfig, create_fraiseql_app
 
-# Requests per second per IP address
-rps_per_ip = 100
+config = FraiseQLConfig(
+    database_url="postgresql://localhost/mydb",
+    # Rate limiting (defaults shown)
+    rate_limit_enabled=True,
+    rate_limit_requests_per_minute=60,
+    rate_limit_requests_per_hour=1000,
+    rate_limit_burst_size=10,
+    rate_limit_window_type="sliding",   # "sliding" or "fixed"
+    rate_limit_whitelist=[],            # IPs/keys never rate limited
+    rate_limit_blacklist=[],            # IPs/keys always rejected
+)
 
-# Requests per second per authenticated user
-rps_per_user = 1000
+app = create_fraiseql_app(config=config, types=[...], queries=[...])
+```
 
-# Maximum burst capacity (tokens accumulated)
-burst_size = 500
+The same settings as environment variables:
 
-# Cleanup interval for stale entries (seconds)
-cleanup_interval_secs = 300
-```text
-<!-- Code example in TEXT -->
+```bash
+FRAISEQL_RATE_LIMIT_ENABLED=true
+FRAISEQL_RATE_LIMIT_REQUESTS_PER_MINUTE=60
+FRAISEQL_RATE_LIMIT_REQUESTS_PER_HOUR=1000
+FRAISEQL_RATE_LIMIT_BURST_SIZE=10
+FRAISEQL_RATE_LIMIT_WINDOW_TYPE=sliding
+```
 
-### Default Values
+### Configuration Fields
 
-- `enabled`: `true`
-- `rps_per_ip`: 100 req/sec
-- `rps_per_user`: 1000 req/sec
-- `burst_size`: 500 requests
-- `cleanup_interval_secs`: 300 seconds (5 minutes)
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rate_limit_enabled` | `bool` | `True` | Enable/disable rate limiting |
+| `rate_limit_requests_per_minute` | `int` | `60` | Allowed requests per minute |
+| `rate_limit_requests_per_hour` | `int` | `1000` | Allowed requests per hour |
+| `rate_limit_burst_size` | `int` | `10` | Burst capacity (token-bucket strategy) |
+| `rate_limit_window_type` | `str` | `"sliding"` | Window strategy: `"sliding"` or `"fixed"` |
+| `rate_limit_whitelist` | `list[str]` | `[]` | IPs/keys never rate limited |
+| `rate_limit_blacklist` | `list[str]` | `[]` | IPs/keys always rejected |
+
+## Programmatic Setup
+
+For finer control (custom per-path rules, a Redis-backed store, multi-instance
+deployments) wire the middleware yourself with `setup_rate_limiting`. It is exported from
+`fraiseql.security`, takes the FastAPI app returned by `create_fraiseql_app`, and installs
+`RateLimitMiddleware`.
+
+```python
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.security import (
+    RateLimit,
+    RateLimitRule,
+    RateLimitStrategy,
+    setup_rate_limiting,
+)
+
+app = create_fraiseql_app(
+    database_url="postgresql://localhost/mydb",
+    types=[...],
+    queries=[...],
+)
+
+custom_rules = [
+    # Throttle the GraphQL endpoint
+    RateLimitRule(
+        path_pattern="/graphql",
+        rate_limit=RateLimit(requests=60, window=60),
+        message="GraphQL rate limit exceeded",
+    ),
+    # Tighter limit on auth endpoints (5 requests / 5 minutes)
+    RateLimitRule(
+        path_pattern="/auth/*",
+        rate_limit=RateLimit(requests=5, window=300),
+        message="Authentication rate limit exceeded",
+    ),
+]
+
+setup_rate_limiting(
+    app,
+    custom_rules=custom_rules,
+    default_limit=RateLimit(requests=100, window=60),
+)
+```
+
+`RateLimit` accepts a `strategy` (`RateLimitStrategy.FIXED_WINDOW`,
+`RateLimitStrategy.SLIDING_WINDOW`, or `RateLimitStrategy.TOKEN_BUCKET`) and an optional
+`burst` value for the token-bucket strategy:
+
+```python
+RateLimit(
+    requests=100,
+    window=60,
+    burst=20,
+    strategy=RateLimitStrategy.TOKEN_BUCKET,
+)
+```
+
+If you do not pass `custom_rules`, FraiseQL installs a sensible set via
+`create_default_rate_limit_rules()` (GraphQL, `/auth/*`, and `/api/*` patterns).
+
+### Multi-Instance Deployments (Redis)
+
+The in-memory store keeps counters per process, so each app instance enforces limits
+independently. To share state across instances, pass a Redis client — `setup_rate_limiting`
+then uses `RedisRateLimitStore` automatically:
+
+```python
+import redis.asyncio as redis
+
+from fraiseql.security import setup_rate_limiting
+
+redis_client = redis.from_url("redis://localhost:6379/0")
+
+setup_rate_limiting(app, redis_client=redis_client)
+```
 
 ## Key Extraction Strategy
 
@@ -90,82 +184,61 @@ Rate limits are applied using the following key extraction logic:
 
 ### 1. Authenticated Requests
 
-For requests with authentication credentials:
+For requests with an authenticated user (the auth layer sets `request.state.user_id`):
 
-- **Key**: User ID
-- **Limit**: `rps_per_user` (higher limit)
-- **Use case**: Trusted authenticated users get higher quotas
+- **Key**: `user:<user_id>`
+- **Use case**: authenticated users are tracked individually
 
 ### 2. Unauthenticated Requests
 
 For requests without authentication:
 
-- **Key**: Client IP address
-- **Limit**: `rps_per_ip` (lower limit)
-- **Use case**: Protects against anonymous abuse
+- **Key**: `ip:<client_ip>`
+- **Use case**: protects against anonymous abuse
 
 ### 3. IP Address Resolution
 
-When extracting the client IP address:
+When extracting the client IP address, the middleware checks, in order:
 
-1. **Direct Connections** (no proxy):
-   - Use the source IP from the socket connection directly
+1. The first entry of the `X-Forwarded-For` header (if present)
+2. The `X-Real-IP` header (if present)
+3. The direct socket peer address (`request.client.host`)
 
-2. **Behind Untrusted Proxies**:
-   - Ignore `X-Forwarded-For` header
-   - Use the proxy server's IP as the rate limit key
-   - **Why**: Clients cannot spoof IPs through untrusted intermediaries
-
-3. **Behind Trusted Proxies** (configured):
-   - Trust the `X-Forwarded-For` header
-   - Use the client's real IP from the header
-   - **Why**: Trusted proxies (load balancers, reverse proxies) are configured to only forward legitimate client IPs
-
-## Configuration for Proxy Environments
-
-To support rate limiting through proxies, configure trusted proxy IP ranges:
-
-```toml
-<!-- Code example in TOML -->
-[rate_limit]
-enabled = true
-rps_per_ip = 100
-rps_per_user = 1000
-# Trusted proxies that can set X-Forwarded-For header
-trusted_proxies = [
-    "10.0.0.0/8",          # Internal load balancer (10.0.0.0 - 10.255.255.255)
-    "172.16.0.0/12",       # VPC CIDR (172.16.0.0 - 172.31.255.255)
-    "203.0.113.0/24",      # CDN egress IPs
-    "203.0.113.5/32",      # Specific trusted reverse proxy
-]
-```text
-<!-- Code example in TEXT -->
-
-### Best Practices
-
-1. **allowlist only known proxies**: Only add IPs/CIDRs of proxies you control
-2. **Use specific IPs when possible**: Prefer individual IPs over large CIDR blocks
-3. **Monitor proxy configurations**: Update if infrastructure changes
-4. **Test rate limiting**: Verify correct keys are used before deployment
+> **Security note:** `X-Forwarded-For` and `X-Real-IP` are client-supplied and can be
+> spoofed. Only trust them when your application sits behind a proxy you control that
+> overwrites these headers. When exposed directly, strip or ignore them at the proxy so the
+> socket peer address is used.
 
 ## Response Headers
 
-When a request is accepted, FraiseQL includes rate limit information in HTTP response headers:
+When a request is rejected, the middleware returns HTTP `429` with the following headers:
 
 ```text
-<!-- Code example in TEXT -->
-X-RateLimit-Limit: 100          # Maximum requests per second
-X-RateLimit-Remaining: 45       # Remaining requests in current window
-Retry-After: 60                 # Seconds to wait before retrying (when limited)
-```text
-<!-- Code example in TEXT -->
+Retry-After: 60           # Seconds to wait before retrying
+X-RateLimit-Limit: 100    # Maximum requests in the window
+X-RateLimit-Window: 60    # Window length in seconds
+```
+
+The JSON body of a rejected non-GraphQL request looks like:
+
+```json
+{
+  "error": "Rate Limit Exceeded",
+  "message": "Rate limit exceeded",
+  "retry_after": 60
+}
+```
+
+GraphQL operations that exceed a limit return a GraphQL error with
+`extensions.code = "RATE_LIMITED"`.
 
 Example client handling:
 
 ```python
-<!-- Code example in Python -->
 import time
+
 import requests
+
 
 def graphql_request(url, query):
     while True:
@@ -178,96 +251,99 @@ def graphql_request(url, query):
             continue
 
         return response.json()
-```text
-<!-- Code example in TEXT -->
+```
 
-## Token Bucket Algorithm
+## GraphQL-Aware Limits
 
-The implementation uses a token bucket algorithm:
+For `POST /graphql`, the middleware applies additional limits via `GraphQLRateLimiter`:
 
-1. Each IP/user gets a "bucket" of tokens
-2. Bucket capacity = `burst_size`
-3. Tokens refill at `rps_per_ip` or `rps_per_user` tokens per second
-4. Each request costs 1 token
-5. If bucket has tokens, request is allowed and 1 token is consumed
-6. If bucket is empty, request is rejected with 429 status
+- **Per operation type**: separate buckets for `query`, `mutation`, and `subscription`.
+- **Per estimated complexity**: queries are bucketed into `low` / `medium` / `high` tiers
+  (based on nesting depth and field count), each with its own limit.
 
-### Example
+A request must pass both the operation-type limit and the complexity limit. These limits
+are keyed on the authenticated user when available, otherwise on the client IP.
 
-With `rps_per_ip=100` and `burst_size=500`:
+## Strategies
 
-```text
-<!-- Code example in TEXT -->
-Initial: [████████████████████] 500 tokens
-After 1 request: [███████████████████] 499 tokens
-After 100 requests: [████] 400 tokens
-1 second later: [██████] 500 tokens (refilled)
-```text
-<!-- Code example in TEXT -->
+`RateLimitStrategy` controls how requests are counted:
+
+1. **Fixed window** (`FIXED_WINDOW`): a counter resets at the start of each window.
+2. **Sliding window** (`SLIDING_WINDOW`): smooths counting across the window boundary.
+3. **Token bucket** (`TOKEN_BUCKET`): each key gets a bucket of up to `burst` tokens that
+   refills over the window; each request consumes one token. This allows short bursts while
+   bounding the long-run rate.
+
+Set the application-wide strategy with `rate_limit_window_type`, or per rule via the
+`strategy` argument to `RateLimit`.
 
 ## Disabling Rate Limiting
 
-To disable rate limiting (not recommended for production):
+To disable rate limiting (not recommended for production), set the flag in config:
 
-```toml
-<!-- Code example in TOML -->
-[rate_limit]
-enabled = false
-```text
-<!-- Code example in TEXT -->
+```python
+config = FraiseQLConfig(
+    database_url="postgresql://localhost/mydb",
+    rate_limit_enabled=False,
+)
+```
 
-Rate limiting can also be disabled at runtime by setting `enabled=false` in the configuration before server startup.
+Or via environment variable:
+
+```bash
+FRAISEQL_RATE_LIMIT_ENABLED=false
+```
 
 ## Monitoring
 
-Monitor rate limiting activity through logging:
+Rate limit violations are recorded through FraiseQL's security logger (see
+`fraiseql.audit.get_security_logger`). Each violation logs the client IP, endpoint, the
+limit and window, and — when known — the user ID and operation metadata.
 
-```rust
-<!-- Code example in RUST -->
-// Debug level logs IP limit violations
-debug!(ip = "192.168.1.100", "Rate limit exceeded for IP");
+Configure visibility through Python's standard `logging`:
 
-// Warn level logs user limit violations
-warn!(user_id = "user123", "Rate limit exceeded for user");
-```text
-<!-- Code example in TEXT -->
+```python
+import logging
 
-Enable debug logging to see rate limit activity:
+logging.getLogger("fraiseql.security").setLevel(logging.DEBUG)
+```
 
-```bash
-<!-- Code example in BASH -->
-RUST_LOG=fraiseql_server::middleware::rate_limit=debug
-```text
-<!-- Code example in TEXT -->
+Pipe these logs into your aggregation stack (ELK, Splunk, etc.) and alert on spikes in
+`429` responses to catch abuse or misconfigured clients.
 
 ## Security Considerations
 
-1. **DoS Protection**: Rate limiting helps prevent DoS attacks but should be combined with other protections (firewall rules, WAF)
+1. **DoS Protection**: Rate limiting helps prevent DoS attacks but should be combined with
+   other protections (firewall rules, WAF).
 
-2. **Proxy Spoofing**: Always allowlist specific trusted proxies. Never trust `X-Forwarded-For` from untrusted sources
+2. **Proxy Spoofing**: `X-Forwarded-For` / `X-Real-IP` are client-controlled. Only trust
+   them behind a proxy you control that overwrites them; otherwise strip them at the proxy.
 
-3. **Distributed Attacks**: Rate limiting is per-server instance. Use shared backend (Redis) for distributed rate limiting in multi-server deployments
+3. **Distributed Attacks**: the in-memory store is per app instance. Use a Redis-backed
+   store (`RedisRateLimitStore`) for shared limits across multiple instances.
 
-4. **User ID Extraction**: Ensure user authentication is correct and user IDs cannot be forged
+4. **User ID Extraction**: ensure authentication is correct and `request.state.user_id`
+   cannot be forged before relying on per-user limits.
 
-5. **Clock Skew**: Uses system time for token refill. Significant clock skew can affect accuracy
+5. **Clock Skew**: counting uses system time. Significant clock skew between instances can
+   affect accuracy when sharing state.
 
 ## Testing Rate Limiting
 
-Test the implementation:
+Test the implementation against the default per-minute limit:
 
 ```bash
-<!-- Code example in BASH -->
-# Test IP-based limiting
-for i in {1..110}; do
-    curl -s http://localhost:4000/graphql -d '{"query":"{ users { id } }"}' \
-         -H "Content-Type: application/json"
+# Send more requests than the per-minute limit allows
+for i in $(seq 1 110); do
+    curl -s http://localhost:8000/graphql \
+         -H "Content-Type: application/json" \
+         -d '{"query":"{ users { id } }"}'
     echo "Request $i"
 done
-```text
-<!-- Code example in TEXT -->
+```
 
-The 101st+ requests should return HTTP 429 (Too Many Requests).
+Once the configured limit is exceeded, further requests return HTTP `429` (Too Many
+Requests).
 
 ## References
 

--- a/docs/configuration/tls-configuration.md
+++ b/docs/configuration/tls-configuration.md
@@ -1,4 +1,3 @@
-<!-- Skip to main content -->
 ---
 
 title: TLS/SSL Configuration Guide
@@ -8,6 +7,25 @@ tags: ["documentation", "reference"]
 ---
 
 # TLS/SSL Configuration Guide
+
+FraiseQL v1 is a Python runtime GraphQL framework that runs as a **FastAPI/ASGI
+application** in front of **PostgreSQL**. It does not ship its own HTTPS server,
+and there is no `[tls]` configuration block to set. Instead, TLS is handled at
+two distinct, independent surfaces:
+
+1. **App ↔ client TLS (inbound HTTPS).** Your FraiseQL app is served by an ASGI
+   server such as `uvicorn` or `gunicorn`. In production, inbound TLS is normally
+   terminated by a **reverse proxy** (nginx, Caddy, Traefik, or a cloud load
+   balancer) in front of the app. For local/simple deployments, `uvicorn` can
+   terminate TLS directly via `--ssl-certfile` / `--ssl-keyfile`.
+
+2. **App ↔ PostgreSQL TLS.** The application's connection to PostgreSQL is
+   encrypted through the `database_url` connection string (or
+   `FRAISEQL_DATABASE_URL`) using libpq/psycopg `sslmode` parameters such as
+   `?sslmode=verify-full&sslrootcert=...`. No FraiseQL code is involved — the
+   PostgreSQL driver negotiates TLS.
+
+This guide covers both surfaces, plus certificate management that applies to either.
 
 ## Prerequisites
 
@@ -22,7 +40,9 @@ tags: ["documentation", "reference"]
 
 **Required Software:**
 
-- FraiseQL v2.0.0-alpha.1 or later
+- A FraiseQL v1 application (FastAPI app built with `create_fraiseql_app`)
+- An ASGI server: `uvicorn` (or `gunicorn` with `uvicorn` workers)
+- A reverse proxy for production TLS termination (nginx, Caddy, Traefik) — optional for local
 - OpenSSL 1.1.1+ (for certificate generation and verification)
 - curl or OpenSSL CLI (for testing HTTPS endpoints)
 - A code editor for configuration files
@@ -30,223 +50,281 @@ tags: ["documentation", "reference"]
 
 **Required Infrastructure:**
 
-- FraiseQL server instance (local or deployed)
-- TLS certificate and private key (self-signed or from CA)
-- Ports 8443 (HTTPS) and optionally 8444 (mTLS client cert)
-- Database with TLS support (PostgreSQL 10+, MySQL 5.7+, etc.)
+- A running FraiseQL app instance (local or deployed)
+- TLS certificate and private key (self-signed or from a CA) for inbound HTTPS
+- PostgreSQL 12+ with TLS (SSL) enabled, for encrypted database connections
 
 **Optional but Recommended:**
 
-- Certificate Authority (CA) certificate for client validation
+- Certificate Authority (CA) certificate for client validation (mTLS)
 - Let's Encrypt or other automated certificate provisioning
 - HSM (Hardware Security Module) for key storage
 - Certificate management tools (cert-manager for Kubernetes)
-- Nginx or Envoy reverse proxy with SSL termination
+- nginx, Caddy, or Traefik reverse proxy with SSL termination
 
 **Time Estimate:** 30-60 minutes for basic setup, 2-3 hours for mTLS in production
 
 ## Overview
 
-FraiseQL v2 Phase 10.10 implements comprehensive TLS encryption for:
+There are two TLS surfaces to secure, and FraiseQL configures neither with a
+custom config block:
 
-1. **HTTP/gRPC Endpoints** - HTTPS and encrypted gRPC (Arrow Flight)
-2. **Mutual TLS (mTLS)** - Optional client certificate requirements
-3. **Database Connections** - TLS for PostgreSQL, Redis, ClickHouse, Elasticsearch
-4. **At-Rest Encryption** - Configuration hooks for database-native encryption
+1. **Inbound HTTPS (app ↔ client)** — terminated by a reverse proxy or by
+   `uvicorn`'s built-in SSL flags. Optionally enforce **mutual TLS (mTLS)** at the
+   proxy by requiring client certificates.
+2. **PostgreSQL connection TLS (app ↔ database)** — driven entirely by the
+   `sslmode` / `sslrootcert` parameters in your `database_url`.
+
+The sections below show real options for each.
 
 ## Quick Start: Production Setup
 
-### 1. Generate TLS Certificate and Key
+### 1. Generate a TLS Certificate and Key (inbound HTTPS)
 
-Using OpenSSL:
+For production, prefer a certificate from a trusted CA (e.g. Let's Encrypt). For
+local testing, you can self-sign with OpenSSL:
 
 ```bash
-<!-- Code example in BASH -->
 # Generate private key
-openssl genrsa -out /etc/FraiseQL/key.pem 2048
+openssl genrsa -out /etc/fraiseql/key.pem 2048
 
 # Generate self-signed certificate (or use your CA)
-openssl req -new -x509 -key /etc/FraiseQL/key.pem -out /etc/FraiseQL/cert.pem \
-  -subj "/CN=FraiseQL.example.com/O=YourOrg/C=US"
+openssl req -new -x509 -key /etc/fraiseql/key.pem -out /etc/fraiseql/cert.pem \
+  -subj "/CN=api.example.com/O=YourOrg/C=US"
 
 # Set proper permissions
-chmod 600 /etc/FraiseQL/key.pem
-chmod 644 /etc/FraiseQL/cert.pem
-```text
-<!-- Code example in TEXT -->
+chmod 600 /etc/fraiseql/key.pem
+chmod 644 /etc/fraiseql/cert.pem
+```
 
-### 2. Configure FraiseQL.toml
+### 2. Terminate TLS in front of the FraiseQL app
 
-```toml
-<!-- Code example in TOML -->
-[server]
-bind_address = "0.0.0.0:8443"  # HTTPS port
-database_url = "postgresql://user:pass@db.example.com/FraiseQL"
+You have two common choices. Pick one.
 
-# TLS for HTTP/gRPC endpoints
-[tls]
-enabled = true
-cert_path = "/etc/FraiseQL/cert.pem"
-key_path = "/etc/FraiseQL/key.pem"
-require_client_cert = false           # Set to true for mTLS
-min_version = "1.2"                   # "1.2" or "1.3" (recommend 1.3)
-
-# TLS for database connections
-[database_tls]
-postgres_ssl_mode = "require"         # disable, allow, prefer, require, verify-ca, verify-full
-redis_ssl = true                      # Use rediss:// protocol
-clickhouse_https = true               # Use HTTPS
-elasticsearch_https = true            # Use HTTPS
-verify_certificates = true            # Verify server certificates
-ca_bundle_path = "/etc/ssl/certs/ca-bundle.crt"  # Optional: CA bundle for verification
-```text
-<!-- Code example in TEXT -->
-
-### 3. Start Server with TLS
+**Option A — Reverse proxy terminates TLS (recommended for production).** Run the
+FraiseQL app on plain HTTP behind nginx/Caddy/Traefik or a cloud load balancer,
+which holds the certificate and terminates TLS:
 
 ```bash
-<!-- Code example in BASH -->
-FRAISEQL_TLS_ENABLED=true \
-  FRAISEQL_TLS_CERT_PATH=/etc/FraiseQL/cert.pem \
-  FRAISEQL_TLS_KEY_PATH=/etc/FraiseQL/key.pem \
-  FraiseQL-server --config FraiseQL.toml
+# Run the FraiseQL FastAPI app on localhost (HTTP); the proxy faces the internet
+uvicorn app:app --host 127.0.0.1 --port 8000
+```
+
+Example nginx server block doing TLS termination and proxying to the app:
+
 ```text
-<!-- Code example in TEXT -->
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name api.example.com;
+
+    ssl_certificate     /etc/fraiseql/cert.pem;
+    ssl_certificate_key /etc/fraiseql/key.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8000;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+**Option B — uvicorn terminates TLS directly (simple deployments).** Pass the
+certificate and key to `uvicorn`; no proxy required:
+
+```bash
+uvicorn app:app \
+  --host 0.0.0.0 --port 8443 \
+  --ssl-certfile /etc/fraiseql/cert.pem \
+  --ssl-keyfile /etc/fraiseql/key.pem
+```
+
+`gunicorn` with `uvicorn` workers accepts the equivalent `--certfile` /
+`--keyfile` options if you run that stack.
+
+### 3. Encrypt the PostgreSQL connection (app ↔ database)
+
+Add the `sslmode` parameter to the `database_url` you pass to
+`create_fraiseql_app(...)` (or set `FRAISEQL_DATABASE_URL`). libpq/psycopg
+negotiates TLS — there is nothing to configure inside FraiseQL:
+
+```python
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+
+app = create_fraiseql_app(
+    database_url=(
+        "postgresql://user:pass@db.example.com/mydb"
+        "?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.pem"
+    ),
+    types=[User],
+    queries=[users, user],
+    mutations=[create_user],
+    production=True,
+)
+```
+
+Or via environment variable (read by `FraiseQLConfig`):
+
+```bash
+export FRAISEQL_DATABASE_URL="postgresql://user:pass@db.example.com/mydb?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.pem"
+uvicorn app:app --host 127.0.0.1 --port 8000
+```
 
 ## Configuration Options
 
-### Server TLS Configuration (`[tls]`)
+### Inbound HTTPS (app ↔ client)
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable TLS for HTTP/gRPC endpoints |
-| `cert_path` | path | Required if enabled | Path to PEM certificate file |
-| `key_path` | path | Required if enabled | Path to PEM private key file |
-| `require_client_cert` | bool | `false` | Require client certificates (mTLS) |
-| `client_ca_path` | path | Optional | CA certificate for validating client certs (required if `require_client_cert = true`) |
-| `min_version` | string | `"1.2"` | Minimum TLS version: `"1.2"` or `"1.3"` |
+FraiseQL has **no built-in HTTPS server config** — these options belong to your
+ASGI server or reverse proxy, not to FraiseQL.
 
-### Database TLS Configuration (`[database_tls]`)
+| Where | Option | Description |
+|-------|--------|-------------|
+| uvicorn | `--ssl-certfile` | Path to the PEM certificate file |
+| uvicorn | `--ssl-keyfile` | Path to the PEM private key file |
+| uvicorn | `--ssl-keyfile-password` | Password for an encrypted key file (if any) |
+| gunicorn | `--certfile` / `--keyfile` | Equivalent options for the gunicorn server |
+| nginx | `ssl_certificate` / `ssl_certificate_key` | Certificate and key at the proxy |
+| nginx | `ssl_protocols` | Minimum/allowed TLS versions, e.g. `TLSv1.2 TLSv1.3` |
+| nginx | `ssl_client_certificate` + `ssl_verify_client on` | Require client certs (mTLS) |
+| Caddy | automatic HTTPS | Caddy provisions and renews certs automatically |
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `postgres_ssl_mode` | string | `"prefer"` | PostgreSQL SSL mode: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full` |
-| `redis_ssl` | bool | `false` | Enable TLS for Redis (uses `rediss://` protocol) |
-| `clickhouse_https` | bool | `false` | Enable HTTPS for ClickHouse |
-| `elasticsearch_https` | bool | `false` | Enable HTTPS for Elasticsearch |
-| `verify_certificates` | bool | `true` | Verify server certificates |
-| `ca_bundle_path` | path | Optional | Path to CA certificate bundle for verification |
+When TLS is terminated by a proxy, run the app with `--proxy-headers` (and an
+appropriate `--forwarded-allow-ips`) so it trusts `X-Forwarded-Proto` and serves
+correct absolute URLs.
+
+### PostgreSQL connection TLS (app ↔ database)
+
+Set these in the `database_url` query string; libpq/psycopg consumes them.
+
+| Parameter | Description |
+|-----------|-------------|
+| `sslmode` | `disable`, `allow`, `prefer`, `require`, `verify-ca`, or `verify-full` |
+| `sslrootcert` | Path to the CA certificate used to verify the server (for `verify-ca`/`verify-full`) |
+| `sslcert` | Client certificate path (for PostgreSQL client-certificate auth) |
+| `sslkey` | Client private key path (for PostgreSQL client-certificate auth) |
 
 ## Configuration Examples
 
 ### Example 1: Development (Permissive)
 
-```toml
-<!-- Code example in TOML -->
-# Development: TLS optional, minimal validation
-[tls]
-enabled = false
+Plain HTTP locally, TLS preferred but not required for the database:
 
-[database_tls]
-postgres_ssl_mode = "prefer"
-redis_ssl = false
-clickhouse_https = false
-elasticsearch_https = false
-verify_certificates = false
-```text
-<!-- Code example in TEXT -->
+```bash
+# No inbound TLS; uvicorn serves HTTP for local development
+uvicorn app:app --reload --host 127.0.0.1 --port 8000
+```
+
+```python
+app = create_fraiseql_app(
+    database_url="postgresql://user:pass@localhost:5432/mydb?sslmode=prefer",
+    types=[User],
+    queries=[users],
+    production=False,  # enables the GraphQL playground
+)
+```
 
 ### Example 2: Staging (Standard)
 
-```toml
-<!-- Code example in TOML -->
-# Staging: TLS required, standard validation
-[tls]
-enabled = true
-cert_path = "/etc/FraiseQL/cert.pem"
-key_path = "/etc/FraiseQL/key.pem"
-require_client_cert = false
-min_version = "1.2"
+Reverse proxy terminates HTTPS; database connection requires TLS:
 
-[database_tls]
-postgres_ssl_mode = "require"
-redis_ssl = true
-clickhouse_https = true
-elasticsearch_https = true
-verify_certificates = true
-ca_bundle_path = "/etc/ssl/certs/ca-bundle.crt"
 ```text
-<!-- Code example in TEXT -->
+# nginx (staging) — TLS termination, proxy to the FraiseQL app
+server {
+    listen 443 ssl;
+    server_name staging.example.com;
+    ssl_certificate     /etc/fraiseql/cert.pem;
+    ssl_certificate_key /etc/fraiseql/key.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    location / { proxy_pass http://127.0.0.1:8000; }
+}
+```
 
-### Example 3: Production (Strict mTLS)
+```python
+app = create_fraiseql_app(
+    database_url="postgresql://user:pass@db.internal:5432/mydb?sslmode=require",
+    types=[User],
+    queries=[users],
+    production=True,
+)
+```
 
-```toml
-<!-- Code example in TOML -->
-# Production: TLS required with mTLS, strict validation
-[tls]
-enabled = true
-cert_path = "/etc/FraiseQL/cert.pem"
-key_path = "/etc/FraiseQL/key.pem"
-require_client_cert = true
-client_ca_path = "/etc/FraiseQL/client-ca.pem"
-min_version = "1.3"  # TLS 1.3 only
+### Example 3: Production (Strict, with mTLS at the proxy)
 
-[database_tls]
-postgres_ssl_mode = "verify-full"
-redis_ssl = true
-clickhouse_https = true
-elasticsearch_https = true
-verify_certificates = true
-ca_bundle_path = "/etc/ssl/certs/ca-bundle.crt"
+TLS 1.3 only at the proxy, client certificates required (mTLS enforced by nginx),
+and `verify-full` for the database:
+
 ```text
-<!-- Code example in TEXT -->
+# nginx (production) — TLS 1.3 + mutual TLS (client certificates required)
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name api.example.com;
+
+    ssl_certificate     /etc/fraiseql/server-cert.pem;
+    ssl_certificate_key /etc/fraiseql/server-key.pem;
+    ssl_protocols       TLSv1.3;
+
+    # Mutual TLS: require and verify client certificates
+    ssl_client_certificate /etc/fraiseql/client-ca.pem;
+    ssl_verify_client      on;
+
+    location / {
+        proxy_pass        http://127.0.0.1:8000;
+        proxy_set_header  X-Forwarded-Proto $scheme;
+        proxy_set_header  X-SSL-Client-Verify $ssl_client_verify;
+    }
+}
+```
+
+```python
+app = create_fraiseql_app(
+    database_url=(
+        "postgresql://user:pass@db.internal:5432/mydb"
+        "?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca-bundle.crt"
+    ),
+    types=[User],
+    queries=[users],
+    mutations=[create_user],
+    production=True,
+)
+```
 
 ## TLS Enforcement Levels
 
-FraiseQL uses three TLS enforcement profiles:
+There is no FraiseQL enforcement API — you choose a posture at the proxy/ASGI
+server and the database connection string. Three common profiles:
 
 ### 1. Permissive (Development)
 
-```rust
-<!-- Code example in RUST -->
-TlsEnforcer::permissive()
-// - TLS optional for HTTP connections
-// - Client certificates optional
-// - TLS 1.2 minimum (if used)
-```text
-<!-- Code example in TEXT -->
+- Inbound TLS optional (plain HTTP via `uvicorn` locally)
+- Client certificates not required
+- Database `sslmode=prefer`
 
-**Usage**: Local development, testing
+**Usage**: Local development, testing.
 
 ### 2. Standard (Production)
 
-```rust
-<!-- Code example in RUST -->
-TlsEnforcer::standard()
-// - TLS required (HTTPS only)
-// - Client certificates optional
-// - TLS 1.2 minimum
-```text
-<!-- Code example in TEXT -->
+- Inbound TLS required (HTTPS only), terminated by the reverse proxy with
+  `ssl_protocols TLSv1.2 TLSv1.3`
+- Client certificates optional
+- Database `sslmode=require`
 
-**Usage**: Default production setup
+**Usage**: Default production setup.
 
 ### 3. Strict (Regulated Environments)
 
-```rust
-<!-- Code example in RUST -->
-TlsEnforcer::strict()
-// - TLS required (HTTPS only)
-// - Client certificates required (mTLS)
-// - TLS 1.3 minimum
-```text
-<!-- Code example in TEXT -->
+- Inbound TLS required, TLS 1.3 only (`ssl_protocols TLSv1.3`)
+- Mutual TLS required (`ssl_verify_client on` at the proxy)
+- Database `sslmode=verify-full`
 
-**Usage**: PCI-DSS, HIPAA, SOC 2 compliance
+**Usage**: PCI-DSS, HIPAA, SOC 2 compliance.
 
 ## PostgreSQL SSL Modes
 
-FraiseQL supports all PostgreSQL SSL modes:
+PostgreSQL connections (via libpq/psycopg) support all standard SSL modes:
 
 | Mode | Security | Behavior |
 |------|----------|----------|
@@ -257,144 +335,47 @@ FraiseQL supports all PostgreSQL SSL modes:
 | `verify-ca` | ✅ Better | SSL + verify CA certificate |
 | `verify-full` | ✅ Best | SSL + verify CA and hostname |
 
-**Recommendation for production**: Use `require` or `verify-full`
+**Recommendation for production**: Use `require`, or `verify-full` when you can
+provide a CA certificate.
 
 ## Database URLs with TLS
 
-### PostgreSQL
+The `database_url` (passed to `create_fraiseql_app` or set as
+`FRAISEQL_DATABASE_URL`) carries all PostgreSQL TLS settings:
 
 ```text
-<!-- Code example in TEXT -->
 # Without TLS
-postgresql://user:pass@localhost:5432/FraiseQL
+postgresql://user:pass@localhost:5432/mydb
 
 # With TLS (require mode)
-postgresql://user:pass@localhost:5432/FraiseQL?sslmode=require
+postgresql://user:pass@localhost:5432/mydb?sslmode=require
 
-# With TLS (verify-full mode)
-postgresql://user:pass@localhost:5432/FraiseQL?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.pem
-```text
-<!-- Code example in TEXT -->
+# With TLS (verify-full mode, verifying the server certificate against a CA)
+postgresql://user:pass@localhost:5432/mydb?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.pem
 
-### Redis
-
-```text
-<!-- Code example in TEXT -->
-# Without TLS
-redis://localhost:6379
-
-# With TLS (automatic with rediss:// protocol)
-rediss://localhost:6379
-rediss://:password@localhost:6379
-```text
-<!-- Code example in TEXT -->
-
-### ClickHouse
-
-```text
-<!-- Code example in TEXT -->
-# Without TLS
-http://localhost:8123
-
-# With TLS (HTTPS)
-https://localhost:8123
-```text
-<!-- Code example in TEXT -->
-
-### Elasticsearch
-
-```text
-<!-- Code example in TEXT -->
-# Without TLS
-http://localhost:9200
-
-# With TLS (HTTPS)
-https://localhost:9200
-```text
-<!-- Code example in TEXT -->
-
-## At-Rest Encryption Configuration
-
-### ClickHouse
-
-To enable encryption at rest in ClickHouse:
-
-```sql
-<!-- Code example in SQL -->
-CREATE TABLE fraiseql_events (
-    event_id UUID,
-    org_id UUID,
-    timestamp DateTime,
-    data String,
-    ...
-) ENGINE = MergeTree()
-PARTITION BY org_id
-ORDER BY (org_id, timestamp)
-WITH SETTINGS
-    storage_disk_name = 'encrypted';
-```text
-<!-- Code example in TEXT -->
-
-**Note**: Requires ClickHouse 21.10+ and disk encryption configured
-
-### Elasticsearch
-
-To enable encryption at rest with ILM policy:
-
-```json
-<!-- Code example in JSON -->
-{
-  "policy": "FraiseQL-policy",
-  "phases": {
-    "hot": {
-      "min_age": "0d",
-      "actions": {
-        "rollover": { "max_size": "50gb" },
-        "set_priority": { "priority": 100 }
-      }
-    },
-    "warm": {
-      "min_age": "7d",
-      "actions": {
-        "set_priority": { "priority": 50 },
-        "forcemerge": { "max_num_segments": 1 }
-      }
-    },
-    "cold": {
-      "min_age": "30d",
-      "actions": {
-        "set_priority": { "priority": 0 },
-        "searchable_snapshot": { "snapshot_repository": "found-snapshots" }
-      }
-    }
-  }
-}
-```text
-<!-- Code example in TEXT -->
-
-**Note**: Requires Elasticsearch 7.9+ and subscription-level features
+# With PostgreSQL client-certificate authentication
+postgresql://user@localhost:5432/mydb?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.pem&sslcert=/etc/ssl/certs/client.pem&sslkey=/etc/ssl/private/client.key
+```
 
 ## Client Certificate Generation (mTLS)
 
-If you're using mTLS (`require_client_cert = true`):
+If you require client certificates for inbound HTTPS (enforced at the reverse
+proxy with `ssl_verify_client on`), generate a CA and per-client certificates:
 
 ### 1. Generate CA Key and Certificate
 
 ```bash
-<!-- Code example in BASH -->
 # CA private key
 openssl genrsa -out ca-key.pem 4096
 
 # CA certificate
 openssl req -new -x509 -days 3650 -key ca-key.pem -out ca-cert.pem \
-  -subj "/CN=FraiseQL-ca/O=YourOrg/C=US"
-```text
-<!-- Code example in TEXT -->
+  -subj "/CN=fraiseql-ca/O=YourOrg/C=US"
+```
 
 ### 2. Generate Client Certificate
 
 ```bash
-<!-- Code example in BASH -->
 # Client key
 openssl genrsa -out client-key.pem 2048
 
@@ -406,48 +387,62 @@ openssl req -new -key client-key.pem -out client.csr \
 openssl x509 -req -days 365 -in client.csr \
   -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial \
   -out client-cert.pem
-```text
-<!-- Code example in TEXT -->
+```
 
-### 3. Configure in FraiseQL.toml
+### 3. Point the proxy at the client CA
 
-```toml
-<!-- Code example in TOML -->
-[tls]
-enabled = true
-cert_path = "/etc/FraiseQL/server-cert.pem"
-key_path = "/etc/FraiseQL/server-key.pem"
-require_client_cert = true
-client_ca_path = "/etc/FraiseQL/ca-cert.pem"
-min_version = "1.3"
+Configure the reverse proxy to require and verify client certificates against the
+CA you created. For nginx:
+
 ```text
-<!-- Code example in TEXT -->
+server {
+    listen 443 ssl;
+    server_name api.example.com;
+
+    ssl_certificate        /etc/fraiseql/server-cert.pem;
+    ssl_certificate_key    /etc/fraiseql/server-key.pem;
+    ssl_protocols          TLSv1.3;
+
+    ssl_client_certificate /etc/fraiseql/ca-cert.pem;
+    ssl_verify_client      on;
+
+    location / { proxy_pass http://127.0.0.1:8000; }
+}
+```
 
 ## Docker Compose Example
 
-```yaml
-<!-- Code example in YAML -->
-version: '3.8'
+The app container runs the FraiseQL FastAPI app under `uvicorn`; an nginx
+container in front of it terminates inbound TLS, and PostgreSQL is configured for
+SSL so the app's `database_url` can use `sslmode=verify-full`:
 
+```yaml
 services:
-  FraiseQL:
-    build: .
+  proxy:
+    image: nginx:1.27
     ports:
-      - "8443:8443"  # HTTPS
-    environment:
-      DATABASE_URL: postgresql://user:pass@postgres:5432/FraiseQL
-      FRAISEQL_TLS_ENABLED: "true"
-      FRAISEQL_TLS_CERT_PATH: /etc/FraiseQL/cert.pem
-      FRAISEQL_TLS_KEY_PATH: /etc/FraiseQL/key.pem
+      - "443:443"
     volumes:
-      - ./certs:/etc/FraiseQL:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./certs:/etc/fraiseql:ro
+    depends_on:
+      - app
+
+  app:
+    build: .
+    # Run the FraiseQL FastAPI app on plain HTTP behind the proxy
+    command: uvicorn app:app --host 0.0.0.0 --port 8000 --proxy-headers
+    environment:
+      FRAISEQL_DATABASE_URL: postgresql://user:pass@postgres:5432/mydb?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.pem
+    volumes:
+      - ./certs/ca.pem:/etc/ssl/certs/ca.pem:ro
     depends_on:
       - postgres
 
   postgres:
     image: postgres:16
     environment:
-      POSTGRES_DB: FraiseQL
+      POSTGRES_DB: mydb
       POSTGRES_PASSWORD: password
     command: >
       -c ssl=on
@@ -456,182 +451,189 @@ services:
     volumes:
       - ./certs/postgres-cert.pem:/var/lib/postgresql/server.crt:ro
       - ./certs/postgres-key.pem:/var/lib/postgresql/server.key:ro
-
-  redis:
-    image: redis:7
-    command: redis-server --tls-port 6379 --port 0 --tls-cert-file /etc/redis/cert.pem --tls-key-file /etc/redis/key.pem
-    volumes:
-      - ./certs/redis-cert.pem:/etc/redis/cert.pem:ro
-      - ./certs/redis-key.pem:/etc/redis/key.pem:ro
-```text
-<!-- Code example in TEXT -->
+```
 
 ## Kubernetes TLS Configuration
 
-### Secret Setup
+In Kubernetes, inbound TLS is typically handled by an Ingress (with
+`cert-manager` provisioning certificates) rather than by the app pod. The app
+pod just runs `uvicorn` on plain HTTP and connects to PostgreSQL with
+`sslmode=verify-full`.
+
+### Secret Setup (certificate used by the Ingress)
 
 ```bash
-<!-- Code example in BASH -->
-# Create TLS secret
-kubectl create secret tls FraiseQL-tls \
+# Create TLS secret for the Ingress
+kubectl create secret tls fraiseql-tls \
   --cert=./certs/cert.pem \
   --key=./certs/key.pem
-```text
-<!-- Code example in TEXT -->
+```
 
-### Deployment Configuration
+### Ingress (inbound HTTPS termination)
 
 ```yaml
-<!-- Code example in YAML -->
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fraiseql
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  tls:
+    - hosts:
+        - api.example.com
+      secretName: fraiseql-tls
+  rules:
+    - host: api.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fraiseql
+                port:
+                  number: 8000
+```
+
+### Deployment (app on plain HTTP; DB TLS via the connection string)
+
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: FraiseQL-server
+  name: fraiseql
 spec:
   template:
     spec:
       containers:
-      - name: FraiseQL
-        image: FraiseQL:latest
-        env:
-        - name: FRAISEQL_TLS_ENABLED
-          value: "true"
-        - name: FRAISEQL_TLS_CERT_PATH
-          value: /etc/FraiseQL/tls/cert.pem
-        - name: FRAISEQL_TLS_KEY_PATH
-          value: /etc/FraiseQL/tls/key.pem
-        volumeMounts:
-        - name: tls-certs
-          mountPath: /etc/FraiseQL/tls
-          readOnly: true
-      volumes:
-      - name: tls-certs
-        secret:
-          secretName: FraiseQL-tls
-```text
-<!-- Code example in TEXT -->
+        - name: fraiseql
+          image: fraiseql-app:latest
+          command:
+            - uvicorn
+            - app:app
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8000"
+            - --proxy-headers
+          env:
+            - name: FRAISEQL_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: fraiseql-db
+                  key: database_url   # includes ?sslmode=verify-full&sslrootcert=...
+```
 
 ## Verification and Testing
 
-### 1. Test HTTPS Connection
+### 1. Test the HTTPS Connection (inbound)
 
 ```bash
-<!-- Code example in BASH -->
 # With curl (ignore self-signed cert warnings)
-curl -k https://localhost:8443/health
+curl -k https://api.example.com/graphql
 
 # With proper CA cert
-curl --cacert /etc/ssl/certs/ca-cert.pem https://localhost:8443/health
+curl --cacert /etc/ssl/certs/ca-cert.pem https://api.example.com/graphql
 
-# With client certificate (mTLS)
+# With a client certificate (mTLS enforced at the proxy)
 curl \
   --cacert /etc/ssl/certs/ca-cert.pem \
-  --cert /etc/FraiseQL/client-cert.pem \
-  --key /etc/FraiseQL/client-key.pem \
-  https://localhost:8443/health
-```text
-<!-- Code example in TEXT -->
+  --cert /etc/fraiseql/client-cert.pem \
+  --key /etc/fraiseql/client-key.pem \
+  https://api.example.com/graphql
+```
 
-### 2. Test TLS Version
-
-```bash
-<!-- Code example in BASH -->
-# Check TLS version
-openssl s_client -connect localhost:8443 -tls1_2 < /dev/null
-
-# Verify minimum version enforcement
-openssl s_client -connect localhost:8443 -tls1_1 < /dev/null  # Should fail
-```text
-<!-- Code example in TEXT -->
-
-### 3. Test Database Connections
+### 2. Test the TLS Version
 
 ```bash
-<!-- Code example in BASH -->
-# PostgreSQL
-psql "postgresql://user@localhost/FraiseQL?sslmode=require"
+# Check that TLS 1.2 is accepted
+openssl s_client -connect api.example.com:443 -tls1_2 < /dev/null
 
-# Redis
-redis-cli --tls --cacert /etc/ssl/certs/ca-cert.pem ping
+# Verify older versions are rejected (should fail when ssl_protocols excludes them)
+openssl s_client -connect api.example.com:443 -tls1_1 < /dev/null  # Should fail
+```
 
-# ClickHouse
-curl --cacert /etc/ssl/certs/ca-cert.pem https://localhost:8123/ping
+### 3. Test the PostgreSQL Connection (app ↔ database)
 
-# Elasticsearch
-curl --cacert /etc/ssl/certs/ca-cert.pem https://localhost:9200/_cluster/health
-```text
-<!-- Code example in TEXT -->
+```bash
+# Verify the encrypted PostgreSQL connection independently of the app
+psql "postgresql://user@db.example.com/mydb?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.pem"
+```
+
+Inside `psql`, confirm the session is encrypted:
+
+```sql
+SELECT ssl, version, cipher FROM pg_stat_ssl WHERE pid = pg_backend_pid();
+```
 
 ## Security Best Practices
 
-1. **Use TLS 1.3** when possible (`min_version = "1.3"`)
-2. **Verify certificates** for all database connections
-3. **Rotate certificates** before expiration (set calendar reminders)
-4. **Use strong private keys** (2048-bit RSA minimum, 4096-bit preferred)
-5. **Protect certificate files** with proper permissions (`chmod 600 key.pem`)
+1. **Use TLS 1.3** when possible (set `ssl_protocols TLSv1.3` at the proxy).
+2. **Verify the database certificate** with `sslmode=verify-full` and a pinned `sslrootcert`.
+3. **Rotate certificates** before expiration (set calendar reminders or automate renewal).
+4. **Use strong private keys** (2048-bit RSA minimum, 4096-bit preferred).
+5. **Protect certificate files** with proper permissions (`chmod 600 key.pem`).
 6. **Use certificate management tools**:
    - Let's Encrypt with Certbot (free automated renewal)
-   - HashiCorp Consul for certificate management
+   - Caddy (automatic HTTPS) or Traefik (built-in ACME)
    - Kubernetes cert-manager (if using K8s)
 7. **Monitor certificate expiration**:
 
    ```bash
-<!-- Code example in BASH -->
-   openssl x509 -enddate -noout -in /etc/FraiseQL/cert.pem
-   ```text
-<!-- Code example in TEXT -->
+   openssl x509 -enddate -noout -in /etc/fraiseql/cert.pem
+   ```
 
-8. **Use different keys per environment** (dev, staging, production)
-9. **Store private keys in secrets management** (HashiCorp Vault, AWS Secrets Manager)
-10. **Enable certificate pinning** for critical database connections
+8. **Use different keys per environment** (dev, staging, production).
+9. **Store private keys in secrets management** (HashiCorp Vault, AWS Secrets Manager, Kubernetes Secrets).
+10. **Keep the app on a private network** and let the proxy/load balancer be the only TLS-terminating, internet-facing component.
 
 ## Troubleshooting
 
-### TLS Certificate Not Found
+### TLS Certificate Not Found (inbound)
 
 ```text
-<!-- Code example in TEXT -->
-error: TLS enabled but certificate file not found: /etc/FraiseQL/cert.pem
-```text
-<!-- Code example in TEXT -->
+error: [Errno 2] No such file or directory: '/etc/fraiseql/cert.pem'
+```
 
-**Solution**: Verify certificate path exists and is readable by the FraiseQL process
+**Solution**: Verify the certificate/key paths passed to `uvicorn`
+(`--ssl-certfile` / `--ssl-keyfile`) or referenced in the proxy config exist and
+are readable by the serving process.
 
-### TLS Version Too Old
-
-```text
-<!-- Code example in TEXT -->
-error: Connection TLS version (1.2) is less than minimum required (1.3)
-```text
-<!-- Code example in TEXT -->
-
-**Solution**: Update client TLS version or lower `min_version` in config
-
-### Client Certificate Required
+### TLS Version Too Old (inbound)
 
 ```text
-<!-- Code example in TEXT -->
-error: Client certificate required, but none provided
+error: no protocols available  (client offered only TLS 1.1)
+```
+
+**Solution**: Update the client's TLS version, or relax `ssl_protocols` at the
+proxy (not recommended for production).
+
+### Client Certificate Required (mTLS)
+
 ```text
-<!-- Code example in TEXT -->
+400 Bad Request — No required SSL certificate was sent
+```
 
-**Solution**: Provide client certificate if using mTLS, or disable with `require_client_cert = false`
+**Solution**: Provide a client certificate when the proxy has
+`ssl_verify_client on`, or set `ssl_verify_client off` to disable mTLS.
 
-### Database Connection SSL Error
+### Database Connection SSL Error (app ↔ database)
 
 ```text
-<!-- Code example in TEXT -->
-error: FATAL: no pg_hba.conf entry for replication connection
-```text
-<!-- Code example in TEXT -->
+error: connection requires a valid client certificate
+error: server does not support SSL, but SSL was required
+```
 
-**Solution**: Ensure database SSL is properly configured and using correct `sslmode`
+**Solution**: Ensure PostgreSQL has SSL enabled and `pg_hba.conf` permits the
+connection, and that your `database_url` uses the correct `sslmode` (and
+`sslrootcert`/`sslcert`/`sslkey` where required).
 
 ## References
 
 - [TLS 1.3 RFC 8446](https://tools.ietf.org/html/rfc8446)
 - [OWASP Transport Layer Protection](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html)
 - [PostgreSQL SSL Support](https://www.postgresql.org/docs/current/ssl-tcp.html)
-- [Redis TLS Support](https://redis.io/topics/encryption)
-- [ClickHouse HTTPS](https://clickhouse.com/docs/en/interfaces/http/)
-- [Elasticsearch TLS Configuration](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-tls.html)
+- [Uvicorn deployment & HTTPS](https://www.uvicorn.org/deployment/)
+- [nginx ngx_http_ssl_module](https://nginx.org/en/docs/http/ngx_http_ssl_module.html)
+- [Let's Encrypt / Certbot](https://certbot.eff.org/)


### PR DESCRIPTION
Phase 2 of the docs v2-contamination cleanup — the **Configuration** nav section (4 files).

Reframes `docs/configuration/` around v1's real config model: `create_fraiseql_app(...)` kwargs > `FraiseQLConfig` (pydantic-settings) > `FRAISEQL_` env / `.env` > defaults. **No** `fraiseql.toml`, **no** compiled-schema layer.

## What changed
- **README.md** — replaced the v2 compiled-schema / `FraiseQL.toml` precedence model with the real pydantic-settings precedence; dropped dead links + the v2.0.0 stamp.
- **postgresql-authentication.md** — reframed as PostgreSQL **connection** auth (psycopg/libpq via `database_url`, `pg_hba.conf`, `scram-sha-256`, `sslmode`); removed `RUST_LOG`/`fraiseql-server`/v2.0.0/`fraiseql.toml`. Also fixed a real bug: `scram-sha256` → `scram-sha-256`.
- **rate-limiting.md** — replaced `fraiseql.toml` + Rust logging with the real `FraiseQLConfig` `rate_limit_*` fields / `FRAISEQL_` env and the `fraiseql.security.rate_limiting` API (`RateLimit`/`RateLimitRule`/`RedisRateLimitStore`/`setup_rate_limiting`); corrected the response-header set.
- **tls-configuration.md** — split into the two real TLS surfaces: inbound HTTPS via **reverse proxy / `uvicorn --ssl-*`**, and app↔PostgreSQL via `database_url` `sslmode`. Removed the Rust `TlsEnforcer` / `fraiseql.toml [tls]` / multi-service (Redis/ClickHouse/Arrow) sections.

## Verification
- ✅ 0 v2 tokens, 0 broken relative links, balanced fences, no stray markup
- ✅ Rate-limit/config fields verified against `src/`
- ✅ `mkdocs build` introduces no new warnings from these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)