### PR TITLE
chore(release): v1.23.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.12] - 2026-07-28
+
+### Fixed
+
+- **Multi-field GraphQL queries no longer crash when a `find_one()`-backed
+  field is combined with a scalar sibling** (e.g. `{ me { … } machinesCount }`).
+  The query previously aborted with `'dict' object has no attribute 'bytes'`
+  (`find_one()` ran the `RustResponseBytes` null-check on the plain dict that
+  field-only mode returns) and/or `'int' object is not an instance of 'str'`
+  (a scalar sibling produced a non-string FFI row that aborted the entire
+  Rust-side merge). Both paths are fixed; multi-field queries mixing
+  `find_one`, `find`, and scalar fields now merge cleanly. (#448)
+
+### Security
+
+- Remediated 21 Dependabot alerts across `pillow`, `pyasn1`, `soupsieve`,
+  `langsmith`, `setuptools`, `pypdf`, and `pydantic-settings`. (#445)
+- Bumped `cryptography` and `starlette` to resolve security advisories. (#412)
+- Bumped `aiohttp` to `>=3.14.1` to resolve security advisories. (#411)
+
+### Documentation
+
+- Overhauled the documentation for v1: removed the v2-only content that had
+  been copied into `docs/` and rewrote the remaining guides, tutorials,
+  reference, configuration, and operations pages for the FraiseQL v1
+  PostgreSQL/FastAPI runtime. Removed the fictional `@FraiseQL.*` API surface
+  and the v2 Arrow Flight section, and fixed the landing page and navigation.
+  (#417–#436)
+
+### Changed
+
+- Routine dependency and CI maintenance: Rust crate updates (`reqwest`,
+  `mockall`, `criterion`, `itertools`), Python dev-dependency updates
+  (`black`, `faker`, `pytest-cov`, `pre-commit`, `graphql-core`), and
+  GitHub Actions bumps.
+
 ## [1.23.11] - 2026-06-14
 
 ### Fixed

--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -155,7 +155,7 @@ name = "fraiseql_rs"
 publish = false
 readme = "README.md"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "1.23.11"
+version = "1.23.12"
 
 # Benchmark profile for accurate measurements
 [profile.bench]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.23.11"
+version = "1.23.12"
 
 [project.optional-dependencies]
 all = [

--- a/tests/integration/fastapi/test_issue_448_multi_field_find_one.py
+++ b/tests/integration/fastapi/test_issue_448_multi_field_find_one.py
@@ -188,9 +188,9 @@ class TestIssue448MultiFieldFindOne:
         """Reporter's exact shape: object field + scalar count (Bug A + Bug B).
 
         Selects typed columns (id/name). The response also carries ``__typename`` (normal
-        FraiseQL behaviour), so assert on values rather than an exact key set. (Whether
-        JSONB-derived sub-fields project through the multi-field path is a separate
-        concern from the #448 crash and is not asserted here.)
+        FraiseQL behaviour), so assert on values rather than an exact key set. Projection
+        of the JSONB-derived ``color`` sub-field through the multi-field path is guarded
+        separately by ``test_multi_field_preserves_jsonb_subfield`` (issue #460).
         """
         body = self._post(app, "{ widget { id name } widgetsCount }")
 
@@ -200,6 +200,45 @@ class TestIssue448MultiFieldFindOne:
         assert data["widget"]["id"] in {_W1, _W2}
         assert data["widget"]["name"] in {"Alpha", "Beta"}
         assert data["widgetsCount"] == 2
+
+    @pytest.mark.asyncio
+    async def test_multi_field_preserves_jsonb_subfield(
+        self, class_db_pool, setup_data, app
+    ) -> None:
+        """Regression guard for issue #460: a JSONB-derived scalar sub-field must survive.
+
+        ``color`` is sourced from ``data->>'color'`` (JSONB-derived), unlike the typed
+        ``id``/``name`` columns. #460 suspected the multi-field path — where find_one's
+        field-only projection is *re-projected* by ``build_multi_field_response`` — dropped
+        JSONB-derived sub-fields while keeping typed columns, so the same object would come
+        back complete in a single-field query but partial next to a sibling field.
+
+        Verified against real PostgreSQL: it does not drop them. ``color`` projects through
+        both the single-field and the multi-field double-projection identically. This test
+        locks that in so the double-projection can't silently regress.
+
+        Row order from ``find_one`` (LIMIT 1, no ORDER BY) is unspecified, so the returned
+        ``color`` is validated against the row's own ``id`` rather than cross-comparing the
+        two responses.
+        """
+        color_by_id = {_W1: "red", _W2: "blue"}
+
+        single = self._post(app, "{ widget { id name color } }")
+        multi = self._post(app, "{ widget { id name color } widgetsCount }")
+
+        assert "errors" not in single, single
+        assert "errors" not in multi, multi
+
+        single_widget = single["data"]["widget"]
+        multi_widget = multi["data"]["widget"]
+
+        # Baseline: single-field mode has always projected the JSONB-derived sub-field.
+        assert single_widget["color"] == color_by_id[single_widget["id"]]
+
+        # The #460 concern: the sub-field must NOT be dropped alongside a sibling field.
+        assert "color" in multi_widget, f"color dropped in multi-field response: {multi_widget}"
+        assert multi_widget["color"] == color_by_id[multi_widget["id"]]
+        assert multi["data"]["widgetsCount"] == 2
 
     @pytest.mark.asyncio
     async def test_find_one_plus_list_sibling(self, class_db_pool, setup_data, app) -> None:


### PR DESCRIPTION
Release **v1.23.12** — a patch release bundling the unreleased bug fixes, security dependency remediation, and the v1-only documentation overhaul since v1.23.11, plus a new regression guard.

## Version bump
- `pyproject.toml` + `fraiseql_rs/Cargo.toml`: `1.23.11` → `1.23.12`
- `CHANGELOG.md`: added the `1.23.12` section

## What's in this release (all patch-level — no API changes)

### Fixed
- Multi-field GraphQL queries no longer crash when a `find_one()`-backed field is combined with a scalar sibling (#448).

### Security
- Remediated 21 Dependabot alerts (pillow/pyasn1/soupsieve/langsmith/setuptools/pypdf/pydantic-settings) (#445)
- Bumped `cryptography`/`starlette` (#412) and `aiohttp` (#411) to resolve advisories.

### Documentation
- Overhauled `docs/` for v1: removed v2-only content, rewrote the remaining guides/tutorials/reference/config, removed the fictional `@FraiseQL.*` API surface and the Arrow Flight section (#417–#436).

### Changed
- Routine Rust/Python dependency and CI maintenance.

## Also included: #460 regression guard
`test(multi-field)` adds `test_multi_field_preserves_jsonb_subfield`, an end-to-end guard confirming a JSONB-derived scalar sub-field (`color` from `data->>'color'`) projects through the multi-field double-projection. Investigation against real PostgreSQL showed **#460 does not reproduce on `dev`** — scalar JSONB sub-fields project correctly in both single- and multi-field mode. No source change; the test locks the behaviour in.

## Verification
- ✅ `make release-check`: 3410 unit tests pass, ruff clean, `pyproject`==`Cargo.toml`==1.23.12
- ✅ `make release-build`: wheel `fraiseql-1.23.12` built, `twine check` passed
- ✅ #460 integration test suite (5 tests) passes against real PostgreSQL

## Release step (after merge)
Tag `v1.23.12` on the merged commit and push it — `release.yml` builds the wheels, creates the GitHub release, and publishes to PyPI. **Not done in this PR** (holding for review/merge first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)