### PR TITLE
chore(security): deadpool dep alignment + .trivyignore trixie re-baseline (release prep)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,5 @@
 # Trivy Vulnerability Exceptions for International Compliance
-# Last Updated: 2026-05-12
+# Last Updated: 2026-07-23  (re-baselined for python:3.13-slim -> Debian 13 trixie)
 # Review Schedule: Monthly
 # Approval: Security Team
 # Compliance: US (NIST/FedRAMP), EU (NIS2/GDPR), UK (NCSC), ISO 27001, SOC 2
@@ -160,16 +160,6 @@ CVE-2025-6141
 # Review Date: 2026-03-21 (weekly check for Debian package update)
 CVE-2024-56433
 
-# CVE-2025-9820: GnuTLS vulnerability (GNUTLS-SA-2025-11-18)
-# Justification: Recently disclosed, details not fully public
-# Impact: TLS library vulnerability, severity unclear
-# Mitigation:
-#   - Application uses Python's ssl module, not GnuTLS directly
-#   - TLS termination typically handled by reverse proxy (nginx/envoy)
-#   - Container-to-container communication over trusted network
-# Status: MONITORING - Update when fixed version available
-# Review Date: Weekly until patch available
-CVE-2025-9820 # KEEP VISIBLE - Do not ignore, monitor actively
 
 # =============================================================================
 # CATEGORY 6: LOW SEVERITY CVEs (All Documented & Accepted)
@@ -217,134 +207,38 @@ CVE-2025-5278 # coreutils sort - sort command not used
 TEMP-0841856-B18BAF # bash privilege escalation - no shell access
 
 # -----------------------------------------------------------------------------
-# CATEGORY 7: GnuTLS Vulnerabilities (Not Used Directly)
-# Risk Level: LOW (FraiseQL uses Python ssl module, not GnuTLS directly)
-# Mitigation: TLS termination handled by reverse proxy (nginx/envoy)
+# CATEGORY 7: Base-OS HIGH/CRITICAL with no upstream fix (python:3.13-slim)
+# Risk Level: LOW (base-image OS packages; never invoked at runtime by the
+#   Python GraphQL API server). Debian 13 (trixie) ships no fixed versions yet.
+# Added: 2026-06-07 | Re-baselined: 2026-07-23 for bookworm -> trixie
+# Verified present via `trivy image python:3.13-slim` on 2026-07-23.
+# Mitigation: non-root container, no shell/interactive access, no untrusted
+#   input processed by these utilities; TLS terminated at the reverse proxy.
+# Review: Monthly until Debian publishes fixes (FixedVersion=none for all).
 # -----------------------------------------------------------------------------
 
-# CVE-2026-33845: GnuTLS DoS via DTLS zero-length fragment (CRITICAL)
-# Justification: FraiseQL does not use DTLS protocol
-# Mitigation: Python ssl module uses OpenSSL, not GnuTLS; DTLS not used
-# Status: MONITORING - No patch in python:3.13-slim yet
-CVE-2026-33845
+# perl-base (trixie) - perl interpreter not invoked at runtime
+CVE-2026-13221 # perl-base (CRITICAL)
+CVE-2026-42496 # perl-base (CRITICAL)
+CVE-2026-57433 # perl-base (CRITICAL)
+CVE-2026-8376  # perl-base (CRITICAL)
+CVE-2026-42497 # perl-base (HIGH)
+CVE-2026-48962 # perl-base (HIGH)
+CVE-2026-57432 # perl-base (HIGH)
+CVE-2026-9538  # perl-base (HIGH)
 
-# CVE-2026-33846: GnuTLS heap buffer overflow in DTLS handshake (HIGH)
-# Justification: DTLS protocol not used by FraiseQL
-# Mitigation: Same as CVE-2026-33845
-CVE-2026-33846
+# ncurses (libncursesw6 / libtinfo6 / ncurses-base / ncurses-bin) - not used by the API server
+CVE-2025-69720 # ncurses (HIGH)
 
-# CVE-2026-42011: GnuTLS name constraint bypass (HIGH)
-# Justification: Certificate validation done by Python ssl / reverse proxy
-# Mitigation: TLS termination at load balancer, not in container
-CVE-2026-42011
+# gzip - not used to decompress untrusted input at runtime
+CVE-2026-41992 # gzip (HIGH)
 
-# CVE-2026-42010: GnuTLS auth bypass via NUL char in username (HIGH)
-# Justification: Authentication handled by FraiseQL JWT, not GnuTLS
-# Mitigation: No GnuTLS-based auth in application
-CVE-2026-42010
+# util-linux / mount / login / lib{blkid,mount,uuid,smartcols}1 / bsdutils / liblastlog2-2
+CVE-2026-53615 # util-linux (HIGH) - mount/login utilities not exposed by the API server
 
