### PR TITLE
fix(deploy): fetch fraiseql-confiture wheel directly (unbreak container build)

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -28,18 +28,16 @@ COPY pyproject.toml README.md ./
 COPY src ./src
 COPY fraiseql_rs ./fraiseql_rs
 
-# Build fraiseql-confiture wheel first (no cp313-manylinux on PyPI yet)
+# Fetch the fraiseql-confiture wheel. It now publishes cp313 manylinux wheels on
+# PyPI, so `pip wheel` downloads the prebuilt wheel directly (and would still fall
+# back to building one from an sdist if no compatible wheel were available).
+# `build`/`maturin` remain installed for the FraiseQL wheel build in the next step.
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     pip install build maturin && \
     mkdir -p /build/dist && \
-    pip download --no-deps --dest /tmp fraiseql-confiture>=0.1.0 && \
-    cd /tmp && \
-    tar -xzf fraiseql_confiture-*.tar.gz && \
-    cd fraiseql_confiture-*/ && \
-    python -m build --wheel && \
-    mv dist/*.whl /build/dist/
+    pip wheel --no-deps --wheel-dir /build/dist fraiseql-confiture>=0.1.0
 
 # Build FraiseQL wheel
 RUN --mount=type=cache,target=/root/.cache/pip \


### PR DESCRIPTION
## Problem

`deploy.yml`'s **Build & Test Container** job has failed on **every `main` sync since 2026-06-19** (staging/production get skipped as a result). The container build never completed, so no environment has been deployed for ~6 weeks. The PyPI release pipeline is separate and unaffected.

## Root cause

`deploy/docker/Dockerfile` built `fraiseql-confiture` from an sdist, with the comment *"no cp313-manylinux on PyPI yet"*:

```dockerfile
pip download --no-deps --dest /tmp fraiseql-confiture>=0.1.0 && \
cd /tmp && tar -xzf fraiseql_confiture-*.tar.gz && ...
```

That assumption is stale — `fraiseql-confiture` (now 0.38.0) ships a `cp313-cp313-manylinux_2_28_x86_64` **wheel**. `pip download` fetches the `.whl`, no `.tar.gz` exists, and `tar -xzf …tar.gz` aborts with *"Cannot open: No such file or directory"* (exit 2).

## Fix

Replace the download + `tar` + `python -m build` dance with `pip wheel`, which downloads the prebuilt wheel (and still falls back to building from an sdist if no compatible wheel exists). `build`/`maturin` stay installed for the FraiseQL wheel build in the next step.

## Verification

- ✅ Full `docker build -f deploy/docker/Dockerfile --target runtime .` succeeds end-to-end (mirrors CI)
- ✅ confiture 0.38.0 cp313 wheel fetched; `fraiseql-1.23.12` wheel built + installed
- ✅ `import fraiseql` → `1.23.12` and the Rust extension loads inside the runtime image

Unrelated to the v1.23.12 release; this just unbreaks the dormant container-deploy pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)