### PR TITLE
ci(security-alerts): roll up the weekly CVE monitor into one issue

### DIFF
--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -114,22 +114,38 @@ jobs:
 
           cat /tmp/alert-summary.md
 
-      - name: Create GitHub Issue for HIGH/CRITICAL vulnerabilities
+      - name: Upsert rolling base-image vulnerability alert
         if: steps.check-vulns.outputs.should_alert == 'true'
         uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
-            const summary = fs.readFileSync('/tmp/alert-summary.md', 'utf8');
+            // Stable hidden marker used to find the single rolling issue instead
+            // of opening a fresh duplicate every weekly run.
+            const MARKER = '<!-- security-alerts:base-image-rolling -->';
+            const title = '🚨 Base-image vulnerability alert (HIGH/CRITICAL)';
             const alertLevel = '${{ steps.check-vulns.outputs.alert_level }}';
+            const summary = fs.readFileSync('/tmp/alert-summary.md', 'utf8');
+            const body = `${MARKER}\n\n${summary}`;
+            const labels = ['security', 'vulnerability', alertLevel.toLowerCase()];
+            const { owner, repo } = context.repo;
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `🚨 ${alertLevel} Vulnerability Alert - Base Images`,
-              body: summary,
-              labels: ['security', 'vulnerability', alertLevel.toLowerCase()],
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', per_page: 100,
             });
+            const existing = open.find(i => !i.pull_request && (i.body || '').includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, title, body, labels });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number,
+                body: `🔄 Refreshed by the weekly base-image scan — current level: **${alertLevel}**. Details updated above.`,
+              });
+              core.info(`Updated rolling alert #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({ owner, repo, title, body, labels });
+              core.info(`Created rolling alert #${created.data.number}`);
+            }
 
       - name: Upload scan results
         uses: actions/upload-artifact@v7
@@ -201,21 +217,37 @@ jobs:
 
           cat /tmp/cve-monitoring-report.md
 
-      - name: Create GitHub Issue if patches available
+      - name: Upsert rolling CVE-patches issue
         if: env.fixed_count > 0
         uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
+            // Stable hidden marker used to find the single rolling issue instead
+            // of opening a fresh duplicate every weekly run.
+            const MARKER = '<!-- security-alerts:cve-patches-rolling -->';
+            const title = 'CVE Patches Available — base-image CVE monitor';
             const report = fs.readFileSync('/tmp/cve-monitoring-report.md', 'utf8');
+            const body = `${MARKER}\n\n${report}`;
+            const labels = ['security', 'patching', 'cve-monitor'];
+            const { owner, repo } = context.repo;
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `CVE Patches Available - ${{ env.fixed_count }} CVE(s) Fixed`,
-              body: report,
-              labels: ['security', 'patching', 'good-news'],
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', per_page: 100,
             });
+            const existing = open.find(i => !i.pull_request && (i.body || '').includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, title, body, labels });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number,
+                body: `🔄 Refreshed by the weekly scan — ${process.env.fixed_count} monitored CVE(s) now show fixes. Report updated above.`,
+              });
+              core.info(`Updated rolling issue #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({ owner, repo, title, body, labels });
+              core.info(`Created rolling issue #${created.data.number}`);
+            }
 
       - name: Upload CVE monitoring report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Problem

The weekly **Security Alerts** workflow (`security-alerts.yml`) called `issues.create` unconditionally in two steps, so every Monday run opened a fresh duplicate. #402 / #438 / #441 / #443 were four identical "CVE Patches Available" reports.

## Fix

Both issue-creating steps now **upsert a single rolling issue**:
1. Look up an existing **open** issue carrying a stable hidden marker (`<!-- security-alerts:cve-patches-rolling -->` / `…:base-image-rolling -->`).
2. If found → update its body + add a short "🔄 refreshed" comment.
3. If not found → create one (with a `cve-monitor` label).

Closing the rolling issue lets the next run mint a fresh one, so there's never more than one open at a time. The CVE-patches title no longer embeds the changing fixed-count (moved to the body) so it stays stable.

## Verification
- ✅ YAML parses; both `github-script` blocks pass `node --check`
- ✅ No unconditional `issues.create` remains — creation only in the not-found branch

Closes the last open item tracked on #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)