### PR TITLE
fix(security): bump pymdown-extensions to 11.0.1 (GHSA-9xwg-3r6f-jcx2)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ mkdocs==1.6.1
 mkdocs-material==9.7.6
 
 # Markdown extensions
-pymdown-extensions==10.21.3  # >=10.21.3 fixes GHSA-62q4-447f-wv8h / GHSA-r6h4-mm7h-8pmq
+pymdown-extensions==11.0.1  # >=11.0.1 fixes GHSA-9xwg-3r6f-jcx2 (b64 path traversal); >=10.21.3 fixed GHSA-62q4-447f-wv8h / GHSA-r6h4-mm7h-8pmq
 
 # Optional but useful extensions
 mkdocs-glightbox==0.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ docs = [
   "mkdocs-mermaid2-plugin>=1.2.3",
   "mkdocs-minify-plugin>=0.8.0",
   "mkdocs-redirects>=1.2.2",
-  "pymdown-extensions>=10.21.3",
+  "pymdown-extensions>=11.0.1",
   "sphinx>=9.1.0",
   "sphinx-autodoc-typehints>=3.6.3",
   "sphinx-rtd-theme>=3.1.0"
@@ -145,7 +145,7 @@ docs = [
   "mkdocs>=1.6.1",
   "mkdocs-material>=9.7.6",
   "mkdocs-redirects>=1.2.2",
-  "pymdown-extensions>=10.21.3"
+  "pymdown-extensions>=11.0.1"
 ]
 kms = ["cryptography>=48.0.1"]
 kms-all = [

--- a/uv.lock
+++ b/uv.lock
@@ -850,7 +850,7 @@ requires-dist = [
   {name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0"},
   {name = "pyjwt", extras = ["crypto"], marker = "extra == 'all'", specifier = ">=2.13.0"},
   {name = "pyjwt", extras = ["crypto"], marker = "extra == 'auth0'", specifier = ">=2.13.0"},
-  {name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.3"},
+  {name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0.1"},
   {name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.13.3"},
   {name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3"},
   {name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0"},
@@ -906,7 +906,7 @@ docs = [
   {name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3"},
   {name = "mkdocs-minify-plugin", specifier = ">=0.8.0"},
   {name = "mkdocs-redirects", specifier = ">=1.2.2"},
-  {name = "pymdown-extensions", specifier = ">=10.21.3"},
+  {name = "pymdown-extensions", specifier = ">=11.0.1"},
   {name = "sphinx", specifier = ">=9.1.0"},
   {name = "sphinx-autodoc-typehints", specifier = ">=3.6.3"},
   {name = "sphinx-rtd-theme", specifier = ">=3.1.0"}
@@ -2847,11 +2847,11 @@ dependencies = [
   {name = "pyyaml"}
 ]
 name = "pymdown-extensions"
-sdist = {url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "10.21.3"
+version = "11.0.1"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z"}
+  {url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z"}
 ]
 
 [[package]]


### PR DESCRIPTION
## Triage

Both open Dependabot alerts on `dev` (the default branch) are the **same advisory**, **GHSA-9xwg-3r6f-jcx2** (*medium*), surfaced in two manifests:

| Alert | Manifest |
|---|---|
| #124 | `docs/requirements.txt` |
| #123 | `uv.lock` |

**Advisory:** path traversal in `pymdown-extensions`' `b64` extension — an `<img src>` can read files outside `base_path` during Markdown rendering. **Vulnerable:** `<= 10.21.3`. **Fixed:** `11.0.1` (the advisory lists `11.0.0`, which was never released on PyPI).

**Scope / risk:** `pymdown-extensions` is a **docs-build-only** dependency (a MkDocs Markdown extension), not a runtime dependency of the shipped package. Real-world risk here is low — docs are maintainer-authored, not user-submitted — but it's remediated to match the repo's security posture (cf. #445).

## Fix

- `docs/requirements.txt`: `pymdown-extensions==10.21.3` → `==11.0.1`
- `pyproject.toml`: `pymdown-extensions>=10.21.3` → `>=11.0.1` (both `docs` groups)
- `uv.lock`: `pymdown-extensions` `10.21.3` → `11.0.1`

The lock edit is **surgical and compact-format-preserving** (5-line diff): only `version`, `sdist`, `wheels`, and the two metadata specifiers changed. Hashes verified against PyPI; deps unchanged (`markdown`, `pyyaml`). `mkdocs-material` 9.7.x permits `pymdown-extensions>=10.2` with no upper bound, so 11.x is compatible.

> A full `uv lock` was deliberately avoided — the local uv (0.9.18) rewrites the committed compact lock into the expanded format, producing a 2400-line whole-file reformat that would bury this change and migrate the lock format.

## Verification
- ✅ `uv.lock` valid TOML (258 packages); `pymdown-extensions` locked at `11.0.1`
- ✅ sdist/wheel `sha256` match PyPI digests

## Note (out of scope)
The committed `uv.lock` on `dev` is otherwise **drifted behind several `pyproject.toml` floors** (e.g. it records `graphql-core>=3.2.7` while the manifest requires `>=3.2.11`; also `black`, `faker`, `pre-commit`, `pytest-cov`), and is in the older compact lock format. Worth a separate lock-refresh + format-decision task; intentionally not bundled here to keep this security fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)