-# CVE-2026-3833: GnuTLS case-sensitive nameConstraints bypass (HIGH)
-# Justification: Certificate validation not done via GnuTLS
-# Mitigation: Reverse proxy handles TLS
-CVE-2026-3833
+# libacl1 - POSIX ACL library not driven by untrusted input
+CVE-2026-54369 # libacl1 (HIGH)
 
-# CVE-2026-3832: GnuTLS OCSP response bypass (LOW)
-# Justification: OCSP checking not done via GnuTLS in container
-CVE-2026-3832
-
-# CVE-2026-42009, CVE-2026-42012, CVE-2026-42013, CVE-2026-42014,
-# CVE-2026-42015: GnuTLS additional CVEs (severity unclassified)
-# Justification: GnuTLS not used directly by FraiseQL
-CVE-2026-42009
-CVE-2026-42012
-CVE-2026-42013
-CVE-2026-42014
-CVE-2026-42015
-
-# -----------------------------------------------------------------------------
-# CATEGORY 8: libssh2 Vulnerability (Not Used)
-# Risk Level: NONE (FraiseQL does not use SSH)
-# -----------------------------------------------------------------------------
-
-# CVE-2026-7598: libssh2 integer overflow via large username/password (CRITICAL)
-# Justification: FraiseQL is a GraphQL API; no SSH connections made
-# Mitigation: libssh2 present in base image but not used by application
-CVE-2026-7598
-
-# -----------------------------------------------------------------------------
-# CATEGORY 9: Kerberos (krb5) Vulnerabilities (Not Used)
-# Risk Level: NONE (FraiseQL does not use Kerberos auth)
-# -----------------------------------------------------------------------------
-
-# CVE-2026-40356: krb5 integer underflow and OOB read (MEDIUM)
-# Justification: Kerberos auth not used; PostgreSQL uses password/cert auth
-CVE-2026-40356
-
-# CVE-2026-40355: krb5 NULL pointer dereference in NegoEx (MEDIUM)
-# Justification: NegoEx mechanism not used
-CVE-2026-40355
-
-# -----------------------------------------------------------------------------
-# CATEGORY 10: curl/libcurl Vulnerabilities (Build Stage Only)
-# Risk Level: LOW (curl only present in build stage, not runtime)
-# Mitigation: Multi-stage Docker build; runtime image has minimal surface
-# -----------------------------------------------------------------------------
-
-# CVE-2026-6276: libcurl cookie leak with custom Host headers (LOW)
-CVE-2026-6276
-
-# CVE-2026-6429: libcurl credential leak via proxy redirects (MEDIUM)
-CVE-2026-6429
-
-# CVE-2026-6253: curl proxy credential disclosure (MEDIUM)
-CVE-2026-6253
-
-# CVE-2026-5773: libcurl wrong file transfer via SMB reuse (MEDIUM)
-CVE-2026-5773
-
-# CVE-2026-5545: libcurl HTTP Negotiate connection reuse (MEDIUM)
-CVE-2026-5545
-
-# CVE-2026-4873: curl TLS connection reuse info disclosure (MEDIUM)
-CVE-2026-4873
-
-# -----------------------------------------------------------------------------
-# CATEGORY 11: pip and other build-time CVEs
-# Risk Level: LOW (only present in build stage)
-# -----------------------------------------------------------------------------
-
-# CVE-2026-6357: pip arbitrary code execution via malicious wheel (MEDIUM)
-# Justification: pip only used during image build, not at runtime
-# Mitigation: Dependencies pinned via uv.lock; no pip install at runtime
-CVE-2026-6357
-
-# CVE-2026-7168: Unclassified (MEDIUM)
-CVE-2026-7168
-
-# CVE-2026-5419, CVE-2026-5260: Unclassified severity
-CVE-2026-5419
-CVE-2026-5260
-
-# -----------------------------------------------------------------------------
-# CATEGORY 12: perl-base and ncurses Vulnerabilities (No Upstream Fix)
-# Risk Level: LOW (base-image OS packages; not invoked by a Python GraphQL app)
-# Added: 2026-06-07 | Review: Monthly until Debian ships a fix (FixedVersion=none)
-# Mitigation: perl and ncurses are pulled in by python:3.13-slim but are never
-#   executed at runtime by FraiseQL (Python GraphQL API server). Debian has not
-#   published fixed versions yet, so there is no patch to apply. Remove these
-#   exceptions once a fixed base image is available.
-# -----------------------------------------------------------------------------
-
-# perl-base 5.40.1-6 - no fixed version available upstream
-CVE-2026-42496 # perl-base (CRITICAL) - perl interpreter not invoked at runtime
-CVE-2026-8376  # perl-base (CRITICAL) - perl interpreter not invoked at runtime
-CVE-2026-42497 # perl-base (HIGH) - perl interpreter not invoked at runtime
-CVE-2026-48962 # perl-base (HIGH) - perl interpreter not invoked at runtime
-CVE-2026-9538  # perl-base (HIGH) - perl interpreter not invoked at runtime
-
-# ncurses 6.5+20250216-2 (libncursesw6 / libtinfo6 / ncurses-base / ncurses-bin)
-# - no fixed version available upstream
-CVE-2025-69720 # ncurses (HIGH) - terminal library not used by the API server
 
 # =============================================================================
 # DISTROLESS IMAGE CVEs (Reference Only - Not Currently Used)

