### PR TITLE
docs: strip leaked tool-call XML trailers from 9 docs pages

### DIFF
--- a/docs/architecture/database/tv-table-pattern.md
+++ b/docs/architecture/database/tv-table-pattern.md
@@ -530,5 +530,3 @@ See `examples/sql/` for complete DDL examples:
 - [Schema Conventions](../../specs/schema-conventions.md)
 - [Naming Patterns](../../reference/naming-patterns.md)
 - [Database-Centric Architecture](../../foundation/03-database-centric-architecture.md)
-</content>
-</invoke>

--- a/docs/architecture/decisions/0003-kms-architecture.md
+++ b/docs/architecture/decisions/0003-kms-architecture.md
@@ -204,5 +204,4 @@ kms_response_time_seconds
 ---
 
 *Accepted: 2025-11-24*
-*Review: Security and Performance Team*</content>
-</xai:function_call">Create the KMS Architecture ADR
+*Review: Security and Performance Team*

--- a/docs/architecture/reliability/consistency-model.md
+++ b/docs/architecture/reliability/consistency-model.md
@@ -582,5 +582,3 @@ nothing less.
 - [View Selection Guide](../database/view-selection-guide.md)
 - [Performance Characteristics](../../foundation/12-performance-characteristics.md)
 - [Schema Conventions](../../specs/schema-conventions.md)
-</content>
-</invoke>

--- a/docs/core/rust-backend-migration.md
+++ b/docs/core/rust-backend-migration.md
@@ -894,5 +894,4 @@ After successful migration, you should see:
 
 ---
 
-**Migration Complete**: This guide covers the complete transition from psycopg to the exclusive Rust backend in FraiseQL v1.9+.</content>
-<parameter name="filePath">docs/core/rust-backend-migration.md
+**Migration Complete**: This guide covers the complete transition from psycopg to the exclusive Rust backend in FraiseQL v1.9+.

--- a/docs/enterprise/README.md
+++ b/docs/enterprise/README.md
@@ -253,5 +253,3 @@ flag. See the full field list and defaults in
 ---
 
 **Back to:** [Documentation Home](../index.md)
-</content>
-</invoke>

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -549,5 +549,4 @@ After successful installation:
 
 ---
 
-*Installation Guide - Choose your path, verify setup, troubleshoot issues*</content>
-</xai:function_call">Write file to INSTALLATION.md
+*Installation Guide - Choose your path, verify setup, troubleshoot issues*

--- a/docs/guides/migrating-to-cascade.md
+++ b/docs/guides/migrating-to-cascade.md
@@ -911,6 +911,4 @@ FROM graphql.create_post('{"title": "Test", "author_id": "user-123"}');
 
 **Migration Effort**: Low to Medium (2-5 days for typical application)
 **Risk Level**: Low (opt-in feature with easy rollback)
-**Performance Impact**: Minimal (typically < 5% overhead)</content>
-</xai:function_call</xai:function_call name="write">
-<parameter name="filePath">README.md
+**Performance Impact**: Minimal (typically < 5% overhead)

--- a/docs/reference/testing-checklist.md
+++ b/docs/reference/testing-checklist.md
@@ -327,6 +327,4 @@ This checklist ensures FraiseQL documentation meets production quality standards
 
 ---
 
-*This checklist ensures FraiseQL documentation maintains production quality and provides excellent user experience.*</content>
-</xai:function_call name="list">
-<parameter name="path">scripts
+*This checklist ensures FraiseQL documentation maintains production quality and provides excellent user experience.*

--- a/docs/reference/vector-operators.md
+++ b/docs/reference/vector-operators.md
@@ -191,5 +191,4 @@ LIMIT 10;
 ## See Also
 
 - [pgvector GitHub Repository](https://github.com/pgvector/pgvector)
-- [Vector Search Best Practices](https://github.com/pgvector/pgvector#best-practices)</content>
-<parameter name="filePath">docs/reference/vector-operators.md
+- [Vector Search Best Practices](https://github.com/pgvector/pgvector#best-practices)


### PR DESCRIPTION
Follow-up cleanup found during the Phase-2 v1 docs rewrite: several **published** docs pages end with **leaked editor tool-call markup** appended after their real content — both Anthropic-style (`</content>` + `</invoke>`, from earlier rewrite PRs) and older xai-session trailers (`</xai:function_call...>`, `<parameter name=...>`). These render as garbage at the bottom of the live pages.

This strips the trailing tool-call garbage (and the stray `</content>` suffix left on the final content line) from 9 files — none of which were in the Phase-2 REWRITE set, so they were untouched until now:

- `architecture/decisions/0003-kms-architecture.md`
- `enterprise/README.md`
- `architecture/reliability/consistency-model.md`
- `architecture/database/tv-table-pattern.md`
- `guides/migrating-to-cascade.md`
- `getting-started/installation.md`
- `reference/testing-checklist.md`
- `reference/vector-operators.md`
- `core/rust-backend-migration.md`

Content is otherwise unchanged (6 insertions / 20 deletions — purely trailing markup). `archive/` is left as-is (unpublished, excluded from nav).

## Verification
- ✅ 0 leaked tool-call markers remain in non-archive `docs/`
- ✅ All 9 files end on real content; code fences remain balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)