### PR TITLE
docs: fix rust-backend-migration psycopg claims + strip archive XML

### DIFF
--- a/docs/archive/database/ltree-index-optimization.md
+++ b/docs/archive/database/ltree-index-optimization.md
@@ -326,7 +326,4 @@ FraiseQL optimizes LTREE queries automatically:
 6. **Monitor for bloat** and reindex as needed
 7. **Test query performance** before and after index changes
 
-Following these practices ensures optimal performance for hierarchical data operations with PostgreSQL LTREE.</content>
-</xai:function_call:
-<xai:function_call name="todowrite">
-<parameter name="todos">[{"content":"Add GiST indexes for production LTREE performance optimization","status":"completed","priority":"low","id":"index_optimization"}]
+Following these practices ensures optimal performance for hierarchical data operations with PostgreSQL LTREE.

--- a/docs/archive/journeys/architect-cto.md
+++ b/docs/archive/journeys/architect-cto.md
@@ -265,5 +265,4 @@ PostgreSQL Views → Schema Generation → Type-Safe Resolvers → Client
 
 ---
 
-*This evaluation provides the business context needed to make an informed technology decision. The technical team should validate performance claims and migration effort estimates before final commitment.*</content>
-<parameter name="filePath">docs/journeys/architect-cto.md
+*This evaluation provides the business context needed to make an informed technology decision. The technical team should validate performance claims and migration effort estimates before final commitment.*

--- a/docs/archive/journeys/backend-engineer.md
+++ b/docs/archive/journeys/backend-engineer.md
@@ -264,5 +264,4 @@ curl http://localhost:8000/metrics
 
 - Can we allocate 2-3 weeks for migration?
 - Do we have Rust experience on the team?
-- What's our risk tolerance for newer frameworks?</content>
-<parameter name="filePath">docs/journeys/backend-engineer.md
+- What's our risk tolerance for newer frameworks?