--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -37,7 +37,9 @@ async-trait = "0.1"
 bytes = "1.11"  # Updated from 1.0 to fix CVE-2026-25541 (integer overflow)
 # Date/time handling
 chrono = {version = "0.4", features = ["serde"]}
-deadpool = "0.12"
+# NB: no direct `deadpool` dependency — the `PoolError` alias is used via
+# deadpool-postgres (see src/security/errors.rs, src/rbac/errors.rs) so the
+# deadpool version always tracks deadpool-postgres and can't split (see #406).
 deadpool-postgres = "0.14"
 # GraphQL parsing (Phase 6)
 graphql-parser = "0.4"

--- a/fraiseql_rs/src/rbac/errors.rs
+++ b/fraiseql_rs/src/rbac/errors.rs
@@ -109,8 +109,11 @@ impl From<tokio_postgres::Error> for RbacError {
     }
 }
 
-impl From<deadpool::managed::PoolError<tokio_postgres::Error>> for RbacError {
-    fn from(error: deadpool::managed::PoolError<tokio_postgres::Error>) -> Self {
+// Reference the PoolError alias re-exported by deadpool-postgres rather than the
+// `deadpool` crate directly, so the error type always tracks the deadpool version
+// that deadpool-postgres resolves to (avoids a two-version split, e.g. #406).
+impl From<deadpool_postgres::PoolError> for RbacError {
+    fn from(error: deadpool_postgres::PoolError) -> Self {
         RbacError::Database(error.to_string())
     }
 }

--- a/fraiseql_rs/src/security/errors.rs
+++ b/fraiseql_rs/src/security/errors.rs
@@ -105,8 +105,11 @@ impl From<tokio_postgres::Error> for SecurityError {
     }
 }
 
-impl From<deadpool::managed::PoolError<tokio_postgres::Error>> for SecurityError {
-    fn from(error: deadpool::managed::PoolError<tokio_postgres::Error>) -> Self {
+// Reference the PoolError alias re-exported by deadpool-postgres rather than the
+// `deadpool` crate directly, so the error type always tracks the deadpool version
+// that deadpool-postgres resolves to (avoids a two-version split, e.g. #406).
+impl From<deadpool_postgres::PoolError> for SecurityError {
+    fn from(error: deadpool_postgres::PoolError) -> Self {
         SecurityError::AuditLogFailure(error.to_string())
     }
 }


### PR DESCRIPTION
Release-prep follow-ups to the dependency remediation. Two independent commits.

## 1. `fix(rust)`: drop the direct `deadpool` dependency (supersedes #406)

Dependabot's `deadpool` 0.12→0.13 bump (#406) can't be adopted: `deadpool-postgres`
0.14.1 pins `deadpool ^0.12` and there's no deadpool-postgres release on 0.13 yet,
so the bump splits the tree into two deadpool versions and the `From<PoolError>`
impls no longer match what `deadpool_postgres::Pool` returns (unfixable while both
coexist).

Fix: reference `deadpool_postgres::PoolError` (the alias deadpool-postgres generates
via `managed_reexports!`) in the two `From` impls and **remove the direct `deadpool`
dependency**. The error type now always tracks deadpool-postgres — a split is
impossible and Dependabot stops proposing incompatible `deadpool` bumps.

- ✅ `cargo build --lib` clean; single deadpool (0.12.3) in the tree
- ✅ `cargo clippy --all-features -- -D warnings` clean; `cargo fmt --check` clean

## 2. `chore(security)`: re-baseline `.trivyignore` for bookworm → trixie

`python:3.13-slim` moved to Debian 13 (trixie), changing the base CVE set. Re-baselined
against `trivy image python:3.13-slim` (2026-07-23):

- **Add 6** new HIGH/CRITICAL base-OS CVEs (all FixedVersion=none): perl-base
  `CVE-2026-13221/57433/57432`, gzip `CVE-2026-41992`, util-linux `CVE-2026-53615`,
  libacl1 `CVE-2026-54369` — these were blocking the Security Gate.
- **Remove 25** stale suppressions absent from trixie (GnuTLS/libssh2/krb5/curl/pip
  categories + `CVE-2025-9820`).
- Consolidate base-OS no-fix entries into one category.

- ✅ `trivy … --severity HIGH,CRITICAL --ignorefile .trivyignore` → **0 unsuppressed** (was 6)

Together with the 21 Dependabot alerts already cleared (#445), this should turn the
Container Security Scan / Security Gate green — the full-image CI scan on this PR is
the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)