--- a/docs/archive/journeys/junior-developer.md
+++ b/docs/archive/journeys/junior-developer.md
@@ -246,5 +246,4 @@ query {
 
 **GraphQL returns null**
 
-- Solution: Check your resolver functions and database queries</content>
-<parameter name="filePath">docs/journeys/junior-developer.md
+- Solution: Check your resolver functions and database queries

--- a/docs/archive/strategic/audiences.md
+++ b/docs/archive/strategic/audiences.md
@@ -312,6 +312,4 @@ open CONTRIBUTING.md
 
 ---
 
-*Audience definitions help users find relevant content quickly and set appropriate expectations for their skill level.*</content>
-</xai:function_call name="read">
-<parameter name="filePath">README.md
+*Audience definitions help users find relevant content quickly and set appropriate expectations for their skill level.*

--- a/docs/archive/strategic/rust-backend-completion.md
+++ b/docs/archive/strategic/rust-backend-completion.md
@@ -371,5 +371,4 @@ A: File issues on GitHub or contact enterprise support for assistance.
 
 **FraiseQL v1.9: The Future of High-Performance GraphQL**
 
-This release marks FraiseQL's transition to a new era of performance and reliability, powered by Rust's systems programming capabilities. The exclusive Rust backend delivers unprecedented speed while maintaining the developer experience that makes GraphQL powerful and accessible.</content>
-<parameter name="filePath">docs/strategic/rust-backend-completion.md
+This release marks FraiseQL's transition to a new era of performance and reliability, powered by Rust's systems programming capabilities. The exclusive Rust backend delivers unprecedented speed while maintaining the developer experience that makes GraphQL powerful and accessible.

--- a/docs/core/rust-backend-migration.md
+++ b/docs/core/rust-backend-migration.md
@@ -1,616 +1,339 @@
 ---
-title: Rust Backend Migration
-description: Migration guide from Python-only to Rust pipeline backend
+title: Rust Transform Pipeline (v1.9+)
+description: Understand the v1.9 Rust JSON-transform architecture and adapt your resolvers to RustResponseBytes
 tags:
   - Rust
-  - migration
   - performance
   - backend
-  - upgrade
+  - architecture
 ---
 
-# Rust Backend Migration Guide
-
-**Last Updated**: December 21, 2025
-**Applies to**: FraiseQL v1.9+ (psycopg removal)
-**Status**: ✅ Migration Complete - Legacy Support Ended
+# Rust Transform Pipeline (v1.9+)
 
 ## Overview
 
-FraiseQL v1.9+ uses an **exclusive Rust backend architecture** where all database operations flow through a high-performance Rust pipeline. The traditional psycopg-only execution path has been **completely removed**.
+FraiseQL v1 has a clear two-layer execution model for reads:
 
-This guide helps existing users migrate from the legacy psycopg implementation to the new Rust-powered architecture.
+1. **Database query layer — psycopg.** Every SQL query against PostgreSQL runs through
+   [psycopg 3](https://www.psycopg.org/) and its async connection pool
+   (`psycopg_pool.AsyncConnectionPool`). psycopg is a **required, first-class dependency** —
+   it is the only PostgreSQL driver FraiseQL uses, and it is not optional, deprecated, or
+   removed.
+2. **JSON transform / response layer — Rust (`fraiseql._fraiseql_rs`).** After psycopg returns
+   the raw JSONB rows, FraiseQL hands them to a bundled Rust extension that performs field
+   projection, `camelCase` conversion, `__typename` injection, and direct UTF-8 byte encoding.
+   The result is a `RustResponseBytes` object that is written straight to the HTTP response,
+   bypassing `graphql-core` serialization.
+
+This guide explains the v1.9 architecture and shows how to write resolvers that use the
+Rust-transform path (`db.find` / `db.find_one`).
 
 ## What Changed in v1.9
 
-### Before v1.9: Dual Execution Paths
+The change in v1.9 is **not** about the database driver — psycopg is still the driver and
+still required. What changed is the **JSON-transform / response path**: it became
+**Rust-exclusive, with no Python-serialization fallback**.
+
+Before v1.9, the JSON transformation could fall back to a Python serialization path. As of
+v1.9+, the Rust extension is bundled and mandatory: it is built with maturin as
+`fraiseql._fraiseql_rs` and loaded by `src/fraiseql/core/rust_pipeline.py`. If the extension
+is missing, FraiseQL raises an error asking you to reinstall — there is no Python fallback.
+
+### Execution flow (v1.9+)
 
 ```
-GraphQL → Repository → [psycopg pool] → PostgreSQL → JSONB → Python Objects → GraphQL Response
-                    ↓
-              [Rust pipeline] (optional)
+GraphQL request
+   → @query resolver calls db.find(...) / db.find_one(...)
+      → psycopg AsyncConnectionPool executes SQL against PostgreSQL
+         → PostgreSQL returns JSONB rows
+            → Rust transform (field projection, camelCase, __typename, UTF-8 bytes)
+               → RustResponseBytes
+                  → written directly to the HTTP response (no graphql-core serialization)
 ```
 
-### v1.9+: Exclusive Rust Pipeline
+### Key points
+
+| Aspect | Detail |
+|--------|--------|
+| **Database driver** | psycopg 3 (`psycopg[pool]`) — required, unchanged |
+| **Connection pool** | `psycopg_pool.AsyncConnectionPool` |
+| **Repository** | `FraiseQLRepository(pool, context)` |
+| **JSON transform** | Rust extension `fraiseql._fraiseql_rs` — bundled, mandatory, no fallback |
+| **Read return type** | `RustResponseBytes` (from `db.find` / `db.find_one`) |
+| **Response handling** | `RustResponseBytes` is written directly to HTTP (zero-copy bytes) |
+
+## Why the Rust Transform Path
+
+Moving JSON transformation out of Python and into the bundled Rust extension keeps the hot
+read path off the Python interpreter once psycopg has fetched the rows.
+
+### Performance characteristics
+
+- **JSON serialization happens in Rust**, not in Python — no intermediate Python dict/list
+  objects are built for the response body.
+- **Direct HTTP response** — `RustResponseBytes` is encoded once and written to the socket,
+  bypassing `graphql-core` serialization.
+- **Lower garbage-collection pressure** — fewer transient Python objects per request under
+  load.
+
+The exact speedup depends on payload size and query shape; benefits are most visible on large
+result sets and deeply-nested GraphQL selections. The figures below are **illustrative
+examples** from a single internal benchmark, not guarantees — measure your own workload.
 
 ```
-GraphQL → Repository → [Rust DatabasePool] → PostgreSQL → JSONB → Rust Transform → RustResponseBytes → HTTP
+Example benchmark — complex GraphQL query returning ~5,000 records
+┌─────────────────┬─────────────┬─────────────┬──────────────────┐
+│ Metric          │ Python JSON │ Rust v1.9+  │ Example delta    │
+├─────────────────┼─────────────┼─────────────┼──────────────────┤
+│ Response Time   │ 450ms       │ 180ms       │ ~2.5x faster     │
+│ Memory Usage    │ 85MB        │ 45MB        │ ~47% less        │
+│ Throughput      │ 120 req/sec │ 280 req/sec │ ~2.3x higher     │
+└─────────────────┴─────────────┴─────────────┴──────────────────┘
 ```
 
-### Key Changes
+### Architecture benefits
 
-| Aspect | Before (psycopg) | After (Rust v1.9+) |
-|--------|------------------|-------------------|
-| **Execution Path** | Python string operations | Zero-copy Rust pipeline |
-| **Response Type** | Python dict/list | `RustResponseBytes` |
-| **Performance** | Baseline | 2-3x faster, 40-60% less memory |
-| **Memory Usage** | High (intermediate objects) | Low (direct serialization) |
-| **Initialization** | `PsycopgRepository(pool)` | `FraiseQLRepository(pool._pool, context)` |
-| **API Methods** | `select_from_json_view()` | `find()` and `find_one()` |
+- **Single read path** — `db.find` / `db.find_one` always use the Rust transform, so there is
+  no mode detection or branching in your resolvers.
+- **Consistent return type** — reads return `RustResponseBytes` everywhere.
+- **Clear failure mode** — if the Rust extension is missing, FraiseQL fails loudly at import
+  time rather than silently degrading.
 
-## Why Migrate to Rust Backend?
+## Setting Up the Pool and Repository
 
-### Performance Benefits
+In almost all applications you do **not** build the pool yourself.
+`create_fraiseql_app(...)` creates the psycopg `AsyncConnectionPool` for you and wires a
+`FraiseQLRepository` into each request's GraphQL context as `info.context["db"]`.
 
-The Rust backend provides significant performance improvements:
-
-#### Query Execution Speed
-
-- **2-3x faster** for large result sets (>1000 rows)
-- **Zero Python string operations** - all JSON serialization happens in Rust
-- **Direct HTTP response** - `RustResponseBytes` bypasses GraphQL serialization
-
-#### Memory Efficiency
-
-- **40-60% reduction** in memory usage for large responses
-- **No intermediate Python objects** between database and HTTP
-- **Reduced garbage collection pressure** under high load
-
-#### Real-World Benchmarks
-
-Based on production testing with 10,000 concurrent users:
-
-```
-Test Scenario: Complex GraphQL query with 5000 user records
-┌─────────────────┬─────────────┬─────────────┬─────────────┐
-│ Metric          │ psycopg     │ Rust v1.9+  │ Improvement │
-├─────────────────┼─────────────┼─────────────┼─────────────┤
-│ Response Time   │ 450ms       │ 180ms       │ 2.5x faster │
-│ Memory Usage    │ 85MB        │ 45MB        │ 47% less    │
-│ CPU Usage       │ 78%         │ 45%         │ 42% less    │
-│ Throughput      │ 120 req/sec │ 280 req/sec │ 2.3x higher │
-└─────────────────┴─────────────┴─────────────┴─────────────┘
-```
-
-### Architecture Benefits
-
-#### Type Safety
-
-- **Compile-time guarantees** prevent data corruption
-- **Memory-safe operations** eliminate null pointer exceptions
-- **Concurrent execution** without GIL limitations
-
-#### Reliability
-
-- **Zero-copy operations** eliminate serialization bugs
-- **Predictable performance** under all load conditions
-- **Automatic optimization** of query execution paths
-
-#### Developer Experience
-
-- **Single execution path** - no mode detection or branching
-- **Consistent API** - same interface across all operations
-- **Better debugging** - clear error messages and stack traces
-
-## Migration Checklist
-
-### Phase 1: Assessment (1-2 hours)
-
-- [ ] **Identify current usage patterns**
-  - Review all `PsycopgRepository` instantiations
-  - Catalog `select_from_json_view()` calls
-  - Document custom query methods
-
-- [ ] **Check dependencies**
-  - Verify PostgreSQL version compatibility
-  - Ensure Rust extension is available
-  - Check system requirements (4GB+ RAM recommended)
-
-- [ ] **Performance baseline**
-  - Run current benchmarks
-  - Document slow queries for comparison
-  - Establish performance requirements
-
-### Phase 2: Code Migration (4-6 hours)
-
-- [ ] **Update imports**
-  - Replace `from psycopg_pool import AsyncConnectionPool`
-  - Add `from fraiseql.core.database import DatabasePool`
-  - Update repository imports
-
-- [ ] **Update initialization**
-  - Replace `PsycopgRepository` with `FraiseQLRepository`
-  - Update connection pool creation
-  - Add context parameter for tenant/session data
-
-- [ ] **Migrate query methods**
-  - Replace `select_from_json_view()` with `find()`/`find_one()`
-  - Update GraphQL resolvers to use new API
-  - Handle `RustResponseBytes` return types
-
-- [ ] **Update error handling**
-  - Replace psycopg-specific exceptions
-  - Add Rust pipeline error handling
-  - Update logging and monitoring
-
-### Phase 3: Testing & Validation (2-4 hours)
-
-- [ ] **Unit tests**
-  - Update test fixtures for new repository
-  - Verify query results match expectations
-  - Test error conditions
-
-- [ ] **Integration tests**
-  - End-to-end GraphQL query testing
-  - Performance regression testing
-  - Load testing with realistic data
-
-- [ ] **Production validation**
-  - Canary deployment testing
-  - Gradual traffic migration
-  - Rollback plan preparation
-
-### Phase 4: Production Deployment (1-2 hours)
-
-- [ ] **Gradual rollout**
-  - Feature flags for new implementation
-  - A/B testing between old and new
-  - Incremental traffic migration
-
-- [ ] **Monitoring**
-  - Performance metrics collection
-  - Error rate monitoring
-  - User experience tracking
-
-- [ ] **Cleanup**
-  - Remove legacy code
-  - Update documentation
-  - Archive migration scripts
-
-## Step-by-Step Migration Guide
-
-### Step 1: Update Dependencies
-
-**Before (psycopg-based):**
+### The normal path: `create_fraiseql_app`
 
 ```python
-# requirements.txt or pyproject.toml
-psycopg-pool==3.2.0
-psycopg==3.1.0
-```
+import fraiseql
+from fraiseql.fastapi import create_fraiseql_app
+from fraiseql.types import ID
 
-**After (Rust-based):**
 
-```python
-# requirements.txt or pyproject.toml
-fraiseql>=1.9.0
-# No direct psycopg dependencies needed
-```
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
+class User:
+    id: ID
+    name: str
+    email: str
 
-### Step 2: Update Connection Pool
 
-**Before:**
+@fraiseql.query
+async def users(info, limit: int = 50, offset: int = 0) -> list[User]:
+    db = info.context["db"]
+    return await db.find("v_user", field_name="users", info=info, limit=limit, offset=offset)
 
-```python
-from psycopg_pool import AsyncConnectionPool
 
-# Create psycopg connection pool
-pool = AsyncConnectionPool(
-    conninfo="postgresql://user:pass@localhost:5432/mydb",
-    min_size=5,
-    max_size=20
+app = create_fraiseql_app(
+    database_url="postgresql://user:pass@localhost:5432/mydb",
+    types=[User],
+    queries=[users],
+    production=False,  # False enables the GraphQL playground
+    connection_pool_size=20,
 )
-
-# Initialize repository
-db = PsycopgRepository(pool, tenant_id="tenant-123")
 ```
 
-**After:**
+`create_fraiseql_app` accepts pool-tuning kwargs: `connection_pool_size`,
+`connection_pool_max_overflow`, `connection_pool_timeout`, and `connection_pool_recycle`.
+
+### The manual path: building the pool yourself
+
+If you are embedding FraiseQL outside the standard app factory (custom context, tests, or
+scripts), build the psycopg pool and the repository directly. The repository takes the
+psycopg `AsyncConnectionPool` and an optional context dict.
 
 ```python
-from fraiseql.core.database import DatabasePool
+from fraiseql.fastapi import create_db_pool
 from fraiseql.db import FraiseQLRepository
 
-# Create Rust-powered connection pool
-pool = DatabasePool(
-    database_url="postgresql://user:pass@localhost:5432/mydb",
-    config={
-        "max_size": 20,
-        "min_idle": 5,
-        "connection_timeout": 30
-    }
-)
+# create_db_pool returns a psycopg_pool.AsyncConnectionPool, configured for FraiseQL
+pool = await create_db_pool("postgresql://user:pass@localhost:5432/mydb")
 
-# Initialize repository with context
 db = FraiseQLRepository(
-    pool=pool._pool,  # Use internal psycopg pool
-    context={"tenant_id": "tenant-123"}
+    pool,
+    context={"tenant_id": "tenant-123"},  # optional: flows into RLS session GUCs
 )
 ```
 
-### Step 3: Migrate Query Methods
+`FraiseQLRepository.__init__(self, pool: AsyncConnectionPool, context: dict | None = None)`
+takes the psycopg pool directly — there is no separate "Rust pool" wrapper.
 
-**Before (Legacy API):**
+## Writing Read Resolvers
 
-```python
-@fraiseql.query
-async def users(info, where=None, limit=50, offset=0):
-    db = info.context["db"]
-    tenant_id = info.context["tenant_id"]
+Read resolvers call `db.find` (lists) or `db.find_one` (single record). Both return
+`RustResponseBytes`; you return that value straight from the resolver and FraiseQL sends it to
+the HTTP response.
 
-    options = QueryOptions(
-        filters=where,
-        pagination=PaginationInput(limit=limit, offset=offset)
-    )
-
-    # Returns Python dict/list
-    results, total = await db.select_from_json_view(
-        tenant_id=tenant_id,
-        view_name="v_user",
-        options=options
-    )
-
-    return results
-```
-
-**After (Rust API):**
+### List query
 
 ```python
-@fraiseql.query
-async def users(info, where=None, limit=50, offset=0):
-    db = info.context["db"]
+import fraiseql
+from fraiseql.types import ID
 
-    # Returns RustResponseBytes - zero-copy to HTTP
+
+@fraiseql.type(sql_source="v_product", jsonb_column="data")
+class Product:
+    id: ID
+    name: str
+    price: float
+
+
+@fraiseql.query
+async def products(info, limit: int = 20, offset: int = 0) -> list[Product]:
+    db = info.context["db"]
     return await db.find(
-        view_name="v_user",
-        field_name="users",
-        info=info,  # Required for GraphQL field selection
-        where=where,
-        limit=limit,
-        offset=offset
-    )
-```
-
-### Step 4: Handle Response Types
-
-**Before (Python Objects):**
-
-```python
-# GraphQL resolver returns Python objects
-# GraphQL-core serializes to JSON → HTTP response
-results, total = await db.select_from_json_view(...)
-return results  # Python dict/list → JSON
-```
-
-**After (RustResponseBytes):**
-
-```python
-# GraphQL resolver returns RustResponseBytes
-# Bypasses GraphQL serialization - direct to HTTP
-result = await db.find(...)
-return result  # RustResponseBytes → HTTP (zero-copy)
-```
-
-### Step 5: Update Error Handling
-
-**Before:**
-
-```python
-from psycopg import DatabaseError, OperationalError
-
-try:
-    results, total = await db.select_from_json_view(...)
-except DatabaseError as e:
-    logger.error(f"Database error: {e}")
-    raise GraphQLError("Database operation failed")
-except OperationalError as e:
-    logger.error(f"Connection error: {e}")
-    raise GraphQLError("Database connection failed")
-```
-
-**After:**
-
-```python
-# Rust pipeline errors are wrapped in standard Python exceptions
-try:
-    result = await db.find(...)
-except Exception as e:  # Rust errors propagate as standard exceptions
-    logger.error(f"Query execution failed: {e}")
-    raise GraphQLError("Database operation failed")
-```
-
-## GraphQL Resolver Migration Examples
-
-### Simple List Query
-
-**Before:**
-
-```python
-@fraiseql.query
-async def products(info, limit=20, offset=0):
-    db = info.context["db"]
-    tenant_id = info.context["tenant_id"]
-
-    options = QueryOptions(
-        pagination=PaginationInput(limit=limit, offset=offset)
-    )
-
-    results, total = await db.select_from_json_view(
-        tenant_id=tenant_id,
-        view_name="v_product",
-        options=options
-    )
-
-    return results
-```
-
-**After:**
-
-```python
-@fraiseql.query
-async def products(info, limit=20, offset=0):
-    db = info.context["db"]
-
-    return await db.find(
-        view_name="v_product",
+        "v_product",
         field_name="products",
-        info=info,
+        info=info,  # drives field selection / projection
         limit=limit,
-        offset=offset
+        offset=offset,
     )
 ```
 
-### Single Record Query
-
-**Before:**
+### Single-record query
 
 ```python
 @fraiseql.query
-async def user(info, id: str):
+async def user(info, id: ID) -> User | None:
     db = info.context["db"]
-    tenant_id = info.context["tenant_id"]
-
-    options = QueryOptions(filters={"id": id})
-
-    results, total = await db.select_from_json_view(
-        tenant_id=tenant_id,
-        view_name="v_user",
-        options=options
-    )
-
-    return results[0] if results else None
+    # find_one returns RustResponseBytes for a hit, or None when no row matches
+    return await db.find_one("v_user", field_name="user", info=info, id=id)
 ```
 
-**After:**
+### Filtered query
+
+`db.find` accepts a `where` dict (and filter kwargs) plus `order_by`. The Rust transform still
+handles the response.
 
 ```python
 @fraiseql.query
-async def user(info, id: str):
+async def search_orders(
+    info,
+    customer_id: ID | None = None,
+    status: str | None = None,
+    date_from: str | None = None,
+) -> list["Order"]:
     db = info.context["db"]
 
-    result = await db.find_one(
-        view_name="v_user",
-        field_name="user",
-        info=info,
-        id=id
-    )
-
-    return result  # Returns RustResponseBytes or None
-```
-
-### Complex Filtering Query
-
-**Before:**
-
-```python
-@fraiseql.query
-async def search_orders(info, customer_id=None, status=None, date_from=None):
-    db = info.context["db"]
-    tenant_id = info.context["tenant_id"]
-
-    filters = {}
+    where: dict[str, object] = {}
     if customer_id:
-        filters["customer_id"] = customer_id
+        where["customer_id"] = customer_id
     if status:
-        filters["status"] = status
+        where["status"] = status
     if date_from:
-        filters["created_at__min"] = date_from
-
-    options = QueryOptions(
-        filters=filters,
-        order_by=OrderByInstructions(instructions=[
-            OrderByInstruction(field="created_at", direction=OrderDirection.DESC)
-        ])
-    )
-
-    results, total = await db.select_from_json_view(
-        tenant_id=tenant_id,
-        view_name="v_order",
-        options=options
-    )
-
-    return results
-```
-
-**After:**
-
-```python
-@fraiseql.query
-async def search_orders(info, customer_id=None, status=None, date_from=None):
-    db = info.context["db"]
-
-    # Build filter dict (same syntax as before)
-    filters = {}
-    if customer_id:
-        filters["customer_id"] = customer_id
-    if status:
-        filters["status"] = status
-    if date_from:
-        filters["created_at__min"] = date_from
+        where["created_at"] = {"gte": date_from}
 
     return await db.find(
-        view_name="v_order",
+        "v_order",
         field_name="orders",
         info=info,
-        **filters,  # Unpack filters as kwargs
-        order_by=[{"field": "created_at", "direction": "DESC"}]
+        where=where,
+        order_by=[{"field": "created_at", "direction": "DESC"}],
     )
 ```
 
-## Configuration Migration
+## Handling `RustResponseBytes`
 
-### Database Configuration
+`db.find` and `db.find_one` return `RustResponseBytes`, defined in
+`fraiseql.core.rust_pipeline`. It wraps a finished UTF-8 byte buffer of the GraphQL response
+body. The point of the type is that it is **already serialized** — return it directly and let
+FraiseQL stream it to the client.
 
-**Before:**
+Do **not** decode-and-re-encode it in your resolver; that throws away the whole benefit:
 
 ```python
-# config.py
-DATABASE_URL = "postgresql://user:pass@localhost:5432/mydb"
+import json
 
-pool = AsyncConnectionPool(
-    conninfo=DATABASE_URL,
-    min_size=5,
-    max_size=20,
-    timeout=30
-)
+# Correct: return RustResponseBytes unchanged
+@fraiseql.query
+async def users(info) -> list[User]:
+    db = info.context["db"]
+    return await db.find("v_user", field_name="users", info=info)
+
+
+# Incorrect: round-tripping through Python JSON defeats the Rust transform
+@fraiseql.query
+async def users_bad(info) -> list[User]:
+    db = info.context["db"]
+    result = await db.find("v_user", field_name="users", info=info)
+    return json.loads(bytes(result).decode())  # don't do this
 ```
 
-**After:**
+Always pass `info` to `find` / `find_one` so the Rust transform knows which fields the client
+requested. If `info` is omitted, FraiseQL tries to recover it from
+`info.context["graphql_info"]`, but passing it explicitly is clearest.
+
+## Mutations
+
+Mutations are unchanged by the Rust-transform work. They call PostgreSQL functions through the
+same psycopg-backed repository:
 
 ```python
-# config.py
-DATABASE_URL = "postgresql://user:pass@localhost:5432/mydb"
+@fraiseql.input
+class CreateUserInput:
+    name: str
+    email: str
 
-from fraiseql.core.database import DatabasePool
 
-pool = DatabasePool(
-    database_url=DATABASE_URL,
-    config={
-        "max_size": 20,
-        "min_idle": 5,
-        "connection_timeout": 30,
-        "idle_timeout": 300,
-        "max_lifetime": 3600
-    }
-)
-```
+@fraiseql.success
+class CreateUserSuccess:
+    user: User
 
-### Application Context
 
-**Before:**
+@fraiseql.error
+class CreateUserError:
+    message: str
+    code: str = "VALIDATION_ERROR"
 
-```python
-# app.py
-db = PsycopgRepository(pool, tenant_id="default")
-```
 
-**After:**
-
-```python
-# app.py
-db = FraiseQLRepository(
-    pool=pool._pool,
-    context={
-        "tenant_id": "default",
-        "user_id": None,  # For RBAC
-        "contact_id": None  # For multi-user contexts
-    }
-)
-```
-
-## Testing Migration
-
-### Unit Test Updates
-
-**Before:**
-
-```python
-# tests/test_repository.py
-import pytest
-from psycopg_pool import AsyncConnectionPool
-from fraiseql.db import PsycopgRepository
-
-@pytest.fixture
-async def db(postgres_url):
-    pool = AsyncConnectionPool(conninfo=postgres_url, min_size=1, max_size=5)
-    return PsycopgRepository(pool, tenant_id="test")
-
-@pytest.mark.asyncio
-async def test_user_query(db):
-    options = QueryOptions(filters={"status": "active"})
-    results, total = await db.select_from_json_view(
-        tenant_id="test",
-        view_name="v_user",
-        options=options
+@fraiseql.mutation
+async def create_user(info, input: CreateUserInput) -> CreateUserSuccess | CreateUserError:
+    db = info.context["db"]
+    result = await db.execute_function(
+        "fn_create_user",
+        {"name": input.name, "email": input.email},
     )
-    assert len(results) > 0
+    if not result.get("success"):
+        return CreateUserError(message=result.get("message", "failed"))
+    return CreateUserSuccess(user=User(**result["user"]))
 ```
 
-**After:**
+## Testing
+
+### Resolver-level tests
+
+Reads return `RustResponseBytes`, so unit tests assert on the type or decode the bytes for
+inspection. A real psycopg pool (or a test fixture that builds one) is required because the
+query still runs through psycopg.
 
 ```python
-# tests/test_repository.py
 import pytest
-from fraiseql.core.database import DatabasePool
+from fraiseql.fastapi import create_db_pool
 from fraiseql.db import FraiseQLRepository
+from fraiseql.core.rust_pipeline import RustResponseBytes
+
 
 @pytest.fixture
-async def db(postgres_url):
-    pool = DatabasePool(database_url=postgres_url, config={"max_size": 5})
-    return FraiseQLRepository(pool=pool._pool, context={"tenant_id": "test"})
+async def db(postgres_url: str) -> FraiseQLRepository:
+    pool = await create_db_pool(postgres_url)
+    return FraiseQLRepository(pool, context={"tenant_id": "test"})
+
 
 @pytest.mark.asyncio
-async def test_user_query(db):
-    # Note: Testing Rust pipeline requires different approach
-    # Integration tests verify end-to-end behavior
-    result = await db.find(
-        view_name="v_user",
-        field_name="users",
-        info=None,  # Mock GraphQL info for testing
-        status="active"
-    )
+async def test_user_query(db: FraiseQLRepository) -> None:
+    result = await db.find("v_user", field_name="users", info=None, status="active")
     assert isinstance(result, RustResponseBytes)
 ```
 
-### Integration Test Updates
+### End-to-end GraphQL tests
 
-**Before:**
-
-```python
-# tests/test_graphql.py
-def test_user_query(client):
-    query = """
-    query {
-        users(limit: 10) {
-            id
-            name
-            email
-        }
-    }
-    """
-
-    response = client.post("/graphql", json={"query": query})
-    data = response.json()["data"]
-
-    assert "users" in data
-    assert len(data["users"]) <= 10
-```
-
-**After:**
+End-to-end tests hit the FastAPI `/graphql` endpoint and assert on the JSON body, exactly as
+before — the Rust transform is transparent to the HTTP contract.
 
 ```python
-# tests/test_graphql.py
-def test_user_query(client):
+def test_user_query(client) -> None:
     query = """
     query {
         users(limit: 10) {
@@ -623,275 +346,96 @@ def test_user_query(client):
 
     response = client.post("/graphql", json={"query": query})
 
-    # Rust pipeline returns direct HTTP response
     assert response.status_code == 200
     data = response.json()["data"]
-
     assert "users" in data
     assert len(data["users"]) <= 10
-
-    # Additional validation: check performance headers
-    assert "X-Rust-Pipeline" in response.headers
-    assert response.headers["X-Rust-Pipeline"] == "true"
 ```
 
-## Troubleshooting Common Issues
+## Troubleshooting
 
-### Issue: "Rust extension not available"
-
-**Symptoms:**
+### "fraiseql Rust extension is not available"
 
 ```
-ImportError: fraiseql Rust extension is not available
+ImportError: fraiseql Rust extension is not available.
+Please reinstall fraiseql: pip install --force-reinstall fraiseql
 ```
 
-**Solutions:**
+The Rust transform is bundled with FraiseQL as `fraiseql._fraiseql_rs`. If the wheel was built
+without it (or a source install failed to compile), reinstall a prebuilt wheel:
 
-1. **Reinstall FraiseQL:**
-
-   ```bash
-   pip uninstall fraiseql
-   pip install --force-reinstall fraiseql
-   ```
-
-2. **Check system dependencies:**
-
-   ```bash
-   # Ubuntu/Debian
-   sudo apt-get install build-essential
-
-   # macOS
-   xcode-select --install
-
-   # Windows
-   # Install Visual Studio Build Tools
-   ```
-
-3. **Verify Python version:**
-   - Rust extension requires Python 3.8+
-   - Check with: `python --version`
-
-### Issue: "Connection pool exhausted"
-
-**Symptoms:**
-
-```
-DatabaseError: Connection pool exhausted
+```bash
+pip install --force-reinstall fraiseql
 ```
 
-**Solutions:**
+If you build from source, ensure a Rust toolchain and maturin are available, then rebuild.
 
-1. **Increase pool size:**
+### "Connection pool exhausted"
 
-   ```python
-   pool = DatabasePool(
-       database_url=DATABASE_URL,
-       config={"max_size": 50, "min_idle": 10}  # Increase from defaults
-   )
-   ```
+This is a psycopg pool limit, not a Rust issue. Raise the pool size or fix connection leaks:
 
-2. **Check connection leaks:**
-   - Ensure connections are properly released
-   - Use context managers for transactions
-   - Monitor connection pool stats
-
-3. **Optimize query patterns:**
-   - Use `find_one()` for single records
-   - Implement proper pagination
-   - Avoid N+1 query patterns
-
-### Issue: "GraphQL type mismatch errors"
-
-**Symptoms:**
-
-```
-GraphQLError: Expected Iterable but got RustResponseBytes
+```python
+app = create_fraiseql_app(
+    database_url=DATABASE_URL,
+    types=[...],
+    queries=[...],
+    connection_pool_size=50,
+    connection_pool_max_overflow=10,
+)
 ```
 
-**Solutions:**
+Also confirm connections are released (use context managers for explicit transactions) and
+prefer `find_one` for single-record lookups to avoid over-fetching.
 
-1. **Check GraphQL resolver return types:**
+### "Expected Iterable but got RustResponseBytes"
 
-   ```python
-   # Correct: Let Rust pipeline handle response
-   @fraiseql.query
-   async def users(info):
-       return await db.find("v_user", "users", info)
+This means a resolver tried to treat `RustResponseBytes` as a plain Python list. Return it
+unchanged from the resolver and pass `info` so the transform produces the correct shape:
 
-   # Incorrect: Manual processing loses optimization
-   @fraiseql.query
-   async def users(info):
-       result = await db.find("v_user", "users", info)
-       return json.loads(result.decode())  # Don't do this!
-   ```
+```python
+@fraiseql.query
+async def users(info) -> list[User]:
+    db = info.context["db"]
+    return await db.find("v_user", field_name="users", info=info)  # return as-is
+```
 
-2. **Verify field selection:**
-   - Pass `info` parameter to `find()` methods
-   - Ensure GraphQL schema matches database views
+### Schema and migration tools
 
-3. **Check multi-field queries:**
-   - Rust pipeline handles single-field queries optimally
-   - Complex multi-field queries may need special handling
+The Rust transform works with any standard PostgreSQL schema — your `v_` / `tv_` read views
+and JSONB structures are unchanged. Migration tools (Alembic and friends) operate on the
+database directly and need no changes:
 
-### Issue: "Performance regression after migration"
-
-**Symptoms:**
-
-- Queries slower than expected
-- Memory usage increased
-- Higher CPU usage
-
-**Solutions:**
-
-1. **Verify Rust pipeline usage:**
-
-   ```python
-   # Check that Rust pipeline is active
-   response = await client.post("/graphql", json={"query": query})
-   assert response.headers.get("X-Rust-Pipeline") == "true"
-   ```
-
-2. **Compare query patterns:**
-   - Ensure using `find()` not legacy `select_from_json_view()`
-   - Check that GraphQL `info` parameter is passed
-   - Verify connection pool configuration
-
-3. **Profile performance:**
-
-   ```python
-   import time
-   start = time.time()
-   result = await db.find("v_user", "users", info)
-   duration = time.time() - start
-   print(f"Query took: {duration:.3f}s")
-   ```
-
-### Issue: "Migration tool compatibility"
-
-**Symptoms:**
-
-- Alembic migrations fail
-- Schema changes not applied
-- Database inconsistencies
-
-**Solutions:**
-
-1. **Use compatible migration tools:**
-   - Continue using existing migration tools
-   - Rust backend works with standard PostgreSQL schemas
-   - No changes needed to migration scripts
-
-2. **Verify schema compatibility:**
-
-   ```sql
-   -- Check that views exist and are accessible
-   SELECT table_name FROM information_schema.views
-   WHERE table_name LIKE 'v_%';
-   ```
-
-3. **Test migrations:**
-
-   ```bash
-   # Run migrations before switching to Rust backend
-   alembic upgrade head
-
-   # Then test with Rust backend
-   pytest tests/integration/
-   ```
+```sql
+-- Confirm your read views exist
+SELECT table_name FROM information_schema.views
+WHERE table_name LIKE 'v_%';
+```
 
 ## FAQ
 
-### General Questions
+**Q: Is psycopg still required?**
+A: Yes. psycopg 3 (`psycopg[pool]`) is the PostgreSQL driver and a required dependency. The
+Rust extension transforms the JSON response after psycopg has fetched the rows; it does not
+replace psycopg.
 
-**Q: Is the migration mandatory?**
-A: Yes, as of FraiseQL v1.9, the psycopg-only path has been completely removed. All applications must use the Rust backend.
-
-**Q: Can I migrate gradually?**
-A: Yes, you can migrate resolvers incrementally. The Rust backend is backward compatible with existing GraphQL schemas and database views.
+**Q: Is the Rust extension optional?**
+A: No. It is bundled as `fraiseql._fraiseql_rs` and mandatory for the read path. There is no
+Python-serialization fallback; a missing extension raises at import time.
 
 **Q: Do I need to change my database schema?**
-A: No, the Rust backend works with existing PostgreSQL schemas, views, and JSONB structures. No database changes are required.
+A: No. The Rust transform works with existing PostgreSQL views and JSONB structures.
 
-**Q: What if I have custom query methods?**
-A: Custom methods using raw SQL will need to be adapted. The Rust backend provides a consistent API, but custom SQL execution may need refactoring.
+**Q: Do I have to build the connection pool myself?**
+A: No. `create_fraiseql_app` builds the psycopg pool and wires `FraiseQLRepository` into
+`info.context["db"]`. Build the pool manually only for custom embedding or tests.
 
-### Performance Questions
-
-**Q: When will I see performance improvements?**
-A: Performance benefits are most noticeable with:
-
-- Large result sets (>1000 rows)
-- Complex GraphQL queries with deep field selection
-- High-concurrency scenarios
-- Memory-constrained environments
-
-**Q: Are there any performance downsides?**
-A: The Rust backend adds minimal overhead for simple queries but provides substantial benefits for complex operations. Memory usage is consistently lower.
-
-**Q: How do I monitor performance?**
-A: Check response headers for `X-Rust-Pipeline: true` to confirm Rust execution. Use standard application performance monitoring tools.
-
-### Compatibility Questions
-
-**Q: Does it work with my existing GraphQL schema?**
-A: Yes, the Rust backend is fully compatible with existing GraphQL schemas. The API changes are in the resolver implementation, not the schema definition.
-
-**Q: Can I use it with my current PostgreSQL version?**
-A: The Rust backend works with PostgreSQL 12+. For optimal performance, PostgreSQL 14+ is recommended.
-
-**Q: What about my existing middleware?**
-A: Most middleware continues to work. The `RustResponseBytes` type integrates seamlessly with HTTP response handling.
-
-### Support Questions
-
-**Q: Where can I get help with migration?**
-A: Check the troubleshooting section above, or create an issue in the FraiseQL repository with migration questions.
-
-**Q: Are there example migrations I can reference?**
-A: This guide includes before/after examples for common patterns. The FraiseQL test suite also demonstrates proper Rust backend usage.
-
-**Q: What if I encounter a bug during migration?**
-A: Report issues to the FraiseQL repository. Include your before/after code, error messages, and FraiseQL version information.
-
-## Success Metrics
-
-After successful migration, you should see:
-
-### Performance Improvements
-
-- ✅ Query response times 2-3x faster for large datasets
-- ✅ Memory usage reduced by 40-60%
-- ✅ CPU usage decreased under load
-- ✅ Higher throughput (requests/second)
-
-### Operational Improvements
-
-- ✅ Consistent query performance
-- ✅ Reduced garbage collection pressure
-- ✅ Better error messages and debugging
-- ✅ Simplified deployment (fewer dependencies)
-
-### Developer Experience
-
-- ✅ Single execution path (no mode detection)
-- ✅ Type-safe operations
-- ✅ Better IDE support and autocomplete
-- ✅ Consistent API across all operations
-
-## Next Steps After Migration
-
-1. **Monitor Performance**: Track query times, memory usage, and error rates
-2. **Optimize Queries**: Use the new API patterns for maximum performance
-3. **Update Documentation**: Document the migration for your team
-4. **Plan Future Updates**: Leverage Rust backend features like advanced caching
+**Q: When will I see the biggest performance benefit?**
+A: On large result sets and deeply-nested GraphQL selections, where moving JSON serialization
+out of Python matters most. Measure your own workload.
 
 ## Additional Resources
 
-- **[Database API Documentation](database-api.md)** - Complete Rust backend API reference
-- **[Performance Optimization Guide](../performance/rust-pipeline-optimization.md)** - Advanced performance tuning
-- **[Troubleshooting Guide](../guides/troubleshooting.md)** - Common issues and solutions
-- **[CI/CD Architecture](../archive/testing/ci-architecture.md)** - Testing the Rust backend
-
----
-
-**Migration Complete**: This guide covers the complete transition from psycopg to the exclusive Rust backend in FraiseQL v1.9+.
+- **[Database API Documentation](database-api.md)** — repository and read/write API reference
+- **[Rust Pipeline Integration](rust-pipeline-integration.md)** — how the transform integrates
+- **[Performance Optimization Guide](../performance/rust-pipeline-optimization.md)** — tuning
+- **[Troubleshooting Guide](../guides/troubleshooting.md)** — common issues and solutions


### PR DESCRIPTION
Two follow-ups from the docs v1 cleanup (both pre-existing defects outside the 86-file Phase-2 set).

## 1. `core/rust-backend-migration.md` — corrected false psycopg claims (kept, per request)
This orphan page (not in nav, no inbound links) mixed real Rust-pipeline content with the **false** claim that psycopg was "completely removed" / "no psycopg dependencies needed", replaced by a "Rust DatabasePool". Verified against `src/`, that's wrong. Corrected to the real v1 two-layer model:
- **Database query layer = psycopg** — required driver (`psycopg[pool]>=3.3.3`), `psycopg_pool.AsyncConnectionPool`, `FraiseQLRepository(pool, context)`. Not removed/optional.
- **JSON transform/response layer = Rust** — the **bundled, mandatory** extension `fraiseql._fraiseql_rs` (built via maturin; import *raises* if missing, no fallback). After psycopg fetches JSONB, Rust does field projection/camelCase/`__typename`/UTF-8 bytes; `db.find`/`db.find_one` return `RustResponseBytes` that bypass graphql-core serialization.

Retitled "Rust Transform Pipeline (v1.9+)"; removed the invented `PsycopgRepository` rename, `select_from_json_view` legacy API, and the "remove psycopg from requirements" step. The "what changed in v1.9" narrative now correctly says the *transform path* became Rust-exclusive — **not** a psycopg removal. Every API verified against `src/` (`db.py`, `fastapi/app.py`, `core/rust_pipeline.py`, `pyproject.toml`).

## 2. Stripped leaked tool-call XML from 6 `archive/` files
Same trailing-garbage strip (`</xai:function_call>` / `<parameter name=>` / `</content>`) applied to the unpublished `archive/` tree for consistency — content otherwise unchanged.

## Verification
- ✅ 0 false "psycopg removed / Rust DatabasePool / PsycopgRepository / pool._pool" claims remain
- ✅ Asserted APIs verified against `src/`; fences balanced; relative links resolve; no leaked XML anywhere in `docs/`
- ✅ Archive strip is trailing-garbage-only (6 ins / 15 del)

🤖 Generated with [Claude Code](https://claude.com/claude-code)