### PR TITLE
fix(mapping): one column resolver for GROUP BY/WHERE/ORDER BY, and clear the security backlog (1.24.0)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,9 +16,16 @@
 .DS_Store
 
 # Build artifacts
-target/
+# `target/` alone matches only a top-level directory — the Rust crate's own
+# fraiseql_rs/target/ (21 GB of local dev artifacts) was being copied into the
+# build context, which is what made `docker build` run out of disk.
+**/target/
 dist/
 build/
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
 *.o
 *.a
 *.so
@@ -27,6 +34,8 @@ build/
 # Dependencies
 node_modules/
 vendor/
+.venv/
+venv/
 
 # Documentation
 docs/

--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -17,10 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Pull latest base images
+      # Only the base image we actually ship. gcr.io/distroless/python3-debian12
+      # used to be pulled and scanned here after it had already been dropped from
+      # the container-security matrix in security-compliance.yml — so its findings
+      # raised alerts for an image nothing builds from. See
+      # security-assessment-2025-12-09-distroless.md for that decision.
+      - name: Pull latest base image
         run: |
           docker pull python:3.13-slim
-          docker pull gcr.io/distroless/python3-debian12:nonroot
 
       - name: Scan python:3.13-slim
         run: |
@@ -32,16 +36,6 @@ jobs:
             python:3.13-slim
         continue-on-error: true
 
-      - name: Scan gcr.io/distroless/python3-debian12:nonroot
-        run: |
-          docker run --rm aquasec/trivy:latest image \
-            --severity HIGH,CRITICAL \
-            --format json \
-            --output /tmp/distroless-scan.json \
-            --exit-code 0 \
-            gcr.io/distroless/python3-debian12:nonroot
-        continue-on-error: true
-
       - name: Check for new HIGH/CRITICAL vulnerabilities
         id: check-vulns
         run: |
@@ -49,17 +43,12 @@ jobs:
           SLIM_CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' /tmp/slim-scan.json || echo 0)
           SLIM_HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' /tmp/slim-scan.json || echo 0)
 
-          DISTROLESS_CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' /tmp/distroless-scan.json || echo 0)
-          DISTROLESS_HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' /tmp/distroless-scan.json || echo 0)
-
           echo "slim_critical=$SLIM_CRITICAL" >> $GITHUB_OUTPUT
           echo "slim_high=$SLIM_HIGH" >> $GITHUB_OUTPUT
-          echo "distroless_critical=$DISTROLESS_CRITICAL" >> $GITHUB_OUTPUT
-          echo "distroless_high=$DISTROLESS_HIGH" >> $GITHUB_OUTPUT
 
           # Determine alert level
-          TOTAL_CRITICAL=$((SLIM_CRITICAL + DISTROLESS_CRITICAL))
-          TOTAL_HIGH=$((SLIM_HIGH + DISTROLESS_HIGH))
+          TOTAL_CRITICAL=$SLIM_CRITICAL
+          TOTAL_HIGH=$SLIM_HIGH
 
           if [ "$TOTAL_CRITICAL" -gt 0 ]; then
             echo "alert_level=CRITICAL" >> $GITHUB_OUTPUT
@@ -82,10 +71,6 @@ jobs:
           ## python:3.13-slim
           - 🔴 Critical: $SLIM_CRITICAL
           - 🟠 High: $SLIM_HIGH
-
-          ## gcr.io/distroless/python3-debian12:nonroot
-          - 🔴 Critical: $DISTROLESS_CRITICAL
-          - 🟠 High: $DISTROLESS_HIGH
 
           ## Action Required
           EOF
@@ -274,14 +259,17 @@ jobs:
           ## Current Security Posture
 
           ### Container Security
-          - Base images scanned for HIGH/CRITICAL vulnerabilities
-          - Distroless migration: In progress (Phase 1)
+          - Base image scanned for HIGH/CRITICAL vulnerabilities: python:3.13-slim
+          - Base image: python:3.13-slim. Distroless was evaluated and rejected —
+            see security-assessment-2025-12-09-distroless.md
+          - Runtime image carries no curl, no pip and no setuptools
           - Security hardening: Enabled (non-root, read-only filesystem compatible)
 
           ### Vulnerability Management
-          - Active monitoring: 4 MEDIUM CVEs (awaiting vendor patches)
-          - Accepted risks: Documented in .trivyignore with justifications
+          - Accepted risks: Documented in .trivyignore with a justification each
           - Patching SLA: < 7 days for HIGH/CRITICAL
+          - Remaining findings are base-OS packages with no upstream fix; the
+            per-run counts are in the scan-base-images job, not restated here
 
           ### Compliance Status
           - ✅ NIS2 Article 21 (Risk Management): Documented risk analysis
@@ -291,7 +279,7 @@ jobs:
 
           ## Next Steps
           1. Continue weekly CVE monitoring
-          2. Complete distroless migration (Phase 2-3)
+          2. Re-evaluate distroless when a Python 3.13 image exists
           3. Implement runtime security monitoring (Falco)
           4. Quarterly penetration testing
 

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -274,11 +274,22 @@ jobs:
     # in pip-audit's schema (it emits `.dependencies[].vulns[]` and carries no
     # severity at all), so the filter matched nothing and the job stayed green
     # through ten open HIGH advisories.
+    #
+    # The third fault, visible only once the exit code stopped being swallowed:
+    # `uv run pip-audit` failed to spawn, because pip-audit is declared nowhere in
+    # pyproject.toml. The job had never audited anything.
+    #
+    # It now audits the *locked* surface rather than whatever `uv pip install`
+    # happens to resolve on the runner, and runs the auditor with `uvx` so that
+    # pip-audit's own dependency tree does not become part of the surface it is
+    # auditing.
     - name: Audit Python dependencies
       run: |
-        uv venv
-        uv pip install ".[dev,all]"
-        uv run pip-audit --format json --output audit-results.json
+        uv export --all-extras --no-emit-project \
+          --format requirements-txt -o audit-requirements.txt
+        uvx --from 'pip-audit>=2.10.1' pip-audit \
+          --requirement audit-requirements.txt \
+          --format json --output audit-results.json
 
     # Only reached when pip-audit exits 0. Re-reads the report so a schema change
     # upstream shows up as a disagreement between the two rather than as silence.

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -251,26 +251,34 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v7
 
+    # pip-audit exits non-zero when it finds anything, and that exit code is what
+    # makes this job authoritative. It used to be swallowed by `|| true`, and the
+    # step below then filtered on `.vulnerabilities[].severity` — neither key exists
+    # in pip-audit's schema (it emits `.dependencies[].vulns[]` and carries no
+    # severity at all), so the filter matched nothing and the job stayed green
+    # through ten open HIGH advisories.
     - name: Audit Python dependencies
       run: |
         uv venv
         uv pip install ".[dev,all]"
-        uv run pip-audit --format json --output audit-results.json || true
+        uv run pip-audit --format json --output audit-results.json
 
-    - name: Check for critical vulnerabilities
+    # Only reached when pip-audit exits 0. Re-reads the report so a schema change
+    # upstream shows up as a disagreement between the two rather than as silence.
+    - name: Confirm the audit report is clean
+      if: success()
       run: |
-        if [ -f audit-results.json ]; then
-          # Check for CRITICAL or HIGH severity vulnerabilities
-          if jq -e '.vulnerabilities[] | select(.severity == "CRITICAL" or .severity == "HIGH")' audit-results.json > /dev/null; then
-            echo "🚨 Critical or high-severity vulnerabilities found!"
-            jq '.vulnerabilities[] | select(.severity == "CRITICAL" or .severity == "HIGH")' audit-results.json
-            exit 1
-          else
-            echo "✅ No critical or high-severity vulnerabilities found"
-          fi
-        else
-          echo "⚠️  pip-audit did not generate results file"
+        if [ ! -f audit-results.json ]; then
+          echo "❌ pip-audit did not generate a results file"
+          exit 1
         fi
+        vulnerable=$(jq '[.dependencies[] | select(.vulns | length > 0)] | length' audit-results.json)
+        if [ "$vulnerable" -gt 0 ]; then
+          echo "🚨 $vulnerable package(s) with known advisories, but pip-audit exited 0:"
+          jq '.dependencies[] | select(.vulns | length > 0) | {name, version, vulns: [.vulns[] | {id, aliases, fix_versions}]}' audit-results.json
+          exit 1
+        fi
+        echo "✅ No known advisories in the declared dependency surface"
 
     - name: Upload audit results
       uses: actions/upload-artifact@v7

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -193,19 +193,36 @@ jobs:
          echo "- Unpatched vulnerabilities: $UNPATCHED" >> security-report.md
          echo "" >> security-report.md
 
-         # Government compliance gate
+         # Government compliance gate.
+         #
+         # Policy, stated rather than implied:
+         #   CRITICAL, any package        -> fail
+         #   HIGH in a *language* package -> fail. These are ours: they come from
+         #                                   the wheel we build, so there is
+         #                                   always something to bump.
+         #   HIGH in an *OS* package      -> report, do not fail. Debian trixie
+         #                                   routinely carries HIGHs with
+         #                                   FixedVersion=none; failing on them
+         #                                   would make this job permanently red
+         #                                   and therefore ignored. Each accepted
+         #                                   one is justified in .trivyignore.
+         #
+         # Anything already suppressed by .trivyignore never reaches these counts.
+         LANG_HIGH=$(jq '[.Results[]? | select(.Class=="lang-pkgs") | .Vulnerabilities[]? | select(.Severity=="HIGH")] | length' trivy-${{ matrix.dockerfile.label }}-detailed.json)
+         OS_HIGH=$((HIGH - LANG_HIGH))
+
          if [ "$CRITICAL" -gt 0 ]; then
            echo "❌ CRITICAL vulnerabilities found - Government compliance FAILED"
            echo "**Status**: ❌ Non-compliant (Critical vulnerabilities present)" >> security-report.md
            exit 1
-         elif [ "$HIGH" -gt 0 ]; then
-           echo "⚠️  HIGH severity vulnerabilities found - Review required"
-           echo "**Status**: ⚠️  Review Required (High severity vulnerabilities)" >> security-report.md
-           # Don't fail for HIGH in base OS packages if documented in .trivyignore
-           if [ "${{ matrix.dockerfile.label }}" == "Distroless (Production)" ]; then
-             echo "Distroless image - HIGH vulnerabilities acceptable if in .trivyignore"
-             exit 0
-           fi
+         elif [ "$LANG_HIGH" -gt 0 ]; then
+           echo "❌ $LANG_HIGH HIGH-severity vulnerabilities in language packages - these are fixable"
+           jq '.Results[]? | select(.Class=="lang-pkgs") | .Vulnerabilities[]? | select(.Severity=="HIGH") | {PkgName, VulnerabilityID, InstalledVersion, FixedVersion}' trivy-${{ matrix.dockerfile.label }}-detailed.json
+           echo "**Status**: ❌ Non-compliant ($LANG_HIGH high-severity findings in language packages)" >> security-report.md
+           exit 1
+         elif [ "$OS_HIGH" -gt 0 ]; then
+           echo "⚠️  $OS_HIGH HIGH-severity vulnerabilities in base-OS packages - review required, not a gate"
+           echo "**Status**: ⚠️  Review Required ($OS_HIGH high-severity base-OS findings)" >> security-report.md
          else
            echo "✅ Container meets government security standards"
            echo "**Status**: ✅ Compliant" >> security-report.md

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,5 @@
 # Trivy Vulnerability Exceptions for International Compliance
-# Last Updated: 2026-07-23  (re-baselined for python:3.13-slim -> Debian 13 trixie)
+# Last Updated: 2026-08-30  (re-baselined after removing curl and pip from the runtime stage)
 # Review Schedule: Monthly
 # Approval: Security Team
 # Compliance: US (NIST/FedRAMP), EU (NIS2/GDPR), UK (NCSC), ISO 27001, SOC 2
@@ -233,13 +233,47 @@ CVE-2025-69720 # ncurses (HIGH)
 # gzip - not used to decompress untrusted input at runtime
 CVE-2026-41992 # gzip (HIGH)
 
-# util-linux / mount / login / lib{blkid,mount,uuid,smartcols}1 / bsdutils / liblastlog2-2
-CVE-2026-53615 # util-linux (HIGH) - mount/login utilities not exposed by the API server
-
 # libacl1 - POSIX ACL library not driven by untrusted input
 CVE-2026-54369 # libacl1 (HIGH)
 
+# -----------------------------------------------------------------------------
+# CATEGORY 8: Added 2026-08-30, verified against the current runtime image
+# Scan: `trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM,LOW` on the
+#   image built from `Dockerfile --target runtime` at 1.23.12. Each entry below
+#   was confirmed present, with FixedVersion=none, in that scan.
+# Review: Monthly. Remove the moment Debian trixie publishes a fixed version.
+# -----------------------------------------------------------------------------
 
+# libsqlite3-0 (HIGH, no fix) - both are in SQLite's FTS5 full-text extension.
+# FraiseQL v1 queries PostgreSQL exclusively: nothing under src/fraiseql imports
+# aiosqlite or sqlite3 outside an unwired startup check, and no code path creates
+# or queries an FTS5 virtual table. libsqlite3-0 is present only because the
+# python:3.13-slim base compiles the stdlib sqlite3 module against it.
+CVE-2026-11822 # libsqlite3-0 (HIGH) - FTS5 full-text search; no FTS5 table is ever created
+CVE-2026-11824 # libsqlite3-0 (HIGH) - FTS5 heap overflow; same precondition
+
+# libsystemd0 / libudev1 - the container runs no init system. systemd-homed is
+# not installed, and the process-kill path needs a local session on the host.
+CVE-2026-16742 # libsystemd0 (MEDIUM) - systemd-homed not present in the image
+CVE-2026-15059 # libsystemd0 (MEDIUM) - requires a local session; container runs one non-root process
+
+# linux-pam - pam_userdb is not configured; the image authenticates nobody.
+CVE-2026-54411 # libpam-modules (MEDIUM) - pam_userdb unused
+
+
+# -----------------------------------------------------------------------------
+# NOT suppressed, deliberately — checked 2026-08-30
+# -----------------------------------------------------------------------------
+#
+# CVE-2026-14456 (OpenSSL, QUIC server unbounded memory) is NOT listed here.
+# It does not appear in a scan of the current runtime image at all, so a
+# suppression for it would be a stale entry from the day it was written.
+#
+# Everything still reported after this file is applied has FixedVersion=none —
+# there is no un-suppressed finding that we could fix and have not. The list is
+# left visible on purpose: a base-OS CVE with no upstream patch is a thing to
+# watch, not a thing to hide.
+#
 # =============================================================================
 # DISTROLESS IMAGE CVEs (Reference Only - Not Currently Used)
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,118 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.0] - 2026-08-30
+
+### Fixed
+
+- **Partial-period aggregate queries silently dropped `OR` and `NOT` filter
+  groups, returning too many rows.** On the `UNION ALL` path a coarse view takes
+  when it has `fine_grain_view` metadata and the query carries a date lower
+  bound, the WHERE clause was rebuilt from its top-level conditions alone —
+  discarding every nested group. When the date bound was the *only* top-level
+  condition it failed open completely: both branches ran with no filter beyond
+  the date range. `mandatory_filters` (#344) was never affected, being injected
+  as flat conditions; a deployment that expresses a tenant or authorization
+  scope through an `OR` group rather than `mandatory_filters` was. (#468)
+- **A date bound that is not a top-level conjunct no longer triggers the
+  partial-period rewrite.** `date >= X OR status = 'a'` was rewritten into
+  `date in [branch] AND status = 'a'`, dropping every row that matched on the
+  date alone. Such queries now take the correct single-statement path. (#468)
+- **`order_by` is no longer discarded on the partial-period path.** It was never
+  passed to the UNION builder, so the statement always ended in `ORDER BY 1` —
+  a positional sort on the serialized JSON — whatever the caller asked for.
+  (#468)
+- **A declared column mapping is now applied to `WHERE` predicates, not only to
+  `GROUP BY`.** A query could group on the flat column while filtering on the
+  JSONB snapshot. (#467)
+- **A mapping key that matches no field now fails at registration** instead of
+  silently doing nothing. Keys accept either the GraphQL or the database
+  spelling and are normalised segment-wise to `snake_case`, so a mapping written
+  for the Rust engine (`dimensions.dateInfo.date`) works here unchanged — it
+  previously matched nothing, with no error, because the key was a valid path
+  and the value a real column. (#467)
+
+### Added
+
+- **`column_mapping=` on `register_type_for_view`** — a top-level peer of
+  `fk_relationships` that maps a dotted field path to a flat SQL column, applied
+  unconditionally to `GROUP BY`, `WHERE` and `ORDER BY` alike.
+  `aggregation["native_dimension_mapping"]` is superseded: it keeps working and
+  feeds the same resolver, and `column_mapping=` wins where both declare the
+  same path. (#467)
+
+### Changed
+
+- **Ordering on a mapped dimension path now sorts on the flat column.** The
+  visible effect is **NULL placement**: a jsonb `null` is the lowest jsonb value
+  and sorts first, while a SQL `NULL` sorts last in `ASC`, so any row with a
+  missing or null mapped dimension moves from one end of the result to the
+  other. Non-null values keep their order for the shapes this library produces —
+  ISO dates sort lexicographically in chronological order by construction, and
+  the generator uses `->` rather than `->>` so a JSON number keeps its type.
+  Values do reorder where the snapshot is untyped: a number written as a string,
+  or an ISO timestamp whose rows do not share one UTC offset. (#467)
+- **Filtering on a mapped path reads the flat column.** Where the column and the
+  frozen JSONB snapshot disagree, results change. This is a correction, and it
+  is observable — which is why this is a minor release, not a patch. (#467)
+
+### Security
+
+Fifteen Dependabot advisories across five packages, with the exposure stated
+rather than implied:
+
+| Package | Advisories | Where it sits |
+|---|---|---|
+| `sqlparse` 0.5.5 → 0.6.0 | 4 (ReDoS ×2, quadratic grouping, backslash breakout) | Was declared as a runtime dependency but **imported nowhere in `src/`** — only by a script that already degrades without it. Moved to the `dev` group. |
+| `nltk` 3.9.4 → 3.10.3 | 5 (path traversal ×3, DNS-rebinding SSRF, ReDoS) | Optional: transitive through the `llamaindex` extra. Not in a default install. |
+| `pypdf` 6.14.2 → 6.16.2 | 2 (memory, runtime) | Optional: declared by the `llamaindex` extra. |
+| `cryptography` 49.0.0 → 50.0.1 | 1 (Bleichenbacher oracle, PKCS#7 `EnvelopedData`) | Not code FraiseQL calls — the only cryptography API it uses is AES-GCM in the KMS key manager. But `pyjwt[crypto]` puts the package in **every** install, so the floor is now declared on `project.dependencies` and not just on the `kms` extras. |
+| `aiohttp` 3.14.1 → 3.14.3 | 3 (OOB heap read, request smuggling, unnegotiated WS frames) | Optional: `dev` extra, transitive via `llama-index-core`. |
+
+- `click` 8.3.1 → 8.5.0 for PYSEC-2026-2132 / CVE-2026-7246, command injection
+  in `click.edit()`. FraiseQL's CLI never calls it; the floor moved because the
+  package is core. This was **not** a Dependabot alert — it is what the
+  dependency-audit job found on its first honest run, see below.
+- **The `dependency-audit` CI job was vacuously green.** `pip-audit ... || true`
+  swallowed its exit code, and the follow-up check filtered on
+  `.vulnerabilities[].severity` — pip-audit emits `.dependencies[].vulns[]` and
+  carries no severity field, so the filter matched nothing and printed
+  "✅ No critical or high-severity vulnerabilities found" through ten open HIGH
+  advisories. pip-audit's exit code is now authoritative.
+
+Container attack surface, measured on the image built from
+`Dockerfile --target runtime` with the same Trivy invocation CI uses:
+
+|        | findings | CRITICAL | HIGH | MEDIUM | LOW |
+|--------|----------|----------|------|--------|-----|
+| before | 139      | 0        | 13   | 76     | 50  |
+| after  | 81       | 0        | 0    | 43     | 38  |
+
+- **`curl` removed from the runtime image.** It existed only to answer the
+  `HEALTHCHECK`, which now probes with the interpreter already in the image.
+  libcurl, libssh2, libnghttp2, libp11-kit and libgnutls go with it.
+- **`pip` and `setuptools` removed from the runtime image**, in the same layer
+  that installs the wheel. That also removes the only msgpack in the image,
+  which was `pip/_vendor/msgpack` rather than a resolved dependency.
+- The krb5 and openldap findings **remain**: they are `libpq5`'s dependencies,
+  not curl's, and a test now pins that so a future reduction cannot trade
+  PostgreSQL connectivity for a lower alert count.
+- `.trivyignore` re-baselined; `security-alerts.yml` no longer scans a
+  distroless image that was dropped from the build matrix months ago; the
+  compliance gate now states its policy and fails on HIGH findings in language
+  packages, which are the ones we can actually fix.
+
+### Internal
+
+- One resolver, `fraiseql.sql.native_columns.resolve_native_column`, now answers
+  "does this field path have a flat SQL column?" for `GROUP BY`, `WHERE` and
+  `ORDER BY`. It had been spelled six different ways across three `build_field`
+  closures, three `is_native` checks and the ORDER BY generator, which is how a
+  new rule reached some of them and not others.
+- `.dockerignore`: `target/` → `**/target/`. The bare pattern matches only a
+  top-level directory, so `fraiseql_rs/target/` was being copied into the build
+  context and `docker build` ran out of disk before reaching the runtime stage.
+
 ## [1.23.12] - 2026-07-28
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ LABEL org.opencontainers.image.source="https://github.com/fraiseql/fraiseql-pyth
 # Install runtime dependencies and security updates
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     libpq5 \
-    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
@@ -58,13 +57,19 @@ WORKDIR /app
 
 # Copy wheel from builder and install
 COPY --from=builder /build/dist/*.whl /tmp/
+# pip and setuptools are build tooling: the wheel is installed here and the
+# entrypoint is gunicorn, so nothing at runtime needs either. They are removed in
+# the *same* layer — a separate RUN would leave the old copies in the image
+# history, where Trivy still finds them. pip's vendored msgpack goes with it,
+# which is the only msgpack in the image.
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install \
     /tmp/*.whl \
     uvicorn[standard] \
     gunicorn \
     prometheus-client \
-    && rm -rf /tmp/*.whl
+    && rm -rf /tmp/*.whl \
+    && pip uninstall -y pip setuptools 2>/dev/null || true
 
 # Copy entrypoint script
 COPY deploy/docker/entrypoint.sh /usr/local/bin/
@@ -76,8 +81,11 @@ USER fraiseql
 
 EXPOSE 8000
 
+# Probed with the interpreter that is already in the image. `curl` was the only
+# reason the runtime stage installed it, and curl + libcurl + libssh2 account for
+# ~40 of the container-security alerts on their own.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD ["python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health', timeout=2).status == 200 else 1)"]
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -57,7 +57,6 @@ LABEL org.opencontainers.image.description="Production-ready GraphQL-to-PostgreS
 # CVE Fixes: CVE-2025-14104, CVE-2025-6141, CVE-2024-56433
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     libpq5 \
-    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
@@ -70,6 +69,11 @@ WORKDIR /app
 COPY --from=builder /build/dist/*.whl /tmp/
 
 # Install FraiseQL and production dependencies
+# pip and setuptools are build tooling: the wheel is installed here and the
+# entrypoint is gunicorn, so nothing at runtime needs either. They are removed in
+# the *same* layer — a separate RUN would leave the old copies in the image
+# history, where Trivy still finds them. pip's vendored msgpack goes with it,
+# which is the only msgpack in the image.
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install \
     /tmp/*.whl \
@@ -81,7 +85,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     opentelemetry-exporter-otlp \
     opentelemetry-instrumentation-fastapi \
     opentelemetry-instrumentation-psycopg \
-    && rm -rf /tmp/*.whl
+    && rm -rf /tmp/*.whl \
+    && pip uninstall -y pip setuptools 2>/dev/null || true
 
 # Copy entrypoint script
 COPY deploy/docker/entrypoint.sh /usr/local/bin/
@@ -97,8 +102,11 @@ USER fraiseql
 EXPOSE 8000
 
 # Health check
+# Probed with the interpreter that is already in the image. `curl` was the only
+# reason the runtime stage installed it, and curl + libcurl + libssh2 account for
+# ~40 of the container-security alerts on their own.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD ["python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health', timeout=2).status == 200 else 1)"]
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/docs/specs/aggregation-operators.md
+++ b/docs/specs/aggregation-operators.md
@@ -92,10 +92,34 @@ register_type_for_view(
         "dimensions": "dimensions",
         "native_dimensions": ["period_date", "category_id"],
         "native_measures": {"measures.quantity": "quantity"},
-        "native_dimension_mapping": {"dimensions.category.id": "category_id"},
+    },
+    column_mapping={
+        "dimensions.dateInfo.date": "period_date",
+        "dimensions.productCategory.id": "category_id",
     },
 )
 ```
+
+### Mapping key spelling
+
+Mapping keys are matched against **database** field paths, and each segment is
+normalised to `snake_case` at registration — so the two spellings below declare the
+same thing and both work:
+
+```python
+column_mapping={"dimensions.dateInfo.date": "period_date"}    # GraphQL spelling
+column_mapping={"dimensions.date_info.date": "period_date"}   # database spelling
+```
+
+This matters because the example above used to read
+`{"dimensions.category.id": "category_id"}` — every segment a single word, so the
+question never came up. A key like `dimensions.dateInfo.date` written against an engine
+that matches the raw GraphQL name would previously have matched nothing here, silently:
+the value is a real column and the key is a valid path, so no validation caught it and
+the mapping simply never fired. That is issue #467.
+
+A key that names a column which does not exist on the view now raises at registration
+under `validate_fk_strict=True`, and warns otherwise.
 
 Metadata keys:
 
@@ -108,12 +132,40 @@ Metadata keys:
   correct for dimension columns.
 - `native_measures` — maps JSONB measure paths to flat SQL column names so `SUM`/`AVG`
   run on native numeric columns and skip the `::numeric` cast.
-- `native_dimension_mapping` — maps deep JSONB dimension paths to flat SQL columns so
-  `GROUP BY` can use native columns even for nested dimension paths.
+- `native_dimension_mapping` — **superseded by the top-level `column_mapping=` below.**
+  Still read, still merged, still works; `column_mapping=` wins where both declare the
+  same path. Prefer the top-level parameter in new code.
+
+The top-level `column_mapping=` parameter on `register_type_for_view` is a peer of
+`fk_relationships`: it maps a deep JSONB path to a flat SQL column, and it is applied
+unconditionally to **`GROUP BY`, `WHERE` and `ORDER BY` alike**. Before 1.24.0 the
+mapping reached `GROUP BY` only, so a query could group on the flat column while
+filtering and sorting on the JSONB snapshot — three expressions for one logical field.
 
 Use `native_dimensions` whenever your view exposes a real SQL column for a grouping key:
 it is the difference between a sequential scan over extracted JSONB text and an
 index-backed `GROUP BY`.
+
+### Migrating an existing `native_dimension_mapping` (1.24.0)
+
+Nothing to change: the key is still read and still merged. What changes is that the
+mapping you already declared now also applies to `WHERE` and `ORDER BY`, so two things
+become visible:
+
+- **Filtering results can change.** Where the flat column and the frozen JSONB snapshot
+  disagree — a column updated after the snapshot was written, say — the filter now
+  follows the column. That is the correction, and it is the reason 1.24.0 is a minor
+  release rather than a patch.
+- **NULLs move in a sort.** A jsonb `null` is the lowest jsonb value and sorts first; a
+  SQL `NULL` sorts last in `ASC`. Any row with a missing or null mapped dimension moves
+  from one end of the result to the other. The non-null *values* keep their order for
+  the shapes this library produces — ISO dates sort lexicographically in chronological
+  order by construction, and the generator uses `->` rather than `->>` so a JSON number
+  keeps its type. Values do reorder where the snapshot is untyped: a number written as
+  a string, or an ISO timestamp whose rows do not share one UTC offset.
+
+If a mapping key you declared never took effect because of the casing rule above, it
+will start working — check the key names before upgrading if you are unsure.
 
 ---
 

--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -152,7 +152,7 @@ name = "fraiseql_rs"
 publish = false
 readme = "README.md"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "1.23.12"
+version = "1.24.0"
 
 # Benchmark profile for accurate measurements
 [profile.bench]

--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -45,9 +45,9 @@ deadpool-postgres = "0.14"
 graphql-parser = "0.4"
 hex = "0.4"  # Hex encoding for tokens
 http = "1.4"  # HTTP header types for CORS
-itertools = "0.14"  # String utilities
+itertools = "0.15"  # String utilities
 # Authentication (Phase 10)
-jsonwebtoken = "10.3"  # JWT validation with built-in JWK support. Updated from 9.2 to fix CVE-2026-25537 (type confusion/auth bypass)
+jsonwebtoken = "11.0"  # JWT validation with built-in JWK support. Updated from 9.2 to fix CVE-2026-25537 (type confusion/auth bypass)
 lazy_static = "1.4"  # Static regex
 linked-hash-map = "0.5"  # For LRU implementation
 # Query caching (Phase 8)
@@ -79,15 +79,12 @@ criterion = {version = "0.8", features = ["async_tokio", "html_reports"]}
 # Legacy benchmarking infrastructure
 dhat = "0.3"  # Heap profiling
 # Mocking
-mockall = "0.14"  # Mock objects for unit tests
+mockall = "0.15"  # Mock objects for unit tests
 pretty_assertions = "1.4"  # Pretty-print assertion failures
 # Property testing
 proptest = "1.0"  # Generate test cases
 # Testing
 pyo3 = {version = "0.29.0", features = ["auto-initialize"]}
-# Test database containers
-testcontainers = "0.15"  # Docker containers for tests
-testcontainers-modules = {version = "0.2", features = ["postgres"]}
 tokio = {version = "1.0", features = ["full"]}
 # Testing framework
 tokio-test = "0.4"  # Async runtime for tests

--- a/fraiseql_rs/src/core/camel.rs
+++ b/fraiseql_rs/src/core/camel.rs
@@ -143,11 +143,10 @@ unsafe fn find_underscores_avx2(input: &[u8]) -> UnderscoreMask {
     let underscore_vec = _mm256_set1_epi8(b'_' as i8);
     let mut mask = UnderscoreMask::new();
 
-    let chunks = input.chunks_exact(32);
+    let (chunks, remainder) = input.as_chunks::<32>();
     let chunks_len = chunks.len();
-    let remainder = chunks.remainder();
 
-    for (chunk_idx, chunk) in chunks.enumerate() {
+    for (chunk_idx, chunk) in chunks.iter().enumerate() {
         let data = _mm256_loadu_si256(chunk.as_ptr() as *const __m256i);
         let cmp = _mm256_cmpeq_epi8(data, underscore_vec);
         let bitmask = _mm256_movemask_epi8(cmp);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
 ]
 docs = [
   "mkdocs>=1.6.1",
-  "mkdocs-material>=9.7.6",
+  "mkdocs-material>=9.7.7",
   "mkdocs-mermaid2-plugin>=1.2.3",
   "mkdocs-minify-plugin>=0.8.0",
   "mkdocs-redirects>=1.2.2",
@@ -57,7 +57,7 @@ dependencies = [
   "graphql-core>=3.2.11",
   "psycopg[pool]>=3.3.3",
   "psycopg-pool>=3.3.0",
-  "uvicorn>=0.49.0",
+  "uvicorn>=0.52.0",
   "pydantic>=2.12.0",
   "pydantic-settings>=2.14.2",
   "httpx>=0.28.0",
@@ -102,12 +102,12 @@ all = [
   "opentelemetry-exporter-otlp>=1.41.1",
   "pyjwt[crypto]>=2.13.0",
   "httpx>=0.28.0",
-  "cyclonedx-python-lib>=11.10.0,<12.0",
+  "cyclonedx-python-lib>=11.11.0,<12.0",
   "packageurl-python>=0.17.0",
   "boto3>=1.38.0",
   "cryptography>=50.0.0",
   "aioboto3>=15.5.0",
-  "google-cloud-kms>=3.11.0",
+  "google-cloud-kms>=3.16.0",
   "fraiseql[langchain]",
   "fraiseql[llamaindex]"
 ]
@@ -128,7 +128,7 @@ dev = [
   "pytest-cov>=7.1.0",
   "pytest-mock>=3.15.0",
   "pytest-benchmark>=5.2.3",
-  "tox>=4.55.1",
+  "tox>=4.58.0",
   "ruff>=0.15.12",
   "ty>=0.0.35",
   "build>=1.4.0",
@@ -144,7 +144,7 @@ dev = [
 ]
 docs = [
   "mkdocs>=1.6.1",
-  "mkdocs-material>=9.7.6",
+  "mkdocs-material>=9.7.7",
   "mkdocs-redirects>=1.2.2",
   "pymdown-extensions>=11.0.1"
 ]
@@ -153,10 +153,10 @@ kms-all = [
   "cryptography>=50.0.0",
   "httpx>=0.28.0",
   "aioboto3>=15.5.0",
-  "google-cloud-kms>=3.11.0"
+  "google-cloud-kms>=3.16.0"
 ]
 kms-aws = ["aioboto3>=15.5.0"]
-kms-gcp = ["google-cloud-kms>=3.11.0"]
+kms-gcp = ["google-cloud-kms>=3.16.0"]
 kms-vault = ["httpx>=0.28.0"]
 langchain = [
   "langchain>=1.3.9",
@@ -174,7 +174,7 @@ llamaindex = [
   "nltk>=3.10.0"
 ]
 llm = ["fraiseql[langchain]", "fraiseql[llamaindex]"]
-sbom = ["cyclonedx-python-lib>=11.10.0,<12.0", "packageurl-python>=0.17.0"]
+sbom = ["cyclonedx-python-lib>=11.11.0,<12.0", "packageurl-python>=0.17.0"]
 tracing = [
   "protobuf>=5.29.0,<8.0",
   "wrapt>=1.16.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.23.12"
+version = "1.24.0"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,11 @@ addopts = [
   "--strict-markers",
   "--strict-config",
   "--disable-warnings",
-  "-ra"
+  "-ra",
+  # Container tests build the runtime image; opt in with `pytest -m container`,
+  # which overrides this default.
+  "-m",
+  "not container"
 ]
 asyncio_mode = "auto"
 # Console output
@@ -270,7 +274,8 @@ markers = [
   "chaos_resources: Chaos tests for resource exhaustion (memory, CPU, disk)",
   "chaos_concurrency: Chaos tests for concurrent execution (deadlocks, race conditions)",
   "chaos_validation: Chaos test validation and success criteria checks",
-  "chaos_verification: Chaos infrastructure verification tests"
+  "chaos_verification: Chaos infrastructure verification tests",
+  "container: Tests that build and run the runtime Docker image (slow, needs Docker)"
 ]
 # Minimum version
 minversion = "9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dev = [
   "testcontainers>=4.14.2",
   "twine>=6.2.0",
   "ty>=0.0.35",
-  "moto[kms]>=5.1.21"
+  "moto[kms]>=5.1.21",
+  "sqlparse>=0.6.0"
 ]
 docs = [
   "mkdocs>=1.6.1",
@@ -61,8 +62,9 @@ dependencies = [
   "pydantic-settings>=2.14.2",
   "httpx>=0.28.0",
   "pyjwt[crypto]>=2.13.0",
+  "cryptography>=50.0.0",
   "python-dateutil>=2.9.0",
-  "click>=8.3.0",
+  "click>=8.3.3",
   "python-dotenv>=1.2.2",
   "structlog>=25.5.0",
   "passlib[argon2]>=1.7.4",
@@ -70,7 +72,6 @@ dependencies = [
   "typer>=0.24.0",
   "rich>=14.0.0",
   "pyyaml>=6.0.2",
-  "sqlparse>=0.5.5",
   "fraiseql-confiture>=0.5.2",
   "jinja2>=3.1.6",
   "urllib3>=2.7.0"
@@ -104,7 +105,7 @@ all = [
   "cyclonedx-python-lib>=11.10.0,<12.0",
   "packageurl-python>=0.17.0",
   "boto3>=1.38.0",
-  "cryptography>=48.0.1",
+  "cryptography>=50.0.0",
   "aioboto3>=15.5.0",
   "google-cloud-kms>=3.11.0",
   "fraiseql[langchain]",
@@ -137,7 +138,7 @@ dev = [
   "email-validator>=2.3.0",
   "hvac>=2.4.0",
   "moto[kms]>=5.1.21",
-  "aiohttp>=3.14.1",
+  "aiohttp>=3.14.3",
   "filelock>=3.24.0",
   "werkzeug>=3.1.6"
 ]
@@ -147,9 +148,9 @@ docs = [
   "mkdocs-redirects>=1.2.2",
   "pymdown-extensions>=11.0.1"
 ]
-kms = ["cryptography>=48.0.1"]
+kms = ["cryptography>=50.0.0"]
 kms-all = [
-  "cryptography>=48.0.1",
+  "cryptography>=50.0.0",
   "httpx>=0.28.0",
   "aioboto3>=15.5.0",
   "google-cloud-kms>=3.11.0"
@@ -169,7 +170,8 @@ llamaindex = [
   "llama-index-core>=0.14.21",
   "banks>=2.4.2",
   "pillow>=12.3.0",
-  "pypdf>=6.13.3"
+  "pypdf>=6.15.0",
+  "nltk>=3.10.0"
 ]
 llm = ["fraiseql[langchain]", "fraiseql[llamaindex]"]
 sbom = ["cyclonedx-python-lib>=11.10.0,<12.0", "packageurl-python>=0.17.0"]

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -752,6 +752,137 @@ def _build_partial_period_union_query(
     return DatabaseQuery(statement=statement, params=all_params, fetch_result=True)
 
 
+def _normalize_aggregation_mapping_keys(aggregation: dict[str, Any]) -> dict[str, Any]:
+    """Return ``aggregation`` with ``native_dimension_mapping`` keys in one spelling.
+
+    Mapping keys are matched against dotted field paths built with
+    ``transform_path=to_snake_case``, so a key in GraphQL spelling
+    (``dimensions.dateInfo.date``) could never match one and the entry would
+    silently never fire. Normalizing each segment at registration accepts both
+    spellings and leaves every consumer looking at the same dict.
+
+    The caller's dict is never mutated: a new dict is returned when anything
+    changed, and the original is returned untouched otherwise.
+    """
+    mapping: dict[str, str] = aggregation.get("native_dimension_mapping") or {}
+    if not mapping:
+        return aggregation
+
+    normalized = {
+        ".".join(to_snake_case(segment) for segment in path.split(".")): column
+        for path, column in mapping.items()
+    }
+    if normalized == mapping:
+        return aggregation
+    return {**aggregation, "native_dimension_mapping": normalized}
+
+
+def _aggregation_mapping_error(
+    view_name: str,
+    meta_key: str,
+    declared: str,
+    column: str,
+    table_columns: set[str],
+) -> str:
+    """Build the message for an aggregation entry naming a non-existent column.
+
+    Mirrors the wording of the ``fk_relationships`` guard so the two read as one
+    voice: what was declared, what is missing, and the two ways to fix it.
+    """
+    subject = (
+        f"Entry '{column}'"
+        if declared == column
+        else f"Path '{declared}' mapped to column '{column}'"
+    )
+    return (
+        f"Invalid {meta_key} for {view_name}: "
+        f"{subject}, but '{column}' not in table_columns: {sorted(table_columns)}. "
+        f"Either add '{column}' to table_columns or fix {meta_key}. "
+        f"To allow this (not recommended), set validate_fk_strict=False."
+    )
+
+
+def _validate_aggregation_mapping(
+    view_name: str,
+    aggregation: dict[str, Any],
+    table_columns: set[str] | None,
+    *,
+    strict: bool,
+) -> None:
+    """Validate that aggregation metadata only names columns that exist.
+
+    ``native_dimension_mapping`` and ``native_measures`` map JSONB paths to flat
+    columns; ``native_dimensions`` names columns directly. A value that is not a
+    real column makes the entry silently dead — the query falls back to JSONB
+    extraction and nothing says why. Same class of declaration as
+    ``fk_relationships``, so the same treatment.
+
+    With no columns registered there is nothing to validate against: warn once
+    naming the view, never raise.
+
+    Args:
+        view_name: The database view the metadata was registered against
+        aggregation: The ``aggregation`` dict from ``register_type_for_view``
+        table_columns: Actual database columns for the view, if known
+        strict: Raise ``ValueError`` when True, log a warning when False
+    """
+    declarations: list[tuple[str, str, str]] = []
+
+    mapping: dict[str, str] = aggregation.get("native_dimension_mapping") or {}
+    declarations += [("native_dimension_mapping", path, col) for path, col in mapping.items()]
+
+    measures: dict[str, str] = aggregation.get("native_measures") or {}
+    declarations += [("native_measures", path, col) for path, col in measures.items()]
+
+    dimensions: list[str] = list(aggregation.get("native_dimensions") or [])
+    declarations += [("native_dimensions", col, col) for col in dimensions]
+
+    if not declarations:
+        return
+
+    if not table_columns:
+        logger.warning(
+            f"No table_columns registered for {view_name} - "
+            f"aggregation mapping validation disabled. Call register_type_for_view()."
+        )
+        return
+
+    for meta_key, declared, column in declarations:
+        if column in table_columns:
+            continue
+        error_msg = _aggregation_mapping_error(view_name, meta_key, declared, column, table_columns)
+        if strict:
+            raise ValueError(error_msg)
+        logger.warning("%s", error_msg)
+
+    _warn_unreachable_mapping_keys(view_name, aggregation)
+
+
+def _warn_unreachable_mapping_keys(view_name: str, aggregation: dict[str, Any]) -> None:
+    """Warn about ``native_dimension_mapping`` keys no dimension path can produce.
+
+    GROUP BY entries are dotted field paths rooted at the configured dimensions
+    prefix, so a key rooted anywhere else can never match one. This is a warning
+    rather than an error: a mapping may legitimately anticipate a field that is
+    not selected by any query yet.
+    """
+    mapping: dict[str, str] = aggregation.get("native_dimension_mapping") or {}
+    if not mapping:
+        return
+
+    prefix: str = aggregation.get("dimensions", "dimensions")
+    accepted_roots = {prefix, to_snake_case(prefix)}
+    for path in mapping:
+        if path.split(".", 1)[0] in accepted_roots:
+            continue
+        logger.warning(
+            f"Unreachable native_dimension_mapping key for {view_name}: "
+            f"'{path}' is not rooted at the configured dimensions prefix '{prefix}', "
+            f"so it can never match a dimension path and will never fire. "
+            f"Either re-root the key at '{prefix}' or fix the 'dimensions' prefix."
+        )
+
+
 def register_type_for_view(
     view_name: str,
     type_class: type,
@@ -794,7 +925,15 @@ def register_type_for_view(
             JSONB-extracted values, avoiding ::numeric casts and improving performance.
             The ``native_dimension_mapping`` key maps deep JSONB dimension paths
             to flat SQL column names, enabling GROUP BY on native columns for
-            complex nested dimension paths.
+            complex nested dimension paths. Its keys accept either spelling —
+            GraphQL (``dimensions.dateInfo.date``) or database
+            (``dimensions.date_info.date``) — and are normalized segment-wise to
+            snake_case at registration, which is the spelling field paths use.
+
+    Raises:
+        ValueError: If ``fk_relationships`` or the aggregation metadata names a
+            column absent from ``table_columns``, unless ``validate_fk_strict``
+            is False (which downgrades both to warnings).
     """
     _type_registry[view_name] = type_class
     logger.debug(f"Registered type {type_class.__name__} for view {view_name}")
@@ -819,6 +958,13 @@ def register_type_for_view(
                     f"Either add '{fk_column}' to table_columns or fix fk_relationships. "
                     f"To allow this (not recommended), set validate_fk_strict=False."
                 )
+
+    # Validate aggregation metadata against real columns (same class as FK)
+    if aggregation:
+        aggregation = _normalize_aggregation_mapping_keys(aggregation)
+        _validate_aggregation_mapping(
+            view_name, aggregation, table_columns, strict=validate_fk_strict
+        )
 
     # Store metadata if provided
     if (

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -2850,6 +2850,60 @@ class FraiseQLRepository:
             f"Available views: {available_views}. Registry size: {len(_type_registry)}",
         )
 
+    def _build_order_by_sql(
+        self,
+        order_by: Any,
+        table_ref: str,
+        native_columns: set[str] | None = None,
+        column_mapping: dict[str, str] | None = None,
+    ) -> tuple[Any | None, bool]:
+        """Resolve any accepted ``order_by`` shape to SQL, once, for every shape.
+
+        Three call sites used to render this — an ``OrderBySet``, a GraphQL
+        ``OrderByInput``, and dict/list input — and each had to be kept in step
+        by hand. One helper means a new resolution rule cannot reach two of the
+        three (#467).
+
+        Returns:
+            ``(order_sql, needs_t_alias)``. A flat column renders ``t."col"``, so
+            the caller must ensure the FROM clause carries that alias; raw string
+            ``order_by`` is passed through untouched and reports ``(None, False)``.
+        """
+        if not order_by:
+            return None, False
+
+        order_set = order_by
+        if not hasattr(order_set, "to_sql"):
+            if hasattr(order_set, "_to_sql_order_by"):
+                order_set = order_set._to_sql_order_by(config=self.context.get("config"))
+            elif isinstance(order_set, (dict, list)):
+                # List format: [{"age": "ASC"}, {"name": "DESC"}] - from GraphQL
+                # Dict format: {"age": "ASC"} - single field, nested paths allowed
+                from fraiseql.sql.graphql_order_by_generator import (
+                    _convert_order_by_input_to_sql,
+                )
+
+                order_set = _convert_order_by_input_to_sql(
+                    order_set, config=self.context.get("config")
+                )
+            else:
+                # Raw SQL string, or something unrecognised — the caller handles it
+                return None, False
+
+        if not order_set or not hasattr(order_set, "to_sql"):
+            return None, False
+
+        order_sql = order_set.to_sql(
+            table_ref, native_columns=native_columns, column_mapping=column_mapping
+        )
+        if not order_sql:
+            return None, False
+
+        needs_alias = hasattr(order_set, "uses_flat_columns") and order_set.uses_flat_columns(
+            native_columns=native_columns, column_mapping=column_mapping
+        )
+        return order_sql, needs_alias
+
     def _build_find_query(
         self,
         view_name: str,
@@ -2890,6 +2944,14 @@ class FraiseQLRepository:
         native_dimension_mapping: dict[str, str] | None = kwargs.pop(
             "native_dimension_mapping", None
         )
+        # Resolve the declaration once (#467). SELECT/GROUP BY and ORDER BY must
+        # render a mapped path identically — PostgreSQL rejects a sort key that is
+        # neither grouped nor functionally determined by the grouping, and two
+        # expressions for one logical field is exactly how that happens. Falling
+        # back to the registration also makes column_mapping= apply to a plain
+        # find(), like fk_relationships does.
+        if native_dimension_mapping is None:
+            native_dimension_mapping = _view_column_mapping(view_name) or None
 
         if aggregations and not group_by:
             msg = "aggregations requires group_by"
@@ -2898,6 +2960,18 @@ class FraiseQLRepository:
         # Use unified WHERE clause building (includes Issue #124 fix for hybrid tables)
         # This ensures WhereInput nested filters work correctly in all code paths
         where_parts, where_params = self._build_where_clause(view_name, **kwargs)
+
+        # Determine table reference for ORDER BY
+        # For JSONB tables, use the column name; for non-JSONB tables, use table alias "t"
+        table_ref = jsonb_column if jsonb_column is not None else "t"
+        # Pass native_dimensions to ORDER BY so native columns use t."col" (#337),
+        # and the declared mapping so mapped paths do too (#467).
+        order_sql, order_needs_alias = self._build_order_by_sql(
+            order_by,
+            table_ref,
+            native_columns=native_dimensions or None,
+            column_mapping=native_dimension_mapping,
+        )
 
         # Handle schema-qualified table names
         if "." in view_name:
@@ -2982,6 +3056,10 @@ class FraiseQLRepository:
                 SQL("::text FROM "),
                 table_identifier,
             ]
+            # A flat sort key renders t."col", which needs the alias to exist.
+            # Only a declared mapping can reach here — this branch has no GROUP BY.
+            if order_needs_alias:
+                query_parts.append(SQL(" AS t"))
 
         # Add WHERE clause
         if where_parts:
@@ -2998,46 +3076,13 @@ class FraiseQLRepository:
         if group_by:
             query_parts.extend([SQL(" GROUP BY "), SQL(", ").join(group_by_exprs)])
 
-        # Determine table reference for ORDER BY
-        # For JSONB tables, use the column name; for non-JSONB tables, use table alias "t"
-        table_ref = jsonb_column if jsonb_column is not None else "t"
-        # Pass native_dimensions to ORDER BY so native columns use t."col" (#337)
-        order_native = native_dimensions or None
-
-        # Add ORDER BY
-        if order_by:
-            if hasattr(order_by, "to_sql"):
-                order_sql = order_by.to_sql(table_ref, native_columns=order_native)
-                if order_sql:
-                    # OrderBySet.to_sql() already includes "ORDER BY " prefix
-                    query_parts.append(SQL(" "))
-                    query_parts.append(order_sql)
-            elif hasattr(order_by, "_to_sql_order_by"):
-                # Convert GraphQL OrderByInput to SQL OrderBySet, then get SQL
-                config = self.context.get("config")
-                sql_order_by_obj = order_by._to_sql_order_by(config=config)
-                if sql_order_by_obj and hasattr(sql_order_by_obj, "to_sql"):
-                    order_sql = sql_order_by_obj.to_sql(table_ref, native_columns=order_native)
-                    if order_sql:
-                        # OrderBySet.to_sql() already includes "ORDER BY " prefix
-                        query_parts.append(SQL(" "))
-                        query_parts.append(order_sql)
-            elif isinstance(order_by, (dict, list)):
-                # Convert dict or list-style order by input to SQL OrderBySet
-                # List format: [{"age": "ASC"}, {"name": "DESC"}] - from GraphQL
-                # Dict format: {"age": "ASC"} - single field
-                from fraiseql.sql.graphql_order_by_generator import _convert_order_by_input_to_sql
-
-                config = self.context.get("config")
-                sql_order_by_obj = _convert_order_by_input_to_sql(order_by, config=config)
-                if sql_order_by_obj and hasattr(sql_order_by_obj, "to_sql"):
-                    order_sql = sql_order_by_obj.to_sql(table_ref, native_columns=order_native)
-                    if order_sql:
-                        # OrderBySet.to_sql() already includes "ORDER BY " prefix
-                        query_parts.append(SQL(" "))
-                        query_parts.append(order_sql)
-            elif isinstance(order_by, str):
-                query_parts.extend([SQL(" ORDER BY "), SQL(order_by)])
+        # Add ORDER BY (resolved above, before the FROM clause needed its alias)
+        if order_sql is not None:
+            # OrderBySet.to_sql() already includes the "ORDER BY " prefix
+            query_parts.append(SQL(" "))
+            query_parts.append(order_sql)
+        elif isinstance(order_by, str):
+            query_parts.extend([SQL(" ORDER BY "), SQL(order_by)])
 
         # Add LIMIT
         if limit is not None:

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -18,7 +18,11 @@ from fraiseql.core.rust_pipeline import (
 )
 from fraiseql.utils.casing import to_snake_case
 from fraiseql.where_clause import WhereClause
-from fraiseql.where_normalization import normalize_dict_where, normalize_whereinput
+from fraiseql.where_normalization import (
+    _apply_column_mapping,
+    normalize_dict_where,
+    normalize_whereinput,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -752,14 +756,23 @@ def _build_partial_period_union_query(
     return DatabaseQuery(statement=statement, params=all_params, fetch_result=True)
 
 
-def _normalize_aggregation_mapping_keys(aggregation: dict[str, Any]) -> dict[str, Any]:
-    """Return ``aggregation`` with ``native_dimension_mapping`` keys in one spelling.
+def _normalize_mapping_keys(mapping: dict[str, str]) -> dict[str, str]:
+    """Return *mapping* with every key's segments in database (snake_case) spelling.
 
     Mapping keys are matched against dotted field paths built with
     ``transform_path=to_snake_case``, so a key in GraphQL spelling
     (``dimensions.dateInfo.date``) could never match one and the entry would
     silently never fire. Normalizing each segment at registration accepts both
     spellings and leaves every consumer looking at the same dict.
+    """
+    return {
+        ".".join(to_snake_case(segment) for segment in path.split(".")): column
+        for path, column in mapping.items()
+    }
+
+
+def _normalize_aggregation_mapping_keys(aggregation: dict[str, Any]) -> dict[str, Any]:
+    """Return ``aggregation`` with ``native_dimension_mapping`` keys in one spelling.
 
     The caller's dict is never mutated: a new dict is returned when anything
     changed, and the original is returned untouched otherwise.
@@ -768,10 +781,7 @@ def _normalize_aggregation_mapping_keys(aggregation: dict[str, Any]) -> dict[str
     if not mapping:
         return aggregation
 
-    normalized = {
-        ".".join(to_snake_case(segment) for segment in path.split(".")): column
-        for path, column in mapping.items()
-    }
+    normalized = _normalize_mapping_keys(mapping)
     if normalized == mapping:
         return aggregation
     return {**aggregation, "native_dimension_mapping": normalized}
@@ -837,6 +847,22 @@ def _validate_aggregation_mapping(
     dimensions: list[str] = list(aggregation.get("native_dimensions") or [])
     declarations += [("native_dimensions", col, col) for col in dimensions]
 
+    _validate_mapping_declarations(view_name, declarations, table_columns, strict=strict)
+    _warn_unreachable_mapping_keys(view_name, aggregation)
+
+
+def _validate_mapping_declarations(
+    view_name: str,
+    declarations: list[tuple[str, str, str]],
+    table_columns: set[str] | None,
+    *,
+    strict: bool,
+) -> None:
+    """Check that every ``(meta_key, declared, column)`` triple names a real column.
+
+    With no columns registered there is nothing to validate against: warn once
+    naming the view, never raise.
+    """
     if not declarations:
         return
 
@@ -855,7 +881,23 @@ def _validate_aggregation_mapping(
             raise ValueError(error_msg)
         logger.warning("%s", error_msg)
 
-    _warn_unreachable_mapping_keys(view_name, aggregation)
+
+def _validate_column_mapping(
+    view_name: str,
+    column_mapping: dict[str, str],
+    table_columns: set[str] | None,
+    *,
+    strict: bool,
+) -> None:
+    """Validate a top-level ``column_mapping`` against the view's real columns.
+
+    Same class of declaration as ``fk_relationships``, so the same treatment. The
+    unreachable-key warning is deliberately *not* applied: it is specific to
+    aggregation dimension paths, and a peer of ``fk_relationships`` may
+    legitimately name any path in the type.
+    """
+    declarations = [("column_mapping", path, col) for path, col in column_mapping.items()]
+    _validate_mapping_declarations(view_name, declarations, table_columns, strict=strict)
 
 
 def _warn_unreachable_mapping_keys(view_name: str, aggregation: dict[str, Any]) -> None:
@@ -883,6 +925,59 @@ def _warn_unreachable_mapping_keys(view_name: str, aggregation: dict[str, Any]) 
         )
 
 
+def _view_column_mapping(view_name: str) -> dict[str, str]:
+    """Return the declared field path → column mapping for *view_name*.
+
+    Two declarations feed one resolver: the top-level ``column_mapping``, which
+    is the peer of ``fk_relationships``, and the older
+    ``aggregation["native_dimension_mapping"]``, which it supersedes. Both are
+    normalized to snake_case keys at registration, so they merge directly; the
+    explicit peer wins where they name the same path.
+    """
+    metadata = _table_metadata.get(view_name)
+    if not metadata:
+        return {}
+    aggregation = metadata.get("aggregation") or {}
+    return {
+        **(aggregation.get("native_dimension_mapping") or {}),
+        **(metadata.get("column_mapping") or {}),
+    }
+
+
+def _apply_view_column_mapping(
+    clause: WhereClause,
+    view_name: str,
+    table_columns: set[str] | None,
+) -> WhereClause:
+    """Re-resolve a view's declared field paths onto flat columns (issue #467).
+
+    The single site where the mapping is applied. Both query paths funnel
+    through :meth:`FraiseQLRepository._normalize_where` — the standard builder
+    via ``_build_where_clause``, and the partial-period UNION dispatch via its
+    own bound probe — so one call here covers both.
+
+    It runs on the finished clause rather than inside the recursive walk: that
+    walk is prefix-unaware and only the completed ``field_path`` carries the
+    dotted path a mapping key is written against.
+    """
+    mapping = _view_column_mapping(view_name)
+    if not mapping:
+        return clause
+
+    metadata = _table_metadata.get(view_name) or {}
+    if table_columns is None:
+        # Mirror normalize_dict_where: fall back to the registered columns so the
+        # resolution-time guard checks against what the walk itself used.
+        table_columns = metadata.get("columns")
+
+    return _apply_column_mapping(
+        clause,
+        mapping,
+        table_columns,
+        strict=metadata.get("validate_fk_strict", True),
+    )
+
+
 def register_type_for_view(
     view_name: str,
     type_class: type,
@@ -892,6 +987,7 @@ def register_type_for_view(
     fk_relationships: dict[str, str] | None = None,
     validate_fk_strict: bool = True,
     aggregation: dict[str, Any] | None = None,
+    column_mapping: dict[str, str] | None = None,
 ) -> None:
     """Register a type class for a specific view name with optional metadata.
 
@@ -909,6 +1005,19 @@ def register_type_for_view(
             If not specified, uses convention: field + "_id"
         validate_fk_strict: If True, raise error on FK validation failures.
             If False, only warn (useful for legacy code migration).
+        column_mapping: Map a dotted field path → flat SQL column name.
+            Example: {"dimensions.item.model.category": "model_category"}
+            A peer of ``fk_relationships``: it declares that a field the JSONB
+            snapshot also carries lives in a real column, so WHERE and GROUP BY
+            read the column instead of extracting from JSONB. Unlike
+            ``fk_relationships`` and the ``<parent>_id`` convention — which reach
+            only a leaf literally named ``id`` — it reaches any depth and any
+            leaf name. Applied unconditionally, aggregated query or not. Keys
+            accept either spelling (GraphQL or database) and are normalized
+            segment-wise to snake_case at registration, and may name any path in
+            the type. Supersedes ``aggregation["native_dimension_mapping"]``,
+            which keeps working and feeds the same resolver; where both declare
+            the same path, ``column_mapping`` wins.
         aggregation: Optional aggregation metadata for auto-aggregation.
             Example: {"measures": {"measures.cost": "SUM", "measures.volume": "SUM"},
                       "dimensions": "dimensions",
@@ -931,9 +1040,10 @@ def register_type_for_view(
             snake_case at registration, which is the spelling field paths use.
 
     Raises:
-        ValueError: If ``fk_relationships`` or the aggregation metadata names a
-            column absent from ``table_columns``, unless ``validate_fk_strict``
-            is False (which downgrades both to warnings).
+        ValueError: If ``fk_relationships``, ``column_mapping`` or the
+            aggregation metadata names a column absent from ``table_columns``,
+            unless ``validate_fk_strict`` is False (which downgrades all of them
+            to warnings).
     """
     _type_registry[view_name] = type_class
     logger.debug(f"Registered type {type_class.__name__} for view {view_name}")
@@ -966,6 +1076,13 @@ def register_type_for_view(
             view_name, aggregation, table_columns, strict=validate_fk_strict
         )
 
+    # Same for the top-level column mapping, the peer of fk_relationships (#467)
+    if column_mapping:
+        column_mapping = _normalize_mapping_keys(column_mapping)
+        _validate_column_mapping(
+            view_name, column_mapping, table_columns, strict=validate_fk_strict
+        )
+
     # Store metadata if provided
     if (
         table_columns is not None
@@ -973,6 +1090,7 @@ def register_type_for_view(
         or jsonb_column is not None
         or fk_relationships
         or aggregation
+        or column_mapping
     ):
         metadata = {
             "columns": table_columns or set(),
@@ -981,6 +1099,7 @@ def register_type_for_view(
             "fk_relationships": fk_relationships,
             "validate_fk_strict": validate_fk_strict,
             "aggregation": aggregation,
+            "column_mapping": column_mapping or {},
         }
         _table_metadata[view_name] = metadata
         logger.debug(
@@ -1561,10 +1680,15 @@ class FraiseQLRepository:
                         kwargs["group_by"],
                         kwargs["aggregations"],
                         native_dims,
-                        native_dim_mapping,
+                        _agg_mapping,
                     ) = result
                     if native_dims:
                         kwargs["native_dimensions"] = native_dims
+                    # Both declarations feed one resolver (#467), so GROUP BY
+                    # reads the same merged mapping the WHERE rewrite does —
+                    # otherwise column_mapping= would work in WHERE and silently
+                    # no-op in the one place the mechanism already worked.
+                    native_dim_mapping = _view_column_mapping(view_name)
                     if native_dim_mapping:
                         kwargs["native_dimension_mapping"] = native_dim_mapping
                     native_meas = agg_meta.get("native_measures")
@@ -2569,61 +2693,54 @@ class FraiseQLRepository:
         if isinstance(where, WhereClause):
             return where
 
+        jsonb_column = "data"
+        if view_name in _table_metadata:
+            metadata = _table_metadata[view_name]
+            if metadata.get("has_jsonb_data", False):
+                jsonb_column = metadata.get("jsonb_column") or "data"
+
+        result: WhereClause | None = None
+
         # Dict-based WHERE
         if isinstance(where, dict):
-            jsonb_column = "data"
-            if view_name in _table_metadata:
-                metadata = _table_metadata[view_name]
-                if metadata.get("has_jsonb_data", False):
-                    jsonb_column = metadata.get("jsonb_column") or "data"
-
             result = normalize_dict_where(where, view_name, table_columns, jsonb_column)
             if result is None:
                 raise ValueError(f"normalize_dict_where returned None for {where!r}")
-            return result
 
         # WhereInput-based WHERE
-        if hasattr(where, "_to_whereinput_dict"):
-            jsonb_column = "data"
-            if view_name in _table_metadata:
-                metadata = _table_metadata[view_name]
-                if metadata.get("has_jsonb_data", False):
-                    jsonb_column = metadata.get("jsonb_column") or "data"
-
+        elif hasattr(where, "_to_whereinput_dict"):
             result = normalize_whereinput(where, view_name, table_columns, jsonb_column)
             if result is None:
                 raise ValueError(f"normalize_whereinput returned None for {where!r}")
-            return result
 
-        # Try to convert dataclass WhereInput objects to dict
-        # (for dynamically created WhereInput types without _to_whereinput_dict method)
-        from dataclasses import asdict, is_dataclass
+        else:
+            # Try to convert dataclass WhereInput objects to dict
+            # (for dynamically created WhereInput types without _to_whereinput_dict method)
+            from dataclasses import asdict, is_dataclass
 
-        if is_dataclass(where):
-            # Convert dataclass to dict, filtering out None values
-            where_dict = {
-                field_name: field_value
-                for field_name, field_value in asdict(where).items()
-                if field_value is not None and field_value != {}
-            }
+            if is_dataclass(where):
+                # Convert dataclass to dict, filtering out None values
+                where_dict = {
+                    field_name: field_value
+                    for field_name, field_value in asdict(where).items()
+                    if field_value is not None and field_value != {}
+                }
 
-            if where_dict:  # Only process if there are non-empty values
-                jsonb_column = "data"
-                if view_name in _table_metadata:
-                    metadata = _table_metadata[view_name]
-                    if metadata.get("has_jsonb_data", False):
-                        jsonb_column = metadata.get("jsonb_column") or "data"
+                if where_dict:  # Only process if there are non-empty values
+                    result = normalize_dict_where(
+                        where_dict, view_name, table_columns, jsonb_column
+                    )
+                    if result is None:
+                        raise ValueError(f"normalize_dict_where returned None for {where_dict!r}")
 
-                result = normalize_dict_where(where_dict, view_name, table_columns, jsonb_column)
-                if result is None:
-                    raise ValueError(f"normalize_dict_where returned None for {where_dict!r}")
-                return result
+        if result is None:
+            # FIX: Always raise error for unsupported types, never return None
+            raise TypeError(
+                f"WHERE clause must be dict, WhereClause, or WhereInput object. "
+                f"Got: {type(where).__name__}"
+            )
 
-        # FIX: Always raise error for unsupported types, never return None
-        raise TypeError(
-            f"WHERE clause must be dict, WhereClause, or WhereInput object. "
-            f"Got: {type(where).__name__}"
-        )
+        return _apply_view_column_mapping(result, view_name, table_columns)
 
     def _build_where_clause(self, view_name: str, **kwargs: Any) -> tuple[list[Any], list[Any]]:
         """Build WHERE clause parts from kwargs.

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -395,6 +395,31 @@ def _build_trunc_expr(trunc: str, col_id: Any) -> Any:
     raise ValueError(msg)
 
 
+def _branch_sort_exprs(
+    entries: list[tuple[str, Any]],
+    order_keys: list[str] | None,
+) -> list[Any]:
+    """Return the branch expressions the outer ORDER BY sorts on, in order.
+
+    A UNION branch projects exactly one column — the ``json_build_object(...)::text``
+    the Rust pipeline reads — so ``ORDER BY`` on a dimension has nothing to
+    reference. Each requested key is therefore projected alongside it, using the
+    branch's *own* expression for that entry: the fine-grain branch truncates its
+    date where the coarse branch reads the column, and sorting has to follow the
+    same expression the branch grouped by.
+
+    *order_keys* is always a subset of the entry names — ``_union_order_terms``
+    resolves it against the same ``group_by`` and ``aggregations`` the entries are
+    built from, and drops anything an aggregated query cannot sort on. A missing
+    key would silently misalign the wrapper's column list, so it raises here
+    instead.
+    """
+    if not order_keys:
+        return []
+    by_key = dict(entries)
+    return [by_key[key] for key in order_keys]
+
+
 def _build_fine_grain_branch(
     *,
     fine_grain_view: str,
@@ -409,12 +434,14 @@ def _build_fine_grain_branch(
     native_dimension_mapping: dict[str, str] | None,
     jsonb_col: str,
     extra_where_sql: Any | None,
+    order_keys: list[str] | None = None,
 ) -> tuple[Any, list[Any]]:
     """Build one fine-grain branch of the UNION ALL query.
 
     Returns (branch_sql, branch_params).  Date bounds are embedded as Literals.
     ``extra_where_sql`` is a Composed fragment produced by WhereClause.to_sql()
-    (may be None when no extra conditions).
+    (may be None when no extra conditions).  ``order_keys`` names the projected
+    entries the caller wants to sort on — see ``_branch_sort_exprs`` (#468).
     """
     from psycopg.sql import SQL, Composed, Identifier, Literal
 
@@ -466,14 +493,17 @@ def _build_fine_grain_branch(
     if extra_where_sql is not None:
         where_parts.append(extra_where_sql)
 
-    branch_parts: list[SQL | Composed] = [
-        SQL("SELECT "),
-        nested_obj,
-        SQL("::text FROM "),
-        table_id,
-        SQL(" AS t WHERE "),
-        SQL(" AND ").join(where_parts),
-    ]
+    branch_parts: list[SQL | Composed] = [SQL("SELECT "), nested_obj, SQL("::text")]
+    for sort_expr in _branch_sort_exprs(entries, order_keys):
+        branch_parts.extend([SQL(", "), sort_expr])
+    branch_parts.extend(
+        [
+            SQL(" FROM "),
+            table_id,
+            SQL(" AS t WHERE "),
+            SQL(" AND ").join(where_parts),
+        ]
+    )
 
     if group_by_exprs:
         branch_parts.extend([SQL(" GROUP BY "), SQL(", ").join(group_by_exprs)])
@@ -494,10 +524,12 @@ def _build_coarse_branch(
     native_dimension_mapping: dict[str, str] | None,
     jsonb_col: str,
     extra_where_sql: Any | None,
+    order_keys: list[str] | None = None,
 ) -> tuple[Any, list[Any]]:
     """Build the coarse-grain branch of the UNION ALL query.
 
-    Returns (branch_sql, branch_params).
+    Returns (branch_sql, branch_params).  ``order_keys`` names the projected
+    entries the caller wants to sort on — see ``_branch_sort_exprs`` (#468).
     """
     from psycopg.sql import SQL, Composed, Identifier, Literal
 
@@ -544,19 +576,61 @@ def _build_coarse_branch(
     if extra_where_sql is not None:
         where_parts.append(extra_where_sql)
 
-    branch_parts: list[SQL | Composed] = [
-        SQL("SELECT "),
-        nested_obj,
-        SQL("::text FROM "),
-        table_id,
-        SQL(" AS t WHERE "),
-        SQL(" AND ").join(where_parts),
-    ]
+    branch_parts: list[SQL | Composed] = [SQL("SELECT "), nested_obj, SQL("::text")]
+    for sort_expr in _branch_sort_exprs(entries, order_keys):
+        branch_parts.extend([SQL(", "), sort_expr])
+    branch_parts.extend(
+        [
+            SQL(" FROM "),
+            table_id,
+            SQL(" AS t WHERE "),
+            SQL(" AND ").join(where_parts),
+        ]
+    )
 
     if group_by_exprs:
         branch_parts.extend([SQL(" GROUP BY "), SQL(", ").join(group_by_exprs)])
 
     return Composed(branch_parts), []
+
+
+def _union_order_terms(
+    order_by: Any | None,
+    group_by: list[str],
+    aggregations: dict[str, str],
+) -> tuple[list[str], list[Any]]:
+    """Resolve an ``OrderBySet`` into projected sort keys and outer ORDER BY terms.
+
+    Returns ``(order_keys, order_terms)``.  ``order_keys`` are the entry names every
+    branch has to project, in projection order; ``order_terms`` are the matching
+    ``"u"."sN" [COLLATE …] ASC|DESC`` fragments for the wrapper's ORDER BY.
+
+    An aggregated query can only sort on a grouped key or a measure, so an
+    instruction naming anything else is dropped and the statement falls back to its
+    positional sort. Both lists are empty when nothing is sortable, which is what
+    keeps a query with no usable ``order_by`` byte-identical to the unwrapped form.
+    """
+    from psycopg.sql import SQL, Identifier
+
+    instructions = getattr(order_by, "instructions", None) or ()
+    if not instructions:
+        return [], []
+
+    projectable = set(group_by) | set(aggregations or {})
+    order_keys: list[str] = []
+    order_terms: list[Any] = []
+
+    for instr in instructions:
+        if instr.field not in projectable:
+            continue
+        if instr.field not in order_keys:
+            order_keys.append(instr.field)
+        term = Identifier("u", f"s{order_keys.index(instr.field)}")
+        if instr.collation is not None:
+            term = term + SQL(" COLLATE ") + Identifier(instr.collation)
+        order_terms.append(term + SQL(" ") + instr._direction_sql())
+
+    return order_keys, order_terms
 
 
 def _build_partial_period_union_query(
@@ -575,6 +649,7 @@ def _build_partial_period_union_query(
     extra_where: Any | None,  # WhereClause | None
     upper_bound_exclusive: Any | None = None,  # date | None (exclusive)
     today: Any | None = None,  # date | None
+    order_by: Any | None = None,  # OrderBySet | None
 ) -> "DatabaseQuery":
     """Build a UNION ALL query for partial-period awareness.
 
@@ -620,13 +695,15 @@ def _build_partial_period_union_query(
                                  run through today.
         today:                   Override today's date (for deterministic testing).
                                  Defaults to ``date.today()``.
+        order_by:                Resolved ``OrderBySet``, or None to keep the
+                                 default positional sort on the projected column.
 
     Returns:
         DatabaseQuery with a UNION ALL Composed statement and params list.
     """
     from datetime import datetime, timedelta
 
-    from psycopg.sql import SQL, Composed
+    from psycopg.sql import SQL, Composed, Identifier
 
     from fraiseql.partial_period import (
         _is_period_aligned,
@@ -689,8 +766,13 @@ def _build_partial_period_union_query(
             extra_where_sql = ew_sql
             extra_where_params = list(ew_params)
 
+    # Sort keys have to be projected per branch before the branches are built:
+    # ORDER BY over a UNION can only reference an output column (#468).
+    order_keys, order_terms = _union_order_terms(order_by, group_by, aggregations)
+
     common = {
         "time_grain_column": time_grain_column,
+        "order_keys": order_keys,
         "group_by": group_by,
         "aggregations": aggregations,
         "native_dimensions": native_dimensions,
@@ -741,17 +823,42 @@ def _build_partial_period_union_query(
     if not branches:
         _add_fine(lo, lo)
 
-    # Join branches with UNION ALL and add ORDER BY 1
+    # Join branches with UNION ALL
     if len(branches) == 1:
-        statement = Composed([branches[0], SQL(" ORDER BY 1")])
+        union_sql: Any = branches[0]
     else:
         union_parts: list[Any] = []
         for i, branch in enumerate(branches):
             if i > 0:
                 union_parts.append(SQL(" UNION ALL "))
             union_parts.append(branch)
-        union_parts.append(SQL(" ORDER BY 1"))
-        statement = Composed(union_parts)
+        union_sql = Composed(union_parts)
+
+    if not order_terms:
+        # No sort requested: order on the single projected column, positionally.
+        statement = Composed([union_sql, SQL(" ORDER BY 1")])
+    else:
+        # Wrap so the statement still yields exactly one column: the sort keys are
+        # projected by every branch but must not reach the Rust pipeline, which
+        # reads ``row[0]``. Naming the subquery's columns means the branches
+        # themselves need no aliases.
+        column_aliases = SQL(", ").join(
+            [Identifier("d"), *(Identifier(f"s{i}") for i in range(len(order_keys)))]
+        )
+        statement = Composed(
+            [
+                SQL("SELECT "),
+                Identifier("u", "d"),
+                SQL(" FROM ("),
+                union_sql,
+                SQL(") AS "),
+                Identifier("u"),
+                SQL("("),
+                column_aliases,
+                SQL(") ORDER BY "),
+                SQL(", ").join(order_terms),
+            ]
+        )
 
     return DatabaseQuery(statement=statement, params=all_params, fetch_result=True)
 
@@ -1730,8 +1837,17 @@ class FraiseQLRepository:
                             _extract_upper_date_bound,
                         )
 
-                        lower_bound = _extract_lower_date_bound(
-                            where_clause_for_pp, time_grain_column
+                        # The builder re-encodes the bounds as per-branch AND
+                        # literals, so it may only rewrite a bound that is itself a
+                        # top-level conjunct. `_extract_lower_date_bound` already
+                        # ignores nested clauses; OR-joined top-level conditions
+                        # have to be excluded here, or `date >= X OR status = 'a'`
+                        # would become `date in [branch] AND status = 'a'` and drop
+                        # every row that matched on the date alone (#468).
+                        lower_bound = (
+                            _extract_lower_date_bound(where_clause_for_pp, time_grain_column)
+                            if where_clause_for_pp.logical_op == "AND"
+                            else None
                         )
                         if lower_bound is not None:
                             use_union_all = True
@@ -1744,38 +1860,24 @@ class FraiseQLRepository:
                         pass
 
         if use_union_all:
-            # Strip the date condition from the where clause for extra_where
-            # (date bounds are encoded per-branch in the UNION builder)
+            # Everything but the time-grain bounds (those are encoded per-branch in
+            # the UNION builder), plus mandatory_filters as FieldConditions (#344).
+            # One construction site: rebuilding the clause from its conditions alone
+            # is what dropped every OR/NOT group (#468).
+            from fraiseql.partial_period import _build_extra_where
+            from fraiseql.where_clause import FieldCondition
 
-            remaining_conditions = [
-                c for c in where_clause_for_pp.conditions if c.target_column != time_grain_column
+            mandatory_fc = [
+                FieldCondition(
+                    field_path=[col],
+                    operator="eq",
+                    value=val,
+                    lookup_strategy="sql_column",
+                    target_column=col,
+                )
+                for col, val in (mandatory_filters or {}).items()
             ]
-            extra_where = (
-                WhereClause(conditions=remaining_conditions) if remaining_conditions else None
-            )
-
-            # Inject mandatory_filters into extra_where as FieldConditions (#344)
-            if mandatory_filters:
-                from fraiseql.where_clause import FieldCondition
-
-                mandatory_fc = [
-                    FieldCondition(
-                        field_path=[col],
-                        operator="eq",
-                        value=val,
-                        lookup_strategy="sql_column",
-                        target_column=col,
-                    )
-                    for col, val in mandatory_filters.items()
-                ]
-                if extra_where:
-                    extra_where = WhereClause(
-                        conditions=[*mandatory_fc, *extra_where.conditions],
-                        nested_clauses=extra_where.nested_clauses,
-                        not_clause=extra_where.not_clause,
-                    )
-                else:
-                    extra_where = WhereClause(conditions=mandatory_fc)
+            extra_where = _build_extra_where(where_clause_for_pp, time_grain_column, mandatory_fc)
 
             # Collect kwargs that affect the query structure
             union_group_by = kwargs.get("group_by") or []
@@ -1784,6 +1886,7 @@ class FraiseQLRepository:
             union_native_measures = kwargs.get("native_measures")
             union_native_dim_mapping = kwargs.get("native_dimension_mapping")
             union_jsonb_col = jsonb_column or "data"
+            union_order_by = self._resolve_order_by_set(kwargs.get("order_by"))
 
             query = _build_partial_period_union_query(
                 coarse_view=view_name,
@@ -1799,6 +1902,7 @@ class FraiseQLRepository:
                 jsonb_col=union_jsonb_col,
                 extra_where=extra_where,
                 upper_bound_exclusive=upper_bound_exclusive,
+                order_by=union_order_by,
             )
         else:
             # Inject mandatory conditions for _build_where_clause consumption (#344)
@@ -2850,6 +2954,43 @@ class FraiseQLRepository:
             f"Available views: {available_views}. Registry size: {len(_type_registry)}",
         )
 
+    def _resolve_order_by_set(self, order_by: Any) -> Any | None:
+        """Normalise any accepted ``order_by`` shape to an ``OrderBySet``.
+
+        Three shapes reach the repository — an ``OrderBySet``, a GraphQL
+        ``OrderByInput`` and dict/list input — and both the single-statement
+        ORDER BY and the partial-period UNION need the resolved instructions.
+
+        Returns:
+            The ``OrderBySet``, or None for a falsy value or a shape with no
+            instructions to read (a raw SQL string, which callers pass through
+            untouched).
+        """
+        if not order_by:
+            return None
+
+        order_set = order_by
+        if not hasattr(order_set, "to_sql"):
+            if hasattr(order_set, "_to_sql_order_by"):
+                order_set = order_set._to_sql_order_by(config=self.context.get("config"))
+            elif isinstance(order_set, (dict, list)):
+                # List format: [{"age": "ASC"}, {"name": "DESC"}] - from GraphQL
+                # Dict format: {"age": "ASC"} - single field, nested paths allowed
+                from fraiseql.sql.graphql_order_by_generator import (
+                    _convert_order_by_input_to_sql,
+                )
+
+                order_set = _convert_order_by_input_to_sql(
+                    order_set, config=self.context.get("config")
+                )
+            else:
+                # Raw SQL string, or something unrecognised — the caller handles it
+                return None
+
+        if not order_set or not hasattr(order_set, "to_sql"):
+            return None
+        return order_set
+
     def _build_order_by_sql(
         self,
         order_by: Any,
@@ -2869,28 +3010,8 @@ class FraiseQLRepository:
             the caller must ensure the FROM clause carries that alias; raw string
             ``order_by`` is passed through untouched and reports ``(None, False)``.
         """
-        if not order_by:
-            return None, False
-
-        order_set = order_by
-        if not hasattr(order_set, "to_sql"):
-            if hasattr(order_set, "_to_sql_order_by"):
-                order_set = order_set._to_sql_order_by(config=self.context.get("config"))
-            elif isinstance(order_set, (dict, list)):
-                # List format: [{"age": "ASC"}, {"name": "DESC"}] - from GraphQL
-                # Dict format: {"age": "ASC"} - single field, nested paths allowed
-                from fraiseql.sql.graphql_order_by_generator import (
-                    _convert_order_by_input_to_sql,
-                )
-
-                order_set = _convert_order_by_input_to_sql(
-                    order_set, config=self.context.get("config")
-                )
-            else:
-                # Raw SQL string, or something unrecognised — the caller handles it
-                return None, False
-
-        if not order_set or not hasattr(order_set, "to_sql"):
+        order_set = self._resolve_order_by_set(order_by)
+        if order_set is None:
             return None, False
 
         order_sql = order_set.to_sql(

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -16,6 +16,7 @@ from fraiseql.core.rust_pipeline import (
     RustResponseBytes,
     execute_via_rust_pipeline,
 )
+from fraiseql.sql.native_columns import resolve_native_column
 from fraiseql.utils.casing import to_snake_case
 from fraiseql.where_clause import WhereClause
 from fraiseql.where_normalization import (
@@ -451,12 +452,14 @@ def _build_fine_grain_branch(
     def build_field(fp: str) -> SQL | Composed:
         if fp == time_grain_column:
             return _build_trunc_expr(time_grain_trunc, col_id)
-        if fp in native_dimensions:
-            return _build_non_jsonb_field_expr(fp, "t")
-        if native_dimension_mapping and fp in native_dimension_mapping:
-            return _build_non_jsonb_field_expr(native_dimension_mapping[fp], "t")
-        if native_measures and fp in native_measures:
-            return _build_non_jsonb_field_expr(native_measures[fp], "t")
+        column = resolve_native_column(
+            fp,
+            native_columns=native_dimensions,
+            column_mapping=native_dimension_mapping,
+            native_measures=native_measures,
+        )
+        if column is not None:
+            return _build_non_jsonb_field_expr(column, "t")
         return _build_jsonb_field_expr(fp, jsonb_col)
 
     # Build entries for json_build_object
@@ -473,9 +476,13 @@ def _build_fine_grain_branch(
             func, field = _parse_aggregation_expr(agg_expr_str)
             field_expr = build_field(field) if field != "*" else SQL("*")
             is_native = (
-                field in native_dimensions
-                or (native_measures and field in native_measures)
-                or (native_dimension_mapping and field in native_dimension_mapping)
+                resolve_native_column(
+                    field,
+                    native_columns=native_dimensions,
+                    column_mapping=native_dimension_mapping,
+                    native_measures=native_measures,
+                )
+                is not None
             )
             if func in _NUMERIC_AGGREGATION_FUNCS and not is_native:
                 agg_sql = SQL("{}(({})::{})").format(SQL(func), field_expr, SQL("numeric"))
@@ -537,12 +544,14 @@ def _build_coarse_branch(
     col_id = Identifier(time_grain_column)
 
     def build_field(fp: str) -> SQL | Composed:
-        if fp in native_dimensions:
-            return _build_non_jsonb_field_expr(fp, "t")
-        if native_dimension_mapping and fp in native_dimension_mapping:
-            return _build_non_jsonb_field_expr(native_dimension_mapping[fp], "t")
-        if native_measures and fp in native_measures:
-            return _build_non_jsonb_field_expr(native_measures[fp], "t")
+        column = resolve_native_column(
+            fp,
+            native_columns=native_dimensions,
+            column_mapping=native_dimension_mapping,
+            native_measures=native_measures,
+        )
+        if column is not None:
+            return _build_non_jsonb_field_expr(column, "t")
         return _build_jsonb_field_expr(fp, jsonb_col)
 
     entries: list[tuple[str, SQL | Composed]] = []
@@ -557,9 +566,13 @@ def _build_coarse_branch(
             func, field = _parse_aggregation_expr(agg_expr_str)
             field_expr = build_field(field) if field != "*" else SQL("*")
             is_native = (
-                field in native_dimensions
-                or (native_measures and field in native_measures)
-                or (native_dimension_mapping and field in native_dimension_mapping)
+                resolve_native_column(
+                    field,
+                    native_columns=native_dimensions,
+                    column_mapping=native_dimension_mapping,
+                    native_measures=native_measures,
+                )
+                is not None
             )
             if func in _NUMERIC_AGGREGATION_FUNCS and not is_native:
                 agg_sql = SQL("{}(({})::{})").format(SQL(func), field_expr, SQL("numeric"))
@@ -1115,8 +1128,12 @@ def register_type_for_view(
         column_mapping: Map a dotted field path → flat SQL column name.
             Example: {"dimensions.item.model.category": "model_category"}
             A peer of ``fk_relationships``: it declares that a field the JSONB
-            snapshot also carries lives in a real column, so WHERE and GROUP BY
-            read the column instead of extracting from JSONB. Unlike
+            snapshot also carries lives in a real column, so GROUP BY, WHERE and
+            ORDER BY all read the column instead of extracting from JSONB. All
+            three go through one resolver
+            (``fraiseql.sql.native_columns.resolve_native_column``) so they cannot
+            disagree — two expressions for one logical field is a query that
+            fails to plan. Unlike
             ``fk_relationships`` and the ``<parent>_id`` convention — which reach
             only a leaf literally named ``id`` — it reaches any depth and any
             leaf name. Applied unconditionally, aggregated query or not. Keys
@@ -3112,12 +3129,14 @@ class FraiseQLRepository:
 
             def build_field(fp: str) -> SQL | Composed:
                 """Build field expression, dispatching native vs JSONB."""
-                if fp in native_dimensions:
-                    return _build_non_jsonb_field_expr(fp, "t")
-                if native_dimension_mapping and fp in native_dimension_mapping:
-                    return _build_non_jsonb_field_expr(native_dimension_mapping[fp], "t")
-                if native_measures and fp in native_measures:
-                    return _build_non_jsonb_field_expr(native_measures[fp], "t")
+                column = resolve_native_column(
+                    fp,
+                    native_columns=native_dimensions,
+                    column_mapping=native_dimension_mapping,
+                    native_measures=native_measures,
+                )
+                if column is not None:
+                    return _build_non_jsonb_field_expr(column, "t")
                 if is_jsonb:
                     return _build_jsonb_field_expr(fp, jsonb_col)
                 return _build_non_jsonb_field_expr(fp, "t")
@@ -3138,9 +3157,13 @@ class FraiseQLRepository:
                     else:
                         field_expr = build_field(field)
                         is_native_field = (
-                            field in native_dimensions
-                            or (native_measures and field in native_measures)
-                            or (native_dimension_mapping and field in native_dimension_mapping)
+                            resolve_native_column(
+                                field,
+                                native_columns=native_dimensions,
+                                column_mapping=native_dimension_mapping,
+                                native_measures=native_measures,
+                            )
+                            is not None
                         )
                         if is_jsonb and func in _NUMERIC_AGGREGATION_FUNCS and not is_native_field:
                             agg_expr = SQL("{}(({})::{})").format(

--- a/src/fraiseql/partial_period.py
+++ b/src/fraiseql/partial_period.py
@@ -16,7 +16,9 @@ from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from fraiseql.where_clause import WhereClause
+    from collections.abc import Sequence
+
+    from fraiseql.where_clause import FieldCondition, WhereClause
 
 _VALID_GRAIN_TRUNCS = frozenset(
     {"day", "week", "half_month", "month", "quarter", "semester", "year"}
@@ -249,3 +251,48 @@ def _extract_upper_date_bound(
         return value
 
     return None
+
+
+def _build_extra_where(
+    where_clause: "WhereClause",
+    time_grain_column: str,
+    mandatory_conditions: "Sequence[FieldCondition]" = (),
+) -> "WhereClause | None":
+    """Build the WHERE the UNION branches carry, from the caller's normalised clause.
+
+    The time-grain bounds are re-encoded per branch as SQL Literals by the union
+    builder, so the top-level conditions on *time_grain_column* are removed here.
+    Everything else the clause carries has to survive: a ``WhereClause`` holds
+    ``conditions``, ``logical_op``, ``nested_clauses`` (every ``OR``/``AND`` group)
+    and ``not_clause``, and rebuilding it from ``conditions`` alone discards every
+    ``OR`` and ``NOT`` group in the filter (#468).
+
+    *mandatory_conditions* (#344) are ANDed in front of what is left. That is only
+    sound because the caller routes through the UNION exclusively for a clause whose
+    top-level ``logical_op`` is ``"AND"``; a date bound that is not a top-level
+    conjunct does not trigger the rewrite in the first place.
+
+    Args:
+        where_clause:         The normalised clause the query was built from.
+        time_grain_column:    SQL column holding the period date (e.g. ``"date"``).
+        mandatory_conditions: Resolver-injected conditions that must apply to every
+                              branch regardless of the caller's filter.
+
+    Returns:
+        The clause every branch should apply, or None when nothing is left to
+        filter on.
+    """
+    from fraiseql.where_clause import WhereClause
+
+    remaining = [c for c in where_clause.conditions if c.target_column != time_grain_column]
+    mandatory = list(mandatory_conditions)
+
+    if not (mandatory or remaining or where_clause.nested_clauses or where_clause.not_clause):
+        return None
+
+    return WhereClause(
+        conditions=[*mandatory, *remaining],
+        logical_op=where_clause.logical_op,
+        nested_clauses=list(where_clause.nested_clauses),
+        not_clause=where_clause.not_clause,
+    )

--- a/src/fraiseql/sql/native_columns.py
+++ b/src/fraiseql/sql/native_columns.py
@@ -1,0 +1,50 @@
+"""One answer to "does this field path have a flat SQL column?".
+
+Three declarations can put a field on a real column instead of inside the JSONB
+snapshot, and they are checked in a fixed order:
+
+1. ``native_columns`` — a **set**, so it can only say "this field *is* a column"
+   (``native_dimensions``, #337).
+2. ``column_mapping`` — a **path → column dict**, so it also reaches a deep path
+   whose column is named something else entirely (``column_mapping=`` /
+   ``aggregation["native_dimension_mapping"]``, #467).
+3. ``native_measures`` — the same shape as ``column_mapping``, for measure paths.
+
+The order matters: a field that is itself a column wins over a mapped path. Two
+different expressions for one logical field is how a GROUP BY constraint gets
+violated, so every builder that renders such a field has to agree — which is the
+reason this lives in one function rather than in each of them.
+"""
+
+from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
+
+
+def resolve_native_column(
+    field_path: str,
+    *,
+    native_columns: AbstractSet[str] | None = None,
+    column_mapping: Mapping[str, str] | None = None,
+    native_measures: Mapping[str, str] | None = None,
+) -> str | None:
+    """Return the flat SQL column *field_path* resolves to, or None for JSONB.
+
+    Args:
+        field_path:       Dotted field path, e.g. ``"dimensions.item.model.category"``.
+        native_columns:   Field names that are themselves columns on the view.
+        column_mapping:   Declared path → column names.
+        native_measures:  Declared measure path → column names. Callers that
+                          render a **sort key** must leave this out: a measure is
+                          aggregated in the SELECT list, so sorting on its raw
+                          column would not be grouped.
+
+    Returns:
+        The column name, or None when the path has to be read out of JSONB.
+    """
+    if native_columns and field_path in native_columns:
+        return field_path
+    if column_mapping and field_path in column_mapping:
+        return column_mapping[field_path]
+    if native_measures and field_path in native_measures:
+        return native_measures[field_path]
+    return None

--- a/src/fraiseql/sql/order_by_generator.py
+++ b/src/fraiseql/sql/order_by_generator.py
@@ -92,22 +92,20 @@ class OrderBy:
     ) -> str | None:
         """Return the flat column this instruction sorts on, or None for JSONB.
 
-        Two declarations reach here. ``native_columns`` is a set, so it can only
-        say "this field *is* a column" (#337). ``column_mapping`` is a
-        path → column dict, so it also reaches a deep path whose column is named
-        something else entirely (#467).
+        Shares :func:`resolve_native_column` with the GROUP BY builders, because
+        the two must agree: PostgreSQL requires a sort key to be grouped or
+        functionally determined by the grouping, and two different expressions
+        for one logical field is how that constraint gets violated.
 
-        Precedence matches the GROUP BY builder (``build_field`` in ``db.py``):
-        a field that is itself a native column wins over a mapped path. The two
-        must agree — PostgreSQL requires a sort key to be grouped or functionally
-        determined by the grouping, and two different expressions for one logical
-        field is how that constraint gets violated.
+        ``native_measures`` is deliberately not passed. A measure is aggregated
+        in the SELECT list, so resolving a sort key to its raw column would
+        produce an ungrouped reference.
         """
-        if native_columns and self.field in native_columns:
-            return self.field
-        if column_mapping and self.field in column_mapping:
-            return column_mapping[self.field]
-        return None
+        from fraiseql.sql.native_columns import resolve_native_column
+
+        return resolve_native_column(
+            self.field, native_columns=native_columns, column_mapping=column_mapping
+        )
 
     def to_sql(
         self,

--- a/src/fraiseql/sql/order_by_generator.py
+++ b/src/fraiseql/sql/order_by_generator.py
@@ -76,10 +76,44 @@ class OrderBy:
     value: list[float] | None = None
     collation: str | None = None
 
+    def _direction_sql(self) -> sql.SQL:
+        """Render the sort direction, accepting either the enum or a bare string."""
+        direction_str = (
+            self.direction.value.upper()
+            if isinstance(self.direction, OrderDirection)
+            else str(self.direction).upper()
+        )
+        return sql.SQL(direction_str)
+
+    def _flat_column(
+        self,
+        native_columns: set[str] | None,
+        column_mapping: dict[str, str] | None,
+    ) -> str | None:
+        """Return the flat column this instruction sorts on, or None for JSONB.
+
+        Two declarations reach here. ``native_columns`` is a set, so it can only
+        say "this field *is* a column" (#337). ``column_mapping`` is a
+        path → column dict, so it also reaches a deep path whose column is named
+        something else entirely (#467).
+
+        Precedence matches the GROUP BY builder (``build_field`` in ``db.py``):
+        a field that is itself a native column wins over a mapped path. The two
+        must agree — PostgreSQL requires a sort key to be grouped or functionally
+        determined by the grouping, and two different expressions for one logical
+        field is how that constraint gets violated.
+        """
+        if native_columns and self.field in native_columns:
+            return self.field
+        if column_mapping and self.field in column_mapping:
+            return column_mapping[self.field]
+        return None
+
     def to_sql(
         self,
         table_ref: str = "t",
         native_columns: set[str] | None = None,
+        column_mapping: dict[str, str] | None = None,
     ) -> sql.Composed:
         """Generate ORDER BY clause using JSONB numeric extraction or vector distance.
 
@@ -88,6 +122,9 @@ class OrderBy:
             native_columns: Set of column names that are native SQL columns on the
                 view (not inside JSONB). These use ``t."col"`` instead of JSONB
                 extraction for correct index usage (#337).
+            column_mapping: Map of dotted field path → flat SQL column name, as
+                declared by ``column_mapping=`` / ``native_dimension_mapping``.
+                Reaches deep paths ``native_columns`` cannot express (#467).
 
         Uses data -> 'field' instead of data ->> 'field' to preserve proper
         numeric ordering. JSONB extraction (data->'field') maintains the
@@ -100,15 +137,11 @@ class OrderBy:
         For vector distance operations like 'embedding.cosine_distance', uses:
         ({table_ref} -> 'embedding') <=> '[0.1,0.2,...]'::vector
         """
-        # Native column short-circuit: use t."col" instead of JSONB extraction (#337)
-        if native_columns and self.field in native_columns:
-            direction_str = (
-                self.direction.value.upper()
-                if isinstance(self.direction, OrderDirection)
-                else str(self.direction).upper()
-            )
-            col_expr = sql.SQL("{}.{}").format(sql.Identifier("t"), sql.Identifier(self.field))
-            return col_expr + sql.SQL(" ") + sql.SQL(direction_str)
+        # Flat column short-circuit: use t."col" instead of JSONB extraction
+        flat_column = self._flat_column(native_columns, column_mapping)
+        if flat_column is not None:
+            col_expr = sql.SQL("{}.{}").format(sql.Identifier("t"), sql.Identifier(flat_column))
+            return col_expr + sql.SQL(" ") + self._direction_sql()
 
         # Check if this is a vector distance operation
         if "." in self.field and self.value is not None:
@@ -138,13 +171,7 @@ class OrderBy:
             collation_clause = sql.SQL(" COLLATE ") + sql.Identifier(self.collation)
             data_expr = data_expr + collation_clause
 
-        # Handle both OrderDirection enum and string directions
-        if isinstance(self.direction, OrderDirection):
-            direction_str = self.direction.value.upper()
-        else:
-            direction_str = str(self.direction).upper()
-        direction_sql = sql.SQL(direction_str)
-        return data_expr + sql.SQL(" ") + direction_sql
+        return data_expr + sql.SQL(" ") + self._direction_sql()
 
     def _build_vector_distance_sql(
         self,
@@ -250,6 +277,7 @@ class OrderBySet:
         self,
         table_ref: str = "t",
         native_columns: set[str] | None = None,
+        column_mapping: dict[str, str] | None = None,
     ) -> sql.Composed:
         """Compile the ORDER BY instructions into a psycopg SQL Composed object.
 
@@ -257,6 +285,8 @@ class OrderBySet:
             table_ref: Table alias or column name to use for field access (default: "t")
             native_columns: Set of native SQL column names to use column refs
                 instead of JSONB extraction (#337).
+            column_mapping: Map of dotted field path → flat SQL column name, for
+                deep paths ``native_columns`` cannot express (#467).
 
         Returns:
             A `psycopg.sql.Composed` instance representing the full ORDER BY
@@ -265,6 +295,24 @@ class OrderBySet:
         if not self.instructions:
             return sql.Composed([])  # Return empty Composed to satisfy Pyright
         clauses = sql.SQL(", ").join(
-            instr.to_sql(table_ref, native_columns=native_columns) for instr in self.instructions
+            instr.to_sql(table_ref, native_columns=native_columns, column_mapping=column_mapping)
+            for instr in self.instructions
         )
         return sql.SQL("ORDER BY ") + clauses
+
+    def uses_flat_columns(
+        self,
+        native_columns: set[str] | None = None,
+        column_mapping: dict[str, str] | None = None,
+    ) -> bool:
+        """True when any instruction sorts on a flat column rather than JSONB.
+
+        A flat column renders as ``t."col"``, so the caller must make sure the
+        FROM clause actually carries the ``t`` alias. Aggregated queries always
+        do; a plain ``SELECT data::text FROM view`` does not until a mapping
+        makes one of its sort keys native.
+        """
+        return any(
+            instr._flat_column(native_columns, column_mapping) is not None
+            for instr in self.instructions
+        )

--- a/src/fraiseql/where_normalization.py
+++ b/src/fraiseql/where_normalization.py
@@ -7,6 +7,7 @@ WhereClause representation.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from typing import Any
 
 from fraiseql.where_clause import ALL_OPERATORS, VECTOR_OPERATORS, FieldCondition, WhereClause
@@ -480,3 +481,117 @@ def normalize_whereinput(
 
     # Use dict normalization logic
     return normalize_dict_where(where_dict, view_name, table_columns, jsonb_column)
+
+
+def _mapped_lookup_strategy(column: str, value: Any) -> str:
+    """Pick the lookup strategy for a condition re-resolved onto *column*.
+
+    ``fk_column`` is what the ltree ``*_of_id`` operators and the UUID coercion
+    path key on, and the ``<parent>_id`` convention already emits it for paths a
+    mapping may also declare.  Downgrading those to ``sql_column`` would silently
+    break the hierarchy operators, so a target that reads like a foreign key —
+    named ``*_id``, or compared against UUIDs — keeps ``fk_column``.
+    """
+    from uuid import UUID
+
+    if column.endswith("_id"):
+        return "fk_column"
+    if isinstance(value, UUID):
+        return "fk_column"
+    if isinstance(value, (list, tuple)) and value and all(isinstance(v, UUID) for v in value):
+        return "fk_column"
+    return "sql_column"
+
+
+def _map_condition(
+    condition: FieldCondition,
+    mapping: dict[str, str],
+    table_columns: set[str] | None,
+    *,
+    strict: bool,
+) -> FieldCondition:
+    """Re-resolve one condition onto a flat column when its path is mapped.
+
+    Returns the condition unchanged when the path is not declared, or when the
+    declared column does not exist and lenient mode asked for a JSONB fallback.
+    """
+    column = mapping.get(".".join(condition.field_path))
+    if column is None:
+        return condition
+
+    # Second guard, mirroring the fk_relationships check in
+    # _is_nested_object_filter: registration validation is bypassable
+    # (validate_fk_strict=False, or a view registered before its columns were
+    # known), so a declared column is re-checked here. With no columns known
+    # there is nothing to check against — trust the declaration rather than
+    # refuse to serve the query.
+    if table_columns and column not in table_columns:
+        error_msg = (
+            f"Column mapping declared ({'.'.join(condition.field_path)} → {column}) "
+            f"but column '{column}' not in table_columns. "
+        )
+        if strict:
+            raise RuntimeError(error_msg + "This should have been caught during registration.")
+        logger.warning("%s Using JSONB fallback.", error_msg)
+        return condition
+
+    return replace(
+        condition,
+        lookup_strategy=_mapped_lookup_strategy(column, condition.value),
+        target_column=column,
+        jsonb_path=None,
+    )
+
+
+def _apply_column_mapping(
+    clause: WhereClause,
+    mapping: dict[str, str],
+    table_columns: set[str] | None = None,
+    *,
+    strict: bool = True,
+) -> WhereClause:
+    """Re-resolve conditions on declared paths onto flat columns.
+
+    A declared column mapping is a peer of ``fk_relationships``: both say "this
+    field lives in a real column, not in the JSONB snapshot". The convention
+    mechanisms reach only a leaf literally named ``id`` under a ``<parent>_id``
+    column, so a path like ``dimensions.item.model.category`` is reachable by
+    nothing else — hence this pass.
+
+    It runs on the finished clause rather than inside ``normalize_dict_where``:
+    the recursion is prefix-unaware (the parent segment is prepended *after* the
+    inner call returns), so only the completed ``field_path`` carries the dotted
+    path a mapping key is written against. Running outside the recursion also
+    stops a partial path from matching a key by accident.
+
+    The input tree is never mutated — the same normalized clause is re-read by
+    the partial-period bound extractors — so a new tree is returned.
+
+    Args:
+        clause: Normalized WHERE clause to rewrite
+        mapping: Dotted field path → flat column name
+        table_columns: Actual database columns, for the resolution-time guard
+        strict: Raise ``RuntimeError`` on a mapping naming a missing column;
+            when False, warn once and leave the condition on JSONB
+
+    Returns:
+        A rewritten clause, or *clause* itself when the mapping is empty
+    """
+    if not mapping:
+        return clause
+
+    return WhereClause(
+        conditions=[
+            _map_condition(c, mapping, table_columns, strict=strict) for c in clause.conditions
+        ],
+        logical_op=clause.logical_op,
+        nested_clauses=[
+            _apply_column_mapping(nested, mapping, table_columns, strict=strict)
+            for nested in clause.nested_clauses
+        ],
+        not_clause=(
+            _apply_column_mapping(clause.not_clause, mapping, table_columns, strict=strict)
+            if clause.not_clause
+            else None
+        ),
+    )

--- a/tests/container/__init__.py
+++ b/tests/container/__init__.py
@@ -1,0 +1,1 @@
+"""Tests that build and run the production runtime image."""

--- a/tests/container/test_runtime_image.py
+++ b/tests/container/test_runtime_image.py
@@ -1,0 +1,180 @@
+"""What the production runtime image is allowed to contain.
+
+Trivy reports one code-scanning alert per affected *binary package*, so a tool
+that is in the image only to answer a HEALTHCHECK is not one alert — `curl` and
+the libraries it drags in account for roughly forty. The cheapest reduction in
+the container attack surface is not to patch those packages but to stop
+installing them.
+
+These tests build the `runtime` stage and assert on the result. They are marked
+``container`` and skip when Docker is unavailable, so they stay out of the normal
+suite; run them with ``-m container``.
+"""
+
+import json
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.container, pytest.mark.slow]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMAGE_TAG = "fraiseql:pytest-runtime"
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(["docker", "info"], capture_output=True, check=False).returncode == 0
+
+
+requires_docker = pytest.mark.skipif(not _docker_available(), reason="Docker is not available")
+
+
+@pytest.fixture(scope="module")
+def runtime_image() -> str:
+    """Build the runtime stage. Warm layer cache makes this cheap after the first run."""
+    build = subprocess.run(
+        ["docker", "build", "--target", "runtime", "-t", IMAGE_TAG, "."],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if build.returncode != 0:
+        pytest.fail(f"docker build failed:\n{build.stdout[-4000:]}\n{build.stderr[-4000:]}")
+    return IMAGE_TAG
+
+
+def _run(image: str, *argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["docker", "run", "--rm", "--entrypoint", "", image, *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@requires_docker
+class TestAttackSurface:
+    def test_curl_is_not_installed(self, runtime_image: str) -> None:
+        """`curl` existed only for the HEALTHCHECK. It and libcurl carry ~40 alerts."""
+        assert _run(runtime_image, "sh", "-c", "command -v curl").returncode != 0
+
+    def test_libcurl_and_libssh2_are_gone_with_it(self, runtime_image: str) -> None:
+        """libssh2 is a libcurl dependency; nothing else in the image pulls either."""
+        installed = _run(runtime_image, "dpkg-query", "-f", "${Package}\n", "-W").stdout
+        packages = set(installed.split())
+        assert not {p for p in packages if p.startswith(("curl", "libcurl", "libssh2"))}
+
+    def test_libpq5_and_its_dependencies_are_still_present(self, runtime_image: str) -> None:
+        """The floor: krb5 and openldap are *libpq5's* dependencies, not curl's.
+
+        They stay, and so do their alerts — dropping curl does not touch them.
+        Asserting it here keeps a future "cut more packages" change from breaking
+        PostgreSQL connectivity in pursuit of a lower alert count.
+        """
+        installed = _run(runtime_image, "dpkg-query", "-f", "${Package}\n", "-W").stdout
+        packages = set(installed.split())
+        assert "libpq5" in packages
+        assert any(p.startswith("libgssapi-krb5") for p in packages)
+        assert any(p.startswith("libldap") for p in packages)
+
+    def test_pip_is_not_installed(self, runtime_image: str) -> None:
+        """The wheel is already installed and the entrypoint is gunicorn.
+
+        pip is also the *only* source of the msgpack alert — the image has no
+        msgpack distribution, just `pip/_vendor/msgpack`.
+        """
+        assert _run(runtime_image, "python", "-c", "import pip").returncode != 0
+
+    def test_setuptools_is_not_installed(self, runtime_image: str) -> None:
+        assert _run(runtime_image, "python", "-c", "import setuptools").returncode != 0
+
+    def test_no_vendored_msgpack_remains(self, runtime_image: str) -> None:
+        found = _run(
+            runtime_image, "sh", "-c", 'find / -iname "msgpack*" -maxdepth 8 2>/dev/null'
+        ).stdout.strip()
+        assert found == "", f"msgpack still present at: {found}"
+
+    def test_fraiseql_still_imports(self, runtime_image: str) -> None:
+        """Removing build tooling must not remove the package it installed."""
+        result = _run(runtime_image, "python", "-c", "import fraiseql; print(fraiseql.__version__)")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip()
+
+    def test_runs_as_a_non_root_user(self, runtime_image: str) -> None:
+        assert _run(runtime_image, "id", "-un").stdout.strip() == "fraiseql"
+
+
+@requires_docker
+class TestHealthcheck:
+    def test_healthcheck_command_does_not_use_curl(self, runtime_image: str) -> None:
+        inspect = subprocess.run(
+            ["docker", "inspect", "--format", "{{json .Config.Healthcheck}}", runtime_image],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        healthcheck = json.loads(inspect.stdout)
+        assert healthcheck is not None, "the image must still declare a HEALTHCHECK"
+        command = " ".join(healthcheck["Test"])
+        assert "curl" not in command
+        assert "python" in command
+
+    def test_healthcheck_reports_healthy_against_a_running_server(
+        self, runtime_image: str
+    ) -> None:
+        """The only functional change in this phase: prove it against a live container.
+
+        A HEALTHCHECK that cannot run is indistinguishable from one that always
+        fails, and both look the same in a build.
+        """
+        name = f"fraiseql-health-{uuid.uuid4().hex[:8]}"
+        started = subprocess.run(
+            [
+                "docker", "run", "-d", "--name", name, "--entrypoint", "python", runtime_image,
+                "-c",
+                "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+                "class H(BaseHTTPRequestHandler):\n"
+                "    def do_GET(self):\n"
+                "        ok = self.path == '/health'\n"
+                "        self.send_response(200 if ok else 404)\n"
+                "        self.end_headers()\n"
+                "        self.wfile.write(b'{\"status\":\"ok\"}' if ok else b'')\n"
+                "    def log_message(self, *a): pass\n"
+                "HTTPServer(('0.0.0.0', 8000), H).serve_forever()\n",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert started.returncode == 0, started.stderr
+        try:
+            deadline = time.time() + 90
+            status = None
+            while time.time() < deadline:
+                status = subprocess.run(
+                    ["docker", "inspect", "--format", "{{.State.Health.Status}}", name],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                ).stdout.strip()
+                if status == "healthy":
+                    break
+                if status == "unhealthy":
+                    logs = subprocess.run(
+                        ["docker", "inspect", "--format", "{{json .State.Health}}", name],
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    ).stdout
+                    pytest.fail(f"HEALTHCHECK reported unhealthy: {logs}")
+                time.sleep(2)
+            assert status == "healthy", f"health status stuck at {status!r}"
+        finally:
+            subprocess.run(["docker", "rm", "-f", name], capture_output=True, check=False)

--- a/tests/integration/database/sql/test_order_by_column_mapping_values.py
+++ b/tests/integration/database/sql/test_order_by_column_mapping_values.py
@@ -1,17 +1,24 @@
-"""Issue #467, third leg: ordering on a mapped column changes row order, for real.
+"""Issue #467, third leg: what ordering on a mapped column actually changes.
 
-The SQL-text tests prove the expression is `t."col"`. They cannot prove the rows
-come back in a different order, and that is the whole risk of this change: a
-JSONB snapshot is compared with jsonb semantics, a real column with the column's
-own type. Where the snapshot holds a number or a date as a *string*, the two
-disagree — lexicographically "10" < "9", and "01/10/2025" < "05/01/2025".
+The SQL-text tests prove the expression is `t."col"`. They cannot prove which
+rows come back first, and that is the whole risk of this change: a JSONB snapshot
+is compared with jsonb semantics, a real column with the column's own type.
 
-So these run against a live database and assert on values: one numeric mapped
-column, one date mapped column, each ordered both ways.
+Dates in a JSONB snapshot are always ISO 8601 — the Date scalar serializes with
+``isoformat()`` and validates the string on the way out — and ISO dates sort
+lexicographically in chronological order. So for the shape this library actually
+produces, **the mapping does not reorder values**. The same holds for a measure
+stored as a JSON number, which is why the generator uses ``->`` and not ``->>``.
 
-They also exercise the ``AS t`` alias a mapped sort key needs on the plain
-(non-aggregated) SELECT — without it PostgreSQL rejects the statement outright,
-so a missing alias fails here as a syntax error rather than as bad SQL text.
+What does change, always, is where NULLs land: jsonb ``null`` is the lowest jsonb
+value and sorts first, while a SQL NULL sorts last in ASC. And values genuinely
+reorder in two shapes a snapshot can still carry — a number written as a string,
+and an ISO *timestamp* whose rows do not share one UTC offset.
+
+Each of those is asserted below, against a live database, mapped and unmapped.
+These also exercise the ``AS t`` alias a mapped sort key needs on the plain
+(non-aggregated) SELECT: without it PostgreSQL rejects the statement outright, so
+a missing alias fails here as a syntax error rather than as bad SQL text.
 """
 
 import json
@@ -26,55 +33,65 @@ from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, reg
 pytestmark = pytest.mark.database
 
 VIEW = "v_467_order_values"
-COLUMNS = {"id", "identifier", "period_date", "model_count", "data"}
+COLUMNS = {"id", "period_date", "model_count", "moment_ts", "data"}
+
+# Every mapped path resolves to the same flat column its snapshot value mirrors.
 MAPPING = {
-    "dimensions.stats.count": "model_count",
     "dimensions.stats.day": "period_date",
+    "dimensions.stats.count": "model_count",
+    "dimensions.stats.count_text": "model_count",
+    "dimensions.stats.moment": "moment_ts",
 }
 
-# The JSONB snapshot stores the count and the day as *strings*, in a spelling
-# whose lexicographic order is neither the numeric nor the chronological one.
-# 'label' is deliberately unmapped: it must sort identically either way.
+# (tag, period_date, model_count, moment_ts). The 'none' row carries jsonb null
+# in every snapshot slot and SQL NULL in every column.
 ROWS = [
-    ("nine", "2025-10-01", 9, "01/10/2025", "c-label"),
-    ("ten", "2025-01-05", 10, "05/01/2025", "a-label"),
-    ("hundred", "2025-02-10", 100, "10/02/2025", "b-label"),
+    ("oct", "2025-10-01", 9, "2025-01-05T00:00:00+02:00"),
+    ("jan", "2025-01-05", 10, "2025-01-04T23:30:00+00:00"),
+    ("feb", "2025-02-10", 100, "2025-01-05T01:00:00+05:00"),
+    ("none", None, None, None),
 ]
-
-
-def _snapshot(count: int, day_text: str, label: str) -> dict:
-    return {"dimensions": {"stats": {"count": str(count), "day": day_text, "label": label}}}
 
 
 class _Stats:
     """Stand-in for a @fraise_type analytics class."""
 
 
+def _snapshot(tag: str, day: str | None, count: int | None, moment: str | None) -> dict:
+    """The frozen JSONB view of a row, mirroring the flat columns."""
+    return {
+        "tag": tag,
+        "dimensions": {
+            "stats": {
+                "day": day,
+                "count": count,
+                "count_text": None if count is None else str(count),
+                "moment": moment,
+                "label": None if count is None else f"label-{count:03d}",
+            }
+        },
+    }
+
+
 @pytest.fixture
 async def stats_table(class_db_pool, test_schema) -> AsyncIterator[None]:
-    """A hybrid table whose flat columns and JSONB snapshot sort differently."""
+    """A hybrid table whose JSONB snapshot mirrors its flat columns."""
     async with class_db_pool.connection() as conn, conn.cursor() as cursor:
         await cursor.execute(f"SET search_path TO {test_schema}")
         await cursor.execute(f"""
             CREATE TABLE IF NOT EXISTS {VIEW} (
                 id UUID PRIMARY KEY,
-                identifier TEXT,
                 period_date DATE,
                 model_count INTEGER,
+                moment_ts TIMESTAMPTZ,
                 data JSONB
             )
         """)
-        for identifier, day, count, day_text, label in ROWS:
+        for tag, day, count, moment in ROWS:
             await cursor.execute(
-                f"INSERT INTO {VIEW} (id, identifier, period_date, model_count, data) "
+                f"INSERT INTO {VIEW} (id, period_date, model_count, moment_ts, data) "
                 f"VALUES (%s, %s, %s, %s, %s::jsonb)",
-                (
-                    uuid.uuid4(),
-                    identifier,
-                    day,
-                    count,
-                    json.dumps(_snapshot(count, day_text, label)),
-                ),
+                (uuid.uuid4(), day, count, moment, json.dumps(_snapshot(tag, day, count, moment))),
             )
         await conn.commit()
 
@@ -100,112 +117,126 @@ def _register(*, with_mapping: bool) -> None:
     )
 
 
-async def _order(pool: Any, schema: str, order_by: dict, *, with_mapping: bool) -> list[str]:
-    """Run the built query against the database and return the identifiers, in order."""
-    _register(with_mapping=with_mapping)
+async def _order(pool: Any, schema: str, path: str, direction: str, *, mapped: bool) -> list[str]:
+    """Run the built query against the database and return the row tags, in order."""
+    _register(with_mapping=mapped)
     repo = FraiseQLRepository(pool)
-    query = repo._build_find_query(VIEW, jsonb_column="data", order_by=order_by)
+    leaf = path.rsplit(".", 1)[-1]
+    query = repo._build_find_query(
+        VIEW,
+        jsonb_column="data",
+        order_by={"dimensions": {"stats": {leaf: direction}}},
+    )
 
     async with pool.connection() as conn, conn.cursor() as cursor:
         await cursor.execute(f"SET search_path TO {schema}")
         await cursor.execute(query.statement, query.params)
         rows = await cursor.fetchall()
 
-    # The projection is the JSONB snapshot; identify rows by the count they carry.
-    counts = [json.loads(row[0])["dimensions"]["stats"]["count"] for row in rows]
-    by_count = {str(count): identifier for identifier, _, count, _, _ in ROWS}
-    return [by_count[c] for c in counts]
+    return [json.loads(row[0])["tag"] for row in rows]
 
 
-class TestNumericMappedColumn:
-    """A count stored as a JSONB string sorts lexicographically; the column does not."""
+def _without_nulls(tags: list[str]) -> list[str]:
+    return [t for t in tags if t != "none"]
 
-    async def test_ascending_is_numeric_not_lexicographic(
+
+class TestIsoDatesKeepTheirOrder:
+    """The convention is ISO, and ISO dates sort the same either way."""
+
+    async def test_ascending_values_are_unchanged_by_the_mapping(
         self, class_db_pool, test_schema, stats_table
     ) -> None:
-        ordered = await _order(
-            class_db_pool,
-            test_schema,
-            {"dimensions": {"stats": {"count": "asc"}}},
-            with_mapping=True,
-        )
+        mapped = await _order(class_db_pool, test_schema, "stats.day", "asc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.day", "asc", mapped=False)
 
-        assert ordered == ["nine", "ten", "hundred"]
+        assert _without_nulls(mapped) == ["jan", "feb", "oct"]
+        assert _without_nulls(unmapped) == _without_nulls(mapped)
 
-    async def test_descending_is_numeric(self, class_db_pool, test_schema, stats_table) -> None:
-        ordered = await _order(
-            class_db_pool,
-            test_schema,
-            {"dimensions": {"stats": {"count": "desc"}}},
-            with_mapping=True,
-        )
-
-        assert ordered == ["hundred", "ten", "nine"]
-
-    async def test_without_the_mapping_the_order_is_lexicographic(
+    async def test_descending_values_are_unchanged_by_the_mapping(
         self, class_db_pool, test_schema, stats_table
     ) -> None:
-        """The contrast that makes this a real change, not just different SQL text."""
-        ordered = await _order(
-            class_db_pool,
-            test_schema,
-            {"dimensions": {"stats": {"count": "asc"}}},
-            with_mapping=False,
-        )
+        mapped = await _order(class_db_pool, test_schema, "stats.day", "desc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.day", "desc", mapped=False)
 
-        assert ordered == ["ten", "hundred", "nine"]
+        assert _without_nulls(mapped) == ["oct", "feb", "jan"]
+        assert _without_nulls(unmapped) == _without_nulls(mapped)
 
 
-class TestDateMappedColumn:
-    """A day stored as a DD/MM/YYYY string sorts by its digits; the DATE column does not."""
+class TestJsonNumbersKeepTheirOrder:
+    """``->`` preserves the jsonb type, so a measure stored as a number already sorted right."""
 
-    async def test_ascending_is_chronological(
+    async def test_values_are_unchanged_by_the_mapping(
         self, class_db_pool, test_schema, stats_table
     ) -> None:
-        ordered = await _order(
-            class_db_pool,
-            test_schema,
-            {"dimensions": {"stats": {"day": "asc"}}},
-            with_mapping=True,
-        )
+        mapped = await _order(class_db_pool, test_schema, "stats.count", "asc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.count", "asc", mapped=False)
 
-        assert ordered == ["ten", "hundred", "nine"]
+        assert _without_nulls(mapped) == ["oct", "jan", "feb"]
+        assert _without_nulls(unmapped) == _without_nulls(mapped)
 
-    async def test_descending_is_chronological(
+
+class TestNullPlacementChanges:
+    """The one change that is always there: jsonb null sorts first, SQL NULL sorts last."""
+
+    async def test_ascending_moves_nulls_from_first_to_last(
         self, class_db_pool, test_schema, stats_table
     ) -> None:
-        ordered = await _order(
-            class_db_pool,
-            test_schema,
-            {"dimensions": {"stats": {"day": "desc"}}},
-            with_mapping=True,
-        )
+        mapped = await _order(class_db_pool, test_schema, "stats.day", "asc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.day", "asc", mapped=False)
 
-        assert ordered == ["nine", "hundred", "ten"]
+        assert unmapped[0] == "none"
+        assert mapped[-1] == "none"
 
-    async def test_without_the_mapping_the_order_is_lexicographic(
+    async def test_descending_moves_nulls_from_last_to_first(
         self, class_db_pool, test_schema, stats_table
     ) -> None:
-        ordered = await _order(
-            class_db_pool,
-            test_schema,
-            {"dimensions": {"stats": {"day": "asc"}}},
-            with_mapping=False,
-        )
+        mapped = await _order(class_db_pool, test_schema, "stats.day", "desc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.day", "desc", mapped=False)
 
-        assert ordered == ["nine", "ten", "hundred"]
+        assert unmapped[-1] == "none"
+        assert mapped[0] == "none"
+
+    async def test_the_same_holds_for_a_numeric_column(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        mapped = await _order(class_db_pool, test_schema, "stats.count", "asc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.count", "asc", mapped=False)
+
+        assert unmapped[0] == "none"
+        assert mapped[-1] == "none"
+
+
+class TestValuesReorderWhenTheSnapshotIsNotTyped:
+    """Two shapes where the mapping genuinely changes which row comes first."""
+
+    async def test_a_number_written_as_a_string_sorted_lexicographically(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        mapped = await _order(class_db_pool, test_schema, "stats.count_text", "asc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.count_text", "asc", mapped=False)
+
+        assert _without_nulls(mapped) == ["oct", "jan", "feb"]  # 9, 10, 100
+        assert _without_nulls(unmapped) == ["jan", "feb", "oct"]  # "10", "100", "9"
+
+    async def test_iso_timestamps_with_differing_offsets(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        """Every string here is valid ISO 8601 — lexicographic still is not chronological."""
+        mapped = await _order(class_db_pool, test_schema, "stats.moment", "asc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.moment", "asc", mapped=False)
+
+        assert _without_nulls(mapped) == ["feb", "oct", "jan"]
+        assert _without_nulls(unmapped) == ["jan", "oct", "feb"]
 
 
 class TestUnmappedOrderingIsUnchanged:
-    """Anything the mapping does not name sorts exactly as it did — same rows, same order."""
+    """Anything the mapping does not name sorts exactly as it did."""
 
     async def test_unmapped_path_is_identical_with_and_without_the_mapping(
         self, class_db_pool, test_schema, stats_table
     ) -> None:
-        order_by = {"dimensions": {"stats": {"label": "asc"}}}
+        mapped = await _order(class_db_pool, test_schema, "stats.label", "asc", mapped=True)
+        unmapped = await _order(class_db_pool, test_schema, "stats.label", "asc", mapped=False)
 
-        with_mapping = await _order(class_db_pool, test_schema, order_by, with_mapping=True)
-        without_mapping = await _order(class_db_pool, test_schema, order_by, with_mapping=False)
-
-        assert with_mapping == without_mapping
-        assert with_mapping == ["ten", "hundred", "nine"]
+        assert mapped == unmapped
+        assert _without_nulls(mapped) == ["oct", "jan", "feb"]

--- a/tests/integration/database/sql/test_order_by_column_mapping_values.py
+++ b/tests/integration/database/sql/test_order_by_column_mapping_values.py
@@ -1,0 +1,211 @@
+"""Issue #467, third leg: ordering on a mapped column changes row order, for real.
+
+The SQL-text tests prove the expression is `t."col"`. They cannot prove the rows
+come back in a different order, and that is the whole risk of this change: a
+JSONB snapshot is compared with jsonb semantics, a real column with the column's
+own type. Where the snapshot holds a number or a date as a *string*, the two
+disagree — lexicographically "10" < "9", and "01/10/2025" < "05/01/2025".
+
+So these run against a live database and assert on values: one numeric mapped
+column, one date mapped column, each ordered both ways.
+
+They also exercise the ``AS t`` alias a mapped sort key needs on the plain
+(non-aggregated) SELECT — without it PostgreSQL rejects the statement outright,
+so a missing alias fails here as a syntax error rather than as bad SQL text.
+"""
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+
+pytestmark = pytest.mark.database
+
+VIEW = "v_467_order_values"
+COLUMNS = {"id", "identifier", "period_date", "model_count", "data"}
+MAPPING = {
+    "dimensions.stats.count": "model_count",
+    "dimensions.stats.day": "period_date",
+}
+
+# The JSONB snapshot stores the count and the day as *strings*, in a spelling
+# whose lexicographic order is neither the numeric nor the chronological one.
+# 'label' is deliberately unmapped: it must sort identically either way.
+ROWS = [
+    ("nine", "2025-10-01", 9, "01/10/2025", "c-label"),
+    ("ten", "2025-01-05", 10, "05/01/2025", "a-label"),
+    ("hundred", "2025-02-10", 100, "10/02/2025", "b-label"),
+]
+
+
+def _snapshot(count: int, day_text: str, label: str) -> dict:
+    return {"dimensions": {"stats": {"count": str(count), "day": day_text, "label": label}}}
+
+
+class _Stats:
+    """Stand-in for a @fraise_type analytics class."""
+
+
+@pytest.fixture
+async def stats_table(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """A hybrid table whose flat columns and JSONB snapshot sort differently."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {test_schema}")
+        await cursor.execute(f"""
+            CREATE TABLE IF NOT EXISTS {VIEW} (
+                id UUID PRIMARY KEY,
+                identifier TEXT,
+                period_date DATE,
+                model_count INTEGER,
+                data JSONB
+            )
+        """)
+        for identifier, day, count, day_text, label in ROWS:
+            await cursor.execute(
+                f"INSERT INTO {VIEW} (id, identifier, period_date, model_count, data) "
+                f"VALUES (%s, %s, %s, %s, %s::jsonb)",
+                (
+                    uuid.uuid4(),
+                    identifier,
+                    day,
+                    count,
+                    json.dumps(_snapshot(count, day_text, label)),
+                ),
+            )
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {test_schema}")
+        await cursor.execute(f"DROP TABLE IF EXISTS {VIEW} CASCADE")
+        await conn.commit()
+
+    _table_metadata.pop(VIEW, None)
+    _type_registry.pop(VIEW, None)
+
+
+def _register(*, with_mapping: bool) -> None:
+    register_type_for_view(
+        VIEW,
+        _Stats,
+        table_columns=COLUMNS,
+        has_jsonb_data=True,
+        jsonb_column="data",
+        column_mapping=MAPPING if with_mapping else None,
+    )
+
+
+async def _order(pool: Any, schema: str, order_by: dict, *, with_mapping: bool) -> list[str]:
+    """Run the built query against the database and return the identifiers, in order."""
+    _register(with_mapping=with_mapping)
+    repo = FraiseQLRepository(pool)
+    query = repo._build_find_query(VIEW, jsonb_column="data", order_by=order_by)
+
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {schema}")
+        await cursor.execute(query.statement, query.params)
+        rows = await cursor.fetchall()
+
+    # The projection is the JSONB snapshot; identify rows by the count they carry.
+    counts = [json.loads(row[0])["dimensions"]["stats"]["count"] for row in rows]
+    by_count = {str(count): identifier for identifier, _, count, _, _ in ROWS}
+    return [by_count[c] for c in counts]
+
+
+class TestNumericMappedColumn:
+    """A count stored as a JSONB string sorts lexicographically; the column does not."""
+
+    async def test_ascending_is_numeric_not_lexicographic(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        ordered = await _order(
+            class_db_pool,
+            test_schema,
+            {"dimensions": {"stats": {"count": "asc"}}},
+            with_mapping=True,
+        )
+
+        assert ordered == ["nine", "ten", "hundred"]
+
+    async def test_descending_is_numeric(self, class_db_pool, test_schema, stats_table) -> None:
+        ordered = await _order(
+            class_db_pool,
+            test_schema,
+            {"dimensions": {"stats": {"count": "desc"}}},
+            with_mapping=True,
+        )
+
+        assert ordered == ["hundred", "ten", "nine"]
+
+    async def test_without_the_mapping_the_order_is_lexicographic(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        """The contrast that makes this a real change, not just different SQL text."""
+        ordered = await _order(
+            class_db_pool,
+            test_schema,
+            {"dimensions": {"stats": {"count": "asc"}}},
+            with_mapping=False,
+        )
+
+        assert ordered == ["ten", "hundred", "nine"]
+
+
+class TestDateMappedColumn:
+    """A day stored as a DD/MM/YYYY string sorts by its digits; the DATE column does not."""
+
+    async def test_ascending_is_chronological(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        ordered = await _order(
+            class_db_pool,
+            test_schema,
+            {"dimensions": {"stats": {"day": "asc"}}},
+            with_mapping=True,
+        )
+
+        assert ordered == ["ten", "hundred", "nine"]
+
+    async def test_descending_is_chronological(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        ordered = await _order(
+            class_db_pool,
+            test_schema,
+            {"dimensions": {"stats": {"day": "desc"}}},
+            with_mapping=True,
+        )
+
+        assert ordered == ["nine", "hundred", "ten"]
+
+    async def test_without_the_mapping_the_order_is_lexicographic(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        ordered = await _order(
+            class_db_pool,
+            test_schema,
+            {"dimensions": {"stats": {"day": "asc"}}},
+            with_mapping=False,
+        )
+
+        assert ordered == ["nine", "ten", "hundred"]
+
+
+class TestUnmappedOrderingIsUnchanged:
+    """Anything the mapping does not name sorts exactly as it did — same rows, same order."""
+
+    async def test_unmapped_path_is_identical_with_and_without_the_mapping(
+        self, class_db_pool, test_schema, stats_table
+    ) -> None:
+        order_by = {"dimensions": {"stats": {"label": "asc"}}}
+
+        with_mapping = await _order(class_db_pool, test_schema, order_by, with_mapping=True)
+        without_mapping = await _order(class_db_pool, test_schema, order_by, with_mapping=False)
+
+        assert with_mapping == without_mapping
+        assert with_mapping == ["ten", "hundred", "nine"]

--- a/tests/integration/database/sql/test_partial_period_union_execution.py
+++ b/tests/integration/database/sql/test_partial_period_union_execution.py
@@ -1,0 +1,363 @@
+"""Issue #468: the partial-period UNION, executed against a live database.
+
+The regression tests assert on SQL text. They cannot say whether PostgreSQL accepts
+the statement, nor which rows come back — and this change touches both:
+
+* an ``OR``/``NOT`` group now survives into ``extra_where``, so the branches must
+  actually *exclude* rows they used to return;
+* a caller's ``order_by`` is projected per branch and referenced from a wrapping
+  ``SELECT "u"."d" FROM (…) AS "u"("d", "s0")``. That column-alias list is new
+  syntax on this path — if it is wrong the tests below fail as a syntax error
+  rather than as a bad string comparison.
+
+The fixture builds a coarse monthly view and the fine-grain daily view it is
+derived from, with a lower bound mid-January so the window straddles a period
+boundary and both branch kinds are exercised.
+"""
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from datetime import date
+from typing import Any
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _build_partial_period_union_query
+from fraiseql.partial_period import _build_extra_where
+from fraiseql.where_clause import FieldCondition, WhereClause
+
+pytestmark = pytest.mark.database
+
+COARSE = "v_468_month"
+FINE = "v_468_day"
+
+# (date, category, status, cost)
+FINE_ROWS = [
+    ("2025-01-10", "A", "active", 5),  # below the lower bound
+    ("2025-01-20", "A", "active", 10),
+    ("2025-01-25", "A", "archived", 100),
+    ("2025-02-10", "A", "active", 20),
+    ("2025-02-15", "B", "pending", 30),
+    ("2025-03-05", "A", "archived", 200),
+]
+
+# The coarse view, pre-aggregated to month starts. Consistent with FINE_ROWS.
+COARSE_ROWS = [
+    ("2025-01-01", "A", "active", 15),
+    ("2025-01-01", "A", "archived", 100),
+    ("2025-02-01", "A", "active", 20),
+    ("2025-02-01", "B", "pending", 30),
+    ("2025-03-01", "A", "archived", 200),
+]
+
+# The window: mid-January (not month-aligned) through the end of March.
+# Branch 1 is fine-grain [01-15, 02-01); Branch 2 is coarse [02-01, 04-01).
+BASE: dict[str, Any] = {
+    "coarse_view": COARSE,
+    "fine_grain_view": FINE,
+    "time_grain_column": "date",
+    "time_grain_trunc": "month",
+    "group_by": ["date", "dimensions.category"],
+    "aggregations": {"measures.cost": "SUM(measures.cost)"},
+    "native_dimensions": {"date"},
+    "native_measures": {"measures.cost": "cost"},
+    "native_dimension_mapping": {"dimensions.category": "model_category"},
+    "jsonb_col": "data",
+    "extra_where": None,
+    "lower_bound": date(2025, 1, 15),
+    "upper_bound_exclusive": date(2025, 4, 1),
+    "today": date(2025, 4, 15),
+}
+
+
+def _snapshot(day: str, category: str, status: str, cost: int) -> dict:
+    return {
+        "date": day,
+        "status": status,
+        "dimensions": {"category": category},
+        "measures": {"cost": cost},
+    }
+
+
+@pytest.fixture
+async def stats_views(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """A coarse monthly table and the fine-grain daily table behind it."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {test_schema}")
+        for table in (COARSE, FINE):
+            await cursor.execute(f"""
+                CREATE TABLE IF NOT EXISTS {table} (
+                    id UUID PRIMARY KEY,
+                    date DATE NOT NULL,
+                    status TEXT NOT NULL,
+                    model_category TEXT NOT NULL,
+                    cost INTEGER NOT NULL,
+                    data JSONB NOT NULL
+                )
+            """)
+        for table, rows in ((FINE, FINE_ROWS), (COARSE, COARSE_ROWS)):
+            for day, category, status, cost in rows:
+                await cursor.execute(
+                    f"INSERT INTO {table} (id, date, status, model_category, cost, data) "
+                    f"VALUES (%s, %s, %s, %s, %s, %s::jsonb)",
+                    (
+                        uuid.uuid4(),
+                        day,
+                        status,
+                        category,
+                        cost,
+                        json.dumps(_snapshot(day, category, status, cost)),
+                    ),
+                )
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {test_schema}")
+        for table in (COARSE, FINE):
+            await cursor.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+        await conn.commit()
+
+
+def _condition(column: str, value: Any, operator: str = "eq") -> FieldCondition:
+    return FieldCondition(
+        field_path=[column],
+        operator=operator,
+        value=value,
+        lookup_strategy="sql_column",
+        target_column=column,
+    )
+
+
+def _lower_bound_condition() -> FieldCondition:
+    """The date bound the UNION builder re-encodes per branch."""
+    return _condition("date", BASE["lower_bound"], operator="gte")
+
+
+async def _run(pool: Any, schema: str, **overrides: Any) -> list[dict]:
+    """Execute the built UNION query and return the decoded rows, in order.
+
+    A ``where=`` override is the caller's *whole* normalised clause, date bound
+    included, and goes through ``_build_extra_where`` exactly as the dispatch in
+    ``find()`` does — so these tests cover the construction that dropped the
+    OR/NOT groups, not only the builder that renders them.
+    """
+    where = overrides.pop("where", None)
+    if where is not None:
+        overrides["extra_where"] = _build_extra_where(
+            where, BASE["time_grain_column"], overrides.pop("mandatory", ())
+        )
+    query = _build_partial_period_union_query(**{**BASE, **overrides})
+
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {schema}")
+        await cursor.execute(query.statement, query.params)
+        rows = await cursor.fetchall()
+
+    return [json.loads(row[0]) for row in rows]
+
+
+def _key(row: dict) -> tuple[str, str, int]:
+    return row["date"], row["dimensions"]["category"], row["measures"]["cost"]
+
+
+class TestUnfiltered:
+    """The baseline every filtering test is measured against."""
+
+    async def test_both_branch_kinds_contribute(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        rows = await _run(class_db_pool, test_schema)
+
+        assert sorted(_key(r) for r in rows) == [
+            # Branch 1, recomputed from the daily view: 10 + 100, and no 2025-01-10.
+            ("2025-01-01", "A", 110),
+            ("2025-02-01", "A", 20),
+            ("2025-02-01", "B", 30),
+            ("2025-03-01", "A", 200),
+        ]
+
+
+class TestOrGroupFilters:
+    """An OR group must exclude rows in every branch, not just survive as text."""
+
+    async def test_or_group_excludes_rows_from_both_branches(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        """The fail-open shape: the date bound is the only top-level condition."""
+        where = WhereClause(
+            conditions=[_lower_bound_condition()],
+            nested_clauses=[
+                WhereClause(
+                    nested_clauses=[
+                        WhereClause(conditions=[_condition("status", "active")]),
+                        WhereClause(conditions=[_condition("status", "pending")]),
+                    ],
+                    logical_op="OR",
+                )
+            ],
+        )
+
+        rows = await _run(class_db_pool, test_schema, where=where)
+
+        assert sorted(_key(r) for r in rows) == [
+            ("2025-01-01", "A", 10),  # the archived 100 is gone
+            ("2025-02-01", "A", 20),
+            ("2025-02-01", "B", 30),
+        ]
+
+    async def test_or_group_combines_with_a_flat_condition(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        where = WhereClause(
+            conditions=[_lower_bound_condition(), _condition("model_category", "A")],
+            nested_clauses=[
+                WhereClause(
+                    nested_clauses=[
+                        WhereClause(conditions=[_condition("status", "active")]),
+                        WhereClause(conditions=[_condition("status", "pending")]),
+                    ],
+                    logical_op="OR",
+                )
+            ],
+        )
+
+        rows = await _run(class_db_pool, test_schema, where=where)
+
+        assert sorted(_key(r) for r in rows) == [
+            ("2025-01-01", "A", 10),
+            ("2025-02-01", "A", 20),
+        ]
+
+    async def test_mandatory_filters_and_the_group_both_apply(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        """#344's injected conditions are ANDed in front of the preserved group."""
+        where = WhereClause(
+            conditions=[_lower_bound_condition()],
+            nested_clauses=[
+                WhereClause(
+                    nested_clauses=[
+                        WhereClause(conditions=[_condition("status", "active")]),
+                        WhereClause(conditions=[_condition("status", "pending")]),
+                    ],
+                    logical_op="OR",
+                )
+            ],
+        )
+
+        rows = await _run(
+            class_db_pool,
+            test_schema,
+            where=where,
+            mandatory=[_condition("model_category", "B")],
+        )
+
+        assert sorted(_key(r) for r in rows) == [("2025-02-01", "B", 30)]
+
+
+class TestNotClauseFilters:
+    async def test_not_clause_excludes_rows_from_both_branches(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        where = WhereClause(
+            conditions=[_lower_bound_condition()],
+            not_clause=WhereClause(conditions=[_condition("status", "active")]),
+        )
+
+        rows = await _run(class_db_pool, test_schema, where=where)
+
+        assert sorted(_key(r) for r in rows) == [
+            ("2025-01-01", "A", 100),
+            ("2025-02-01", "B", 30),
+            ("2025-03-01", "A", 200),
+        ]
+
+
+class TestOrderByAcrossTheUnion:
+    """The wrapper is new SQL on this path — these fail as syntax errors if it is wrong."""
+
+    @staticmethod
+    def _order_by(pool: Any, spec: Any) -> Any:
+        return FraiseQLRepository(pool)._resolve_order_by_set(spec)
+
+    async def test_measure_alias_orders_the_whole_result(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        rows = await _run(
+            class_db_pool,
+            test_schema,
+            order_by=self._order_by(class_db_pool, {"measures": {"cost": "desc"}}),
+        )
+
+        assert [r["measures"]["cost"] for r in rows] == [200, 110, 30, 20]
+
+    async def test_mapped_dimension_orders_the_whole_result(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        """Ordering on the mapped path sorts on ``model_category``, across branches."""
+        rows = await _run(
+            class_db_pool,
+            test_schema,
+            order_by=self._order_by(class_db_pool, {"dimensions": {"category": "desc"}}),
+        )
+
+        assert [r["dimensions"]["category"] for r in rows] == ["B", "A", "A", "A"]
+
+    async def test_native_dimension_orders_across_branch_kinds(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        """``date`` is truncated in the fine branch and read raw in the coarse one."""
+        rows = await _run(
+            class_db_pool,
+            test_schema,
+            order_by=self._order_by(class_db_pool, {"date": "desc"}),
+        )
+
+        assert [r["date"] for r in rows] == [
+            "2025-03-01",
+            "2025-02-01",
+            "2025-02-01",
+            "2025-01-01",
+        ]
+
+    async def test_two_sort_keys_apply_in_order(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        rows = await _run(
+            class_db_pool,
+            test_schema,
+            order_by=self._order_by(
+                class_db_pool, {"date": "asc", "dimensions": {"category": "desc"}}
+            ),
+        )
+
+        assert [_key(r) for r in rows] == [
+            ("2025-01-01", "A", 110),
+            ("2025-02-01", "B", 30),
+            ("2025-02-01", "A", 20),
+            ("2025-03-01", "A", 200),
+        ]
+
+    async def test_ordering_and_filtering_compose(
+        self, class_db_pool, test_schema, stats_views
+    ) -> None:
+        where = WhereClause(
+            conditions=[_lower_bound_condition()],
+            not_clause=WhereClause(conditions=[_condition("status", "active")]),
+        )
+
+        rows = await _run(
+            class_db_pool,
+            test_schema,
+            where=where,
+            order_by=self._order_by(class_db_pool, {"measures": {"cost": "asc"}}),
+        )
+
+        assert [_key(r) for r in rows] == [
+            ("2025-02-01", "B", 30),
+            ("2025-01-01", "A", 100),
+            ("2025-03-01", "A", 200),
+        ]

--- a/tests/regression/issue_467/__init__.py
+++ b/tests/regression/issue_467/__init__.py
@@ -1,0 +1,1 @@
+"""Issue #467: a declared column mapping honoured in GROUP BY but ignored in WHERE."""

--- a/tests/regression/issue_467/test_order_by_mapping.py
+++ b/tests/regression/issue_467/test_order_by_mapping.py
@@ -1,0 +1,222 @@
+"""Issue #467, third leg: ORDER BY on a mapped dimension path.
+
+``native_dimensions`` (a set of column names) reached the ORDER BY generator;
+the mapping (a path → column dict) did not fit that shape and was never passed.
+Sorting on a mapped path therefore re-ran the whole ``jsonb_build_object`` per
+row — on the aggregated path, on a key already computed natively in the SELECT
+list.
+
+The load-bearing assertion is not "it says model_category". It is that the ORDER
+BY expression is **byte-identical** to the GROUP BY expression for the same path:
+PostgreSQL requires a sort key to be grouped or functionally determined by the
+grouping, so two different expressions for one logical field is a query that
+fails to plan, not merely a slow one.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+
+COLUMNS = {"id", "data", "date", "model_category"}
+MAPPING = {"dimensions.item.model.category": "model_category"}
+
+
+class _Stats:
+    """Stand-in for the reporter's @fraise_type analytics class."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    for view in [v for v in _table_metadata if v.startswith("v_467")]:
+        del _table_metadata[view]
+    for view in [v for v in _type_registry if v.startswith("v_467")]:
+        del _type_registry[view]
+
+
+def _register(view_name: str, **agg_extra: Any) -> None:
+    register_type_for_view(
+        view_name,
+        _Stats,
+        table_columns=COLUMNS,
+        has_jsonb_data=True,
+        jsonb_column="data",
+        aggregation={
+            "dimensions": "dimensions",
+            "measures": {"measures.cost": "SUM"},
+            "native_dimensions": ["date"],
+            "native_dimension_mapping": MAPPING,
+            **agg_extra,
+        },
+    )
+
+
+def _make_pool() -> Any:
+    mock_pool = MagicMock()
+    ctx = mock_pool.connection.return_value
+    ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_pool
+
+
+async def _rendered_sql(view_name: str, **find_kwargs: Any) -> str:
+    repo = FraiseQLRepository(_make_pool())
+    info = MagicMock()
+    info.schema = None
+
+    with (
+        patch(
+            "fraiseql.core.ast_parser.extract_field_paths_from_info",
+            return_value=[
+                MagicMock(path=["date"]),
+                MagicMock(path=["dimensions", "item", "model", "category"]),
+                MagicMock(path=["measures", "cost"]),
+            ],
+        ),
+        patch(
+            "fraiseql.db.execute_via_rust_pipeline",
+            new_callable=AsyncMock,
+            return_value=b'{"data":{"x":[]}}',
+        ) as mock_execute,
+    ):
+        await repo.find(view_name, info=info, **find_kwargs)
+
+    return mock_execute.call_args[0][1].as_string(None)
+
+
+def _clause(rendered: str, keyword: str) -> str:
+    """Return the text of one SQL clause, up to the next clause keyword."""
+    start = rendered.index(keyword) + len(keyword)
+    tail = rendered[start:]
+    for following in (" GROUP BY ", " ORDER BY ", " LIMIT ", " OFFSET "):
+        if following in tail:
+            tail = tail[: tail.index(following)]
+    return tail.strip()
+
+
+class TestOrderByOnAMappedPath:
+    @pytest.mark.asyncio
+    async def test_mapped_path_sorts_on_the_column(self) -> None:
+        _register("v_467_order")
+
+        rendered = await _rendered_sql(
+            "v_467_order", order_by={"dimensions": {"item": {"model": {"category": "desc"}}}}
+        )
+
+        assert 'ORDER BY "t"."model_category" DESC' in rendered
+
+    @pytest.mark.asyncio
+    async def test_sort_key_is_identical_to_the_group_by_key(self) -> None:
+        """The whole point: one logical field, one expression."""
+        _register("v_467_order_match")
+
+        rendered = await _rendered_sql(
+            "v_467_order_match",
+            order_by={"dimensions": {"item": {"model": {"category": "asc"}}}},
+        )
+
+        group_by = _clause(rendered, " GROUP BY ")
+        order_by = _clause(rendered, " ORDER BY ")
+
+        assert order_by == 'ORDER BY "t"."model_category" ASC'.removeprefix("ORDER BY ")
+        assert order_by.removesuffix(" ASC") in group_by
+
+    @pytest.mark.asyncio
+    async def test_native_dimension_ordering_is_unaffected(self) -> None:
+        _register("v_467_order_native")
+
+        rendered = await _rendered_sql("v_467_order_native", order_by={"date": "desc"})
+
+        assert 'ORDER BY "t"."date" DESC' in rendered
+
+    @pytest.mark.asyncio
+    async def test_unmapped_path_still_sorts_on_jsonb(self) -> None:
+        """Byte-identical to today for anything the mapping does not name."""
+        _register("v_467_order_unmapped")
+
+        rendered = await _rendered_sql(
+            "v_467_order_unmapped",
+            order_by={"dimensions": {"item": {"model": {"name": "asc"}}}},
+        )
+
+        assert "-> 'dimensions' -> 'item' -> 'model' -> 'name' ASC" in rendered
+
+    @pytest.mark.asyncio
+    async def test_mixed_ordering_keeps_each_leg_in_its_own_shape(self) -> None:
+        _register("v_467_order_mixed")
+
+        rendered = await _rendered_sql(
+            "v_467_order_mixed",
+            order_by={
+                "date": "desc",
+                "dimensions": {"item": {"model": {"category": "asc"}}},
+            },
+        )
+
+        assert 'ORDER BY "t"."date" DESC, "t"."model_category" ASC' in rendered
+
+    @pytest.mark.asyncio
+    async def test_top_level_column_mapping_reaches_order_by(self) -> None:
+        """``column_mapping=`` is the peer declaration; it must reach here too."""
+        register_type_for_view(
+            "v_467_order_peer",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping=MAPPING,
+            aggregation={
+                "dimensions": "dimensions",
+                "measures": {"measures.cost": "SUM"},
+                "native_dimensions": ["date"],
+            },
+        )
+
+        rendered = await _rendered_sql(
+            "v_467_order_peer",
+            order_by={"dimensions": {"item": {"model": {"category": "desc"}}}},
+        )
+
+        assert 'ORDER BY "t"."model_category" DESC' in rendered
+
+
+class TestNonAggregatedOrdering:
+    """No group_by at all — the mapping is unconditional, like fk_relationships."""
+
+    @pytest.mark.asyncio
+    async def test_mapping_applies_without_aggregation(self) -> None:
+        register_type_for_view(
+            "v_467_order_rows",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping=MAPPING,
+        )
+
+        repo = FraiseQLRepository(_make_pool())
+        info = MagicMock()
+        info.schema = None
+
+        with (
+            patch(
+                "fraiseql.core.ast_parser.extract_field_paths_from_info",
+                return_value=[MagicMock(path=["id"])],
+            ),
+            patch(
+                "fraiseql.db.execute_via_rust_pipeline",
+                new_callable=AsyncMock,
+                return_value=b'{"data":{"x":[]}}',
+            ) as mock_execute,
+        ):
+            await repo.find(
+                "v_467_order_rows",
+                info=info,
+                order_by={"dimensions": {"item": {"model": {"category": "asc"}}}},
+            )
+
+        rendered = mock_execute.call_args[0][1].as_string(None)
+        assert 'ORDER BY "t"."model_category" ASC' in rendered

--- a/tests/regression/issue_467/test_order_by_union_path.py
+++ b/tests/regression/issue_467/test_order_by_union_path.py
@@ -6,7 +6,10 @@ orders on the wrapper. Every branch projects one column — the
 in ``ORDER BY 1``, a positional reference to it. There is no per-branch JSONB
 path in a sort position to fix.
 
-These tests pin that, and pin the gap next to it.
+These tests pin that, and pin what used to be the gap next to it: ``order_by`` was
+never passed to ``_build_partial_period_union_query`` at all, so a caller's sort was
+accepted and silently discarded. Fixed with #468 — ``TestCallerOrderBy`` below is the
+rewrite of the ``TestKnownGap`` that recorded it.
 """
 
 from typing import Any
@@ -120,23 +123,101 @@ class TestUnionOrdering:
         assert rendered.count('"t"."model_category"') >= branches
 
 
-class TestKnownGap:
-    """Not a desired property — a gap pinned so a future fix trips this loudly."""
+class TestCallerOrderBy:
+    """``order_by`` now reaches the UNION query (#468).
+
+    Every branch projects exactly one column, so a sort key has to be projected
+    alongside it and referenced from an outer SELECT — that keeps the statement's
+    output at the single ``json_build_object(...)::text`` column the Rust pipeline
+    reads, while sorting on a typed expression rather than on the JSON text.
+    """
 
     @pytest.mark.asyncio
-    async def test_caller_order_by_does_not_reach_the_union_query(self) -> None:
-        """``order_by`` is never passed to ``_build_partial_period_union_query``.
-
-        Same family as #467 — a declaration accepted and silently discarded — but
-        a different mechanism, so it is recorded here rather than fixed in this
-        phase. When it is fixed, this test should be rewritten, not deleted.
-        """
-        _register("v_467_union_order_dropped")
+    async def test_mapped_dimension_path_orders_on_the_flat_column(self) -> None:
+        _register("v_467_union_order_mapped")
 
         rendered = await _rendered_sql(
-            "v_467_union_order_dropped",
+            "v_467_union_order_mapped",
             order_by={"dimensions": {"item": {"model": {"category": "desc"}}}},
         )
 
+        branches = rendered.count("UNION ALL") + 1
+        assert rendered.endswith(' ORDER BY "u"."s0" DESC')
+        # The sort key is projected once per branch, as the mapped flat column.
+        assert rendered.count('"t"."model_category"') >= 2 * branches
+        assert "ORDER BY 1" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_native_dimension_orders_on_the_branch_expression(self) -> None:
+        """``date`` is truncated per branch — the sort must use the same expression."""
+        _register("v_467_union_order_native")
+
+        rendered = await _rendered_sql("v_467_union_order_native", order_by={"date": "asc"})
+
+        assert rendered.endswith(' ORDER BY "u"."s0" ASC')
+        assert "ORDER BY 1" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_measure_alias_orders_on_the_aggregate(self) -> None:
+        _register("v_467_union_order_measure")
+
+        rendered = await _rendered_sql(
+            "v_467_union_order_measure", order_by={"measures": {"cost": "desc"}}
+        )
+
+        assert rendered.endswith(' ORDER BY "u"."s0" DESC')
+
+    @pytest.mark.asyncio
+    async def test_outer_select_projects_exactly_one_column(self) -> None:
+        """The Rust pipeline reads ``row[0]``; the sort keys must not reach it."""
+        _register("v_467_union_order_shape")
+
+        rendered = await _rendered_sql(
+            "v_467_union_order_shape",
+            order_by={"dimensions": {"item": {"model": {"category": "desc"}}}},
+        )
+
+        assert rendered.startswith('SELECT "u"."d" FROM (')
+        assert ') AS "u"("d", "s0") ORDER BY ' in rendered
+
+    @pytest.mark.asyncio
+    async def test_two_sort_keys_are_projected_separately(self) -> None:
+        """The bare-dict form, which is the one that recurses into nested paths.
+
+        The list-of-dicts form collapses ``{"measures": {"cost": "desc"}}`` to
+        ``measures`` ASC before it ever reaches column resolution — input parsing,
+        pre-existing, and recorded in phase 03's notes rather than fixed here.
+        """
+        _register("v_467_union_order_two")
+
+        rendered = await _rendered_sql(
+            "v_467_union_order_two",
+            order_by={"date": "asc", "measures": {"cost": "desc"}},
+        )
+
+        assert ') AS "u"("d", "s0", "s1") ORDER BY ' in rendered
+        assert rendered.endswith(' ORDER BY "u"."s0" ASC, "u"."s1" DESC')
+
+    @pytest.mark.asyncio
+    async def test_unsortable_field_falls_back_to_the_wrapper_column(self) -> None:
+        """An aggregated query can only sort on a grouped key or a measure.
+
+        A field that is neither is skipped rather than emitted as invalid SQL.
+        """
+        _register("v_467_union_order_unknown")
+
+        rendered = await _rendered_sql("v_467_union_order_unknown", order_by={"nope": "desc"})
+
         assert rendered.endswith(" ORDER BY 1")
         assert "DESC" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_no_order_by_is_byte_identical_to_before(self) -> None:
+        """No sort requested → today's exact statement, unwrapped."""
+        _register("v_467_union_order_none")
+
+        rendered = await _rendered_sql("v_467_union_order_none")
+
+        assert rendered.startswith("SELECT json_build_object(")
+        assert rendered.endswith(" ORDER BY 1")
+        assert ' AS "u"(' not in rendered

--- a/tests/regression/issue_467/test_order_by_union_path.py
+++ b/tests/regression/issue_467/test_order_by_union_path.py
@@ -1,0 +1,142 @@
+"""Issue #467, third leg: ordering across a partial-period UNION.
+
+Confirmed before writing any code, as the phase asked: the UNION builder already
+orders on the wrapper. Every branch projects one column — the
+``json_build_object(...)::text`` the Rust pipeline reads — and the statement ends
+in ``ORDER BY 1``, a positional reference to it. There is no per-branch JSONB
+path in a sort position to fix.
+
+These tests pin that, and pin the gap next to it.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+
+COLUMNS = {"id", "data", "date", "model_category"}
+MAPPING = {"dimensions.item.model.category": "model_category"}
+WHERE = {"date": {"gte": "2025-01-15"}}
+
+
+class _Stats:
+    """Stand-in for the reporter's @fraise_type analytics class."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    for view in [v for v in _table_metadata if v.startswith("v_467")]:
+        del _table_metadata[view]
+    for view in [v for v in _type_registry if v.startswith("v_467")]:
+        del _type_registry[view]
+
+
+def _register(view_name: str) -> None:
+    register_type_for_view(
+        view_name,
+        _Stats,
+        table_columns=COLUMNS,
+        has_jsonb_data=True,
+        jsonb_column="data",
+        aggregation={
+            "dimensions": "dimensions",
+            "measures": {"measures.cost": "SUM"},
+            "native_dimensions": ["date"],
+            "native_dimension_mapping": MAPPING,
+            "fine_grain_view": f"{view_name}_day",
+            "time_grain_column": "date",
+            "time_grain_trunc": "month",
+        },
+    )
+
+
+def _make_pool() -> Any:
+    mock_pool = MagicMock()
+    ctx = mock_pool.connection.return_value
+    ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_pool
+
+
+async def _rendered_sql(view_name: str, **find_kwargs: Any) -> str:
+    repo = FraiseQLRepository(_make_pool())
+    info = MagicMock()
+    info.schema = None
+
+    with (
+        patch(
+            "fraiseql.core.ast_parser.extract_field_paths_from_info",
+            return_value=[
+                MagicMock(path=["date"]),
+                MagicMock(path=["dimensions", "item", "model", "category"]),
+                MagicMock(path=["measures", "cost"]),
+            ],
+        ),
+        patch(
+            "fraiseql.db.execute_via_rust_pipeline",
+            new_callable=AsyncMock,
+            return_value=b'{"data":{"x":[]}}',
+        ) as mock_execute,
+    ):
+        await repo.find(view_name, info=info, where=WHERE, **find_kwargs)
+
+    return mock_execute.call_args[0][1].as_string(None)
+
+
+class TestUnionOrdering:
+    @pytest.mark.asyncio
+    async def test_union_orders_on_the_wrapper_column(self) -> None:
+        _register("v_467_union_order")
+
+        rendered = await _rendered_sql("v_467_union_order")
+
+        assert "UNION ALL" in rendered
+        assert rendered.endswith(" ORDER BY 1")
+        # Exactly one sort position, on the single projected column.
+        assert rendered.count("ORDER BY") == 1
+
+    @pytest.mark.asyncio
+    async def test_no_per_branch_jsonb_path_in_a_sort_position(self) -> None:
+        _register("v_467_union_order_paths")
+
+        rendered = await _rendered_sql("v_467_union_order_paths")
+
+        after_order_by = rendered[rendered.index("ORDER BY") :]
+        assert "->" not in after_order_by
+        assert after_order_by == "ORDER BY 1"
+
+    @pytest.mark.asyncio
+    async def test_mapped_group_by_key_is_native_in_every_branch(self) -> None:
+        """The sort is positional, so the branch keys still have to line up."""
+        _register("v_467_union_order_keys")
+
+        rendered = await _rendered_sql("v_467_union_order_keys")
+
+        branches = rendered.count("UNION ALL") + 1
+        assert rendered.count("GROUP BY") == branches
+        assert rendered.count('"t"."model_category"') >= branches
+
+
+class TestKnownGap:
+    """Not a desired property — a gap pinned so a future fix trips this loudly."""
+
+    @pytest.mark.asyncio
+    async def test_caller_order_by_does_not_reach_the_union_query(self) -> None:
+        """``order_by`` is never passed to ``_build_partial_period_union_query``.
+
+        Same family as #467 — a declaration accepted and silently discarded — but
+        a different mechanism, so it is recorded here rather than fixed in this
+        phase. When it is fixed, this test should be rewritten, not deleted.
+        """
+        _register("v_467_union_order_dropped")
+
+        rendered = await _rendered_sql(
+            "v_467_union_order_dropped",
+            order_by={"dimensions": {"item": {"model": {"category": "desc"}}}},
+        )
+
+        assert rendered.endswith(" ORDER BY 1")
+        assert "DESC" not in rendered

--- a/tests/regression/issue_467/test_where_mapping_both_paths.py
+++ b/tests/regression/issue_467/test_where_mapping_both_paths.py
@@ -1,0 +1,249 @@
+"""Issue #467: one call site, both query paths.
+
+The rewrite is applied in ``FraiseQLRepository._normalize_where``, the single
+entry point both builders funnel through — the standard ``_build_find_query``
+via ``_build_where_clause``, and the partial-period UNION dispatch via its own
+bound probe. These tests assert on the SQL each path actually hands to the
+executor, so a call site that only covers one of them fails here.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+
+COLUMNS = {"id", "data", "date", "item_id", "model_category"}
+MAPPING = {"dimensions.item.model.category": "model_category"}
+WHERE = {
+    "date": {"gte": "2025-01-15"},
+    "dimensions": {"item": {"model": {"category": {"eq": "laser"}}}},
+}
+
+
+class _Stats:
+    """Stand-in for the reporter's @fraise_type analytics class."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    for view in [v for v in _table_metadata if v.startswith("v_467")]:
+        del _table_metadata[view]
+    for view in [v for v in _type_registry if v.startswith("v_467")]:
+        del _type_registry[view]
+
+
+def _aggregation(**extra: Any) -> dict[str, Any]:
+    return {
+        "dimensions": "dimensions",
+        "measures": {"measures.cost": "SUM"},
+        "native_dimensions": ["date"],
+        "native_dimension_mapping": MAPPING,
+        **extra,
+    }
+
+
+def _field_paths() -> list[Any]:
+    return [
+        MagicMock(path=["date"]),
+        MagicMock(path=["dimensions", "item", "model", "category"]),
+        MagicMock(path=["measures", "cost"]),
+    ]
+
+
+def _make_pool() -> Any:
+    mock_pool = MagicMock()
+    ctx = mock_pool.connection.return_value
+    ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_pool
+
+
+async def _rendered_sql(view_name: str, where: dict) -> tuple[str, list[Any]]:
+    """Run find() to completion and return the SQL it handed the executor."""
+    repo = FraiseQLRepository(_make_pool())
+    info = MagicMock()
+    info.schema = None
+
+    with (
+        patch(
+            "fraiseql.core.ast_parser.extract_field_paths_from_info",
+            return_value=_field_paths(),
+        ),
+        patch(
+            "fraiseql.db.execute_via_rust_pipeline",
+            new_callable=AsyncMock,
+            return_value=b'{"data":{"x":[]}}',
+        ) as mock_execute,
+    ):
+        await repo.find(view_name, info=info, where=where)
+
+    statement, params = mock_execute.call_args[0][1], mock_execute.call_args[0][2]
+    return statement.as_string(None), params
+
+
+class TestPartialPeriodUnionPath:
+    """A coarse view with ``fine_grain_view`` routes through the UNION builder."""
+
+    @pytest.mark.asyncio
+    async def test_mapped_predicate_is_a_column_in_every_branch(self) -> None:
+        register_type_for_view(
+            "v_467_union_month",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            aggregation=_aggregation(
+                fine_grain_view="v_467_union_day",
+                time_grain_column="date",
+                time_grain_trunc="month",
+            ),
+        )
+
+        rendered, params = await _rendered_sql("v_467_union_month", WHERE)
+
+        branches = rendered.count("UNION ALL") + 1
+        assert branches >= 2, "expected the window to straddle a period boundary"
+        assert rendered.count('"model_category" = ') == branches
+        assert "->> 'category'" not in rendered
+        assert params.count("laser") == branches
+
+    @pytest.mark.asyncio
+    async def test_date_bounds_stay_per_branch_literals(self) -> None:
+        register_type_for_view(
+            "v_467_union_bounds",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            aggregation=_aggregation(
+                fine_grain_view="v_467_union_bounds_day",
+                time_grain_column="date",
+                time_grain_trunc="month",
+            ),
+        )
+
+        rendered, params = await _rendered_sql("v_467_union_bounds", WHERE)
+
+        # The date filter is encoded per branch as Literals by the UNION builder,
+        # never as a parameter, and never left in the extra_where.
+        assert "'2025-01-15'" in rendered
+        assert "'2025-02-01'" in rendered
+        assert "2025-01-15" not in params
+
+
+class TestStandardFindPath:
+    """A view without ``fine_grain_view`` goes through ``_build_find_query``."""
+
+    @pytest.mark.asyncio
+    async def test_mapped_predicate_is_a_column(self) -> None:
+        register_type_for_view(
+            "v_467_plain_month",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            aggregation=_aggregation(),
+        )
+
+        rendered, params = await _rendered_sql("v_467_plain_month", WHERE)
+
+        assert "UNION ALL" not in rendered
+        assert '"model_category" = ' in rendered
+        assert "->> 'category'" not in rendered
+        assert "laser" in params
+
+    @pytest.mark.asyncio
+    async def test_top_level_mapping_on_a_non_aggregated_view(self) -> None:
+        """No aggregation at all — the mapping is a peer of fk_relationships (D1)."""
+        register_type_for_view(
+            "v_467_plain_rows",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping=MAPPING,
+        )
+
+        repo = FraiseQLRepository(_make_pool())
+        info = MagicMock()
+        info.schema = None
+
+        with (
+            patch(
+                "fraiseql.core.ast_parser.extract_field_paths_from_info",
+                return_value=[MagicMock(path=["id"])],
+            ),
+            patch(
+                "fraiseql.db.execute_via_rust_pipeline",
+                new_callable=AsyncMock,
+                return_value=b'{"data":{"x":[]}}',
+            ) as mock_execute,
+        ):
+            await repo.find(
+                "v_467_plain_rows",
+                info=info,
+                where={"dimensions": {"item": {"model": {"category": {"eq": "laser"}}}}},
+            )
+
+        rendered = mock_execute.call_args[0][1].as_string(None)
+        assert '"model_category" = ' in rendered
+        assert "->> 'category'" not in rendered
+
+
+class TestOneDeclarationEveryConsumer:
+    """``column_mapping=`` supersedes the aggregation key, so it must reach GROUP BY.
+
+    A new parameter that worked in WHERE and silently no-opped in GROUP BY — the
+    one place the mechanism already worked — would recreate the exact trap this
+    issue is about.
+    """
+
+    @pytest.mark.asyncio
+    async def test_top_level_mapping_reaches_group_by(self) -> None:
+        register_type_for_view(
+            "v_467_groupby",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping=MAPPING,
+            aggregation={
+                "dimensions": "dimensions",
+                "measures": {"measures.cost": "SUM"},
+                "native_dimensions": ["date"],
+            },
+        )
+
+        rendered, _params = await _rendered_sql("v_467_groupby", WHERE)
+
+        assert '"t"."model_category"' in rendered
+        assert "GROUP BY" in rendered
+        assert "-> 'item' -> 'model' ->> 'category'" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_top_level_mapping_reaches_group_by_on_the_union_path(self) -> None:
+        register_type_for_view(
+            "v_467_groupby_union",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping=MAPPING,
+            aggregation={
+                "dimensions": "dimensions",
+                "measures": {"measures.cost": "SUM"},
+                "native_dimensions": ["date"],
+                "fine_grain_view": "v_467_groupby_union_day",
+                "time_grain_column": "date",
+                "time_grain_trunc": "month",
+            },
+        )
+
+        rendered, _params = await _rendered_sql("v_467_groupby_union", WHERE)
+
+        branches = rendered.count("UNION ALL") + 1
+        assert branches >= 2
+        assert rendered.count('"t"."model_category"') >= branches

--- a/tests/regression/issue_467/test_where_mapping_date_dispatch.py
+++ b/tests/regression/issue_467/test_where_mapping_date_dispatch.py
@@ -1,0 +1,135 @@
+"""Issue #467: a mapping whose target is the time-grain column changes dispatch.
+
+The rewrite runs inside ``_normalize_where``, which the partial-period probe
+calls *before* ``_extract_lower_date_bound``. So a mapping like
+``{"dimensions.dateInfo.date": "date"}`` — the exact shape the issue's casing
+example uses — now makes a nested date filter visible to the bound extractor,
+and a query that previously took the single-query path takes the UNION path.
+
+That is arguably more correct: the filter really is a bound on the time-grain
+column, and honouring it is the whole point of partial-period awareness. It is
+also a dispatch change, so it is pinned here rather than discovered in
+production.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+
+COLUMNS = {"id", "data", "date"}
+NESTED_DATE_WHERE = {"dimensions": {"dateInfo": {"date": {"gte": "2025-01-15"}}}}
+
+
+class _Stats:
+    """Stand-in for the reporter's @fraise_type analytics class."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    for view in [v for v in _table_metadata if v.startswith("v_467")]:
+        del _table_metadata[view]
+    for view in [v for v in _type_registry if v.startswith("v_467")]:
+        del _type_registry[view]
+
+
+def _register(view_name: str, mapping: dict[str, str]) -> None:
+    register_type_for_view(
+        view_name,
+        _Stats,
+        table_columns=COLUMNS,
+        has_jsonb_data=True,
+        jsonb_column="data",
+        aggregation={
+            "dimensions": "dimensions",
+            "measures": {"measures.cost": "SUM"},
+            "native_dimensions": ["date"],
+            "native_dimension_mapping": mapping,
+            "fine_grain_view": f"{view_name}_day",
+            "time_grain_column": "date",
+            "time_grain_trunc": "month",
+        },
+    )
+
+
+def _make_pool() -> Any:
+    mock_pool = MagicMock()
+    ctx = mock_pool.connection.return_value
+    ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_pool
+
+
+async def _rendered_sql(view_name: str, where: dict) -> str:
+    repo = FraiseQLRepository(_make_pool())
+    info = MagicMock()
+    info.schema = None
+
+    with (
+        patch(
+            "fraiseql.core.ast_parser.extract_field_paths_from_info",
+            return_value=[
+                MagicMock(path=["date"]),
+                MagicMock(path=["dimensions", "dateInfo", "date"]),
+                MagicMock(path=["measures", "cost"]),
+            ],
+        ),
+        patch(
+            "fraiseql.db.execute_via_rust_pipeline",
+            new_callable=AsyncMock,
+            return_value=b'{"data":{"x":[]}}',
+        ) as mock_execute,
+    ):
+        await repo.find(view_name, info=info, where=where)
+
+    return mock_execute.call_args[0][1].as_string(None)
+
+
+class TestTimeGrainTargetedMapping:
+    """Pinned behaviour: the mapped nested date filter drives partial-period dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_nested_date_filter_now_routes_through_the_union_path(self) -> None:
+        _register("v_467_dispatch", {"dimensions.date_info.date": "date"})
+
+        rendered = await _rendered_sql("v_467_dispatch", NESTED_DATE_WHERE)
+
+        assert "UNION ALL" in rendered
+
+    @pytest.mark.asyncio
+    async def test_the_bound_is_encoded_per_branch_not_left_in_extra_where(self) -> None:
+        """The UNION builder strips conditions on the time-grain column."""
+        _register("v_467_dispatch_bounds", {"dimensions.date_info.date": "date"})
+
+        rendered = await _rendered_sql("v_467_dispatch_bounds", NESTED_DATE_WHERE)
+
+        assert "'2025-01-15'" in rendered
+        assert "'2025-02-01'" in rendered
+        # One date predicate pair per branch, none carried over as extra_where.
+        branches = rendered.count("UNION ALL") + 1
+        assert rendered.count('"date" >= ') == branches
+        assert '"date" >= %s' not in rendered
+
+    @pytest.mark.asyncio
+    async def test_camelcase_key_spelling_dispatches_identically(self) -> None:
+        """D2: keys are normalized at registration, so both spellings dispatch alike."""
+        _register("v_467_dispatch_camel", {"dimensions.dateInfo.date": "date"})
+
+        rendered = await _rendered_sql("v_467_dispatch_camel", NESTED_DATE_WHERE)
+
+        assert "UNION ALL" in rendered
+
+    @pytest.mark.asyncio
+    async def test_an_unmapped_nested_date_filter_still_takes_the_single_query_path(
+        self,
+    ) -> None:
+        """Without the mapping the bound is invisible — the contrast that makes it a change."""
+        _register("v_467_dispatch_none", {"dimensions.item.model.category": "date"})
+
+        rendered = await _rendered_sql("v_467_dispatch_none", NESTED_DATE_WHERE)
+
+        assert "UNION ALL" not in rendered
+        assert "->> 'date'" in rendered

--- a/tests/regression/issue_467/test_where_native_mapping.py
+++ b/tests/regression/issue_467/test_where_native_mapping.py
@@ -1,0 +1,237 @@
+"""Issue #467: the declared column mapping now reaches the WHERE resolver.
+
+The reporter registered ``native_dimension_mapping`` against an analytics view,
+saw it honoured in ``GROUP BY``, and found via ``EXPLAIN`` that the same paths in
+``WHERE`` were still being read out of the JSONB snapshot. One of their two
+entries (``dimensions.item.id``) was already native — the ``<parent>_id``
+convention reaches it — but ``dimensions.item.model.category`` was reachable by
+no mechanism at all.
+
+These tests assert on rendered SQL for the reporter's exact registration, through
+``FraiseQLRepository._normalize_where``: the single site where the rewrite is
+applied, and the one both query paths funnel through.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+
+VIEW = "v_467_stats_month"
+COLUMNS = {"id", "data", "item_id", "model_category", "date"}
+MAPPING = {
+    "dimensions.item.id": "item_id",
+    "dimensions.item.model.category": "model_category",
+}
+
+
+class _Stats:
+    """Stand-in for the reporter's @fraise_type analytics class."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    for view in [v for v in _table_metadata if v.startswith("v_467")]:
+        del _table_metadata[view]
+    for view in [v for v in _type_registry if v.startswith("v_467")]:
+        del _type_registry[view]
+
+
+def _register(view_name: str = VIEW, **overrides: object) -> None:
+    """The reporter's registration: the mapping declared under ``aggregation``."""
+    kwargs = {
+        "table_columns": COLUMNS,
+        "has_jsonb_data": True,
+        "jsonb_column": "data",
+        "aggregation": {
+            "dimensions": "dimensions",
+            "measures": {"measures.cost": "SUM"},
+            "native_dimension_mapping": MAPPING,
+        },
+    }
+    kwargs.update(overrides)
+    register_type_for_view(view_name, _Stats, **kwargs)
+
+
+def _sql(where: dict, view_name: str = VIEW, columns: set[str] | None = None) -> str:
+    repo = FraiseQLRepository(MagicMock())
+    clause = repo._normalize_where(where, view_name, columns or COLUMNS)
+    sql, _params = clause.to_sql()
+    return sql.as_string(None)
+
+
+class TestNativeDimensionMappingInWhere:
+    """The mapping declared under ``aggregation`` feeds the WHERE resolver."""
+
+    def test_deep_mapped_path_becomes_a_column(self) -> None:
+        _register()
+
+        rendered = _sql({"dimensions": {"item": {"model": {"category": {"eq": "laser"}}}}})
+
+        assert '"model_category" = ' in rendered
+        assert "data" not in rendered
+
+    def test_convention_resolved_path_stays_native(self) -> None:
+        """``dimensions.item.id`` was already ``item_id``; the mapping must agree."""
+        _register()
+
+        rendered = _sql({"dimensions": {"item": {"id": {"eq": "abc"}}}})
+
+        assert '"item_id" = ' in rendered
+
+    def test_id_path_keeps_fk_column_strategy(self) -> None:
+        """``fk_column`` is what the ltree ``*_of_id`` operators key on."""
+        _register()
+        repo = FraiseQLRepository(MagicMock())
+
+        clause = repo._normalize_where(
+            {"dimensions": {"item": {"id": {"eq": "abc"}}}}, VIEW, COLUMNS
+        )
+
+        assert clause.conditions[0].lookup_strategy == "fk_column"
+        assert clause.conditions[0].target_column == "item_id"
+
+    def test_unmapped_path_still_uses_jsonb(self) -> None:
+        _register()
+
+        rendered = _sql({"dimensions": {"item": {"model": {"name": {"eq": "X1"}}}}})
+
+        assert "model_category" not in rendered
+        assert "'model'" in rendered
+        assert "'name'" in rendered
+
+    def test_camelcase_key_spelling_fires_too(self) -> None:
+        """Keys are normalized segment-wise at registration (D2)."""
+        _register(
+            "v_467_camel",
+            aggregation={
+                "dimensions": "dimensions",
+                "native_dimension_mapping": {"dimensions.item.model.category": "model_category"},
+            },
+        )
+
+        rendered = _sql(
+            {"dimensions": {"item": {"model": {"category": {"eq": "laser"}}}}}, "v_467_camel"
+        )
+
+        assert '"model_category" = ' in rendered
+
+    def test_or_and_not_groups_are_rewritten(self) -> None:
+        _register()
+
+        rendered = _sql(
+            {
+                "OR": [
+                    {"dimensions": {"item": {"model": {"category": {"eq": "laser"}}}}},
+                    {"dimensions": {"item": {"model": {"category": {"eq": "inkjet"}}}}},
+                ]
+            }
+        )
+
+        assert rendered.count('"model_category" = ') == 2
+        assert "data" not in rendered
+
+
+class TestTopLevelColumnMapping:
+    """``column_mapping=`` is the peer of ``fk_relationships`` (D1)."""
+
+    def test_top_level_mapping_applies_without_aggregation(self) -> None:
+        register_type_for_view(
+            "v_467_peer",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping=MAPPING,
+        )
+
+        rendered = _sql(
+            {"dimensions": {"item": {"model": {"category": {"eq": "laser"}}}}}, "v_467_peer"
+        )
+
+        assert '"model_category" = ' in rendered
+
+    def test_top_level_mapping_may_name_any_path(self) -> None:
+        """The dimensions-prefix warning is aggregation-specific; a peer has no prefix."""
+        register_type_for_view(
+            "v_467_any_path",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping={"device.model.category": "model_category"},
+        )
+
+        rendered = _sql({"device": {"model": {"category": {"eq": "laser"}}}}, "v_467_any_path")
+
+        assert '"model_category" = ' in rendered
+
+    def test_top_level_mapping_key_casing_is_normalized(self) -> None:
+        register_type_for_view(
+            "v_467_peer_camel",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping={"dimensions.itemDetail.modelCategory": "model_category"},
+        )
+
+        rendered = _sql(
+            {"dimensions": {"itemDetail": {"modelCategory": {"eq": "laser"}}}},
+            "v_467_peer_camel",
+        )
+
+        assert '"model_category" = ' in rendered
+
+    def test_unknown_column_raises_at_registration(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            register_type_for_view(
+                "v_467_bad",
+                _Stats,
+                table_columns={"id", "data"},
+                column_mapping={"dimensions.item.model.category": "nope"},
+            )
+
+        message = str(exc_info.value)
+        assert "v_467_bad" in message
+        assert "column_mapping" in message
+        assert "nope" in message
+        assert "validate_fk_strict=False" in message
+
+    def test_no_unreachable_key_warning_for_top_level_mapping(self, caplog) -> None:
+        """A peer of ``fk_relationships`` is not rooted at a dimensions prefix."""
+        with caplog.at_level(logging.WARNING, logger="fraiseql.db"):
+            register_type_for_view(
+                "v_467_no_warn",
+                _Stats,
+                table_columns=COLUMNS,
+                column_mapping={"device.model.category": "model_category"},
+            )
+
+        assert [r for r in caplog.records if "Unreachable" in r.message] == []
+
+    def test_top_level_mapping_wins_over_aggregation_mapping(self) -> None:
+        register_type_for_view(
+            "v_467_both",
+            _Stats,
+            table_columns=COLUMNS | {"other_category"},
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping={"dimensions.item.model.category": "other_category"},
+            aggregation={
+                "dimensions": "dimensions",
+                "native_dimension_mapping": {"dimensions.item.model.category": "model_category"},
+            },
+        )
+
+        rendered = _sql(
+            {"dimensions": {"item": {"model": {"category": {"eq": "laser"}}}}},
+            "v_467_both",
+            COLUMNS | {"other_category"},
+        )
+
+        assert '"other_category" = ' in rendered
+        assert "model_category" not in rendered

--- a/tests/regression/issue_468/__init__.py
+++ b/tests/regression/issue_468/__init__.py
@@ -1,0 +1,1 @@
+"""Regression tests for issue #468: OR/NOT sub-clauses dropped on the partial-period UNION path."""

--- a/tests/regression/issue_468/test_union_date_bound_scope.py
+++ b/tests/regression/issue_468/test_union_date_bound_scope.py
@@ -1,0 +1,199 @@
+"""Issue #468, Cycle 3: which date bounds may trigger the partial-period rewrite.
+
+The UNION builder re-encodes the date bounds as per-branch ``AND`` literals. That
+is only equivalent to the caller's filter when the bound is a top-level conjunct.
+Two shapes are therefore excluded, and this pins both:
+
+* a date bound nested inside an ``OR`` group — ``_extract_lower_date_bound`` only
+  scans top-level conditions, so it never fired; now that the group survives the
+  rebuild (#468) this has to stay true, or the predicate would appear both as a
+  branch literal and inside the preserved group;
+* a clause whose top-level conditions are ``OR``-joined — the rewrite would turn
+  ``date >= X OR status = 'a'`` into ``date in [branch] AND status = 'a'`` and
+  silently drop every row that matched on the date alone.
+
+Both fall back to the standard single-statement query, which is correct and merely
+unoptimised.
+"""
+
+from datetime import date
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+from fraiseql.where_clause import FieldCondition, WhereClause
+
+COLUMNS = {"id", "data", "date", "status", "model_category"}
+
+
+class _Stats:
+    """Stand-in for an aggregated analytics type."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    for view in [v for v in _table_metadata if v.startswith("v_468")]:
+        del _table_metadata[view]
+    for view in [v for v in _type_registry if v.startswith("v_468")]:
+        del _type_registry[view]
+
+
+def _register(view_name: str) -> None:
+    register_type_for_view(
+        view_name,
+        _Stats,
+        table_columns=COLUMNS,
+        has_jsonb_data=True,
+        jsonb_column="data",
+        aggregation={
+            "dimensions": "dimensions",
+            "measures": {"measures.cost": "SUM"},
+            "native_dimensions": ["date"],
+            "native_dimension_mapping": {"dimensions.item.model.category": "model_category"},
+            "fine_grain_view": f"{view_name}_day",
+            "time_grain_column": "date",
+            "time_grain_trunc": "month",
+        },
+    )
+
+
+def _make_pool() -> Any:
+    mock_pool = MagicMock()
+    ctx = mock_pool.connection.return_value
+    ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_pool
+
+
+async def _rendered(view_name: str, **find_kwargs: Any) -> tuple[str, list[Any]]:
+    repo = FraiseQLRepository(_make_pool())
+    info = MagicMock()
+    info.schema = None
+
+    with (
+        patch(
+            "fraiseql.core.ast_parser.extract_field_paths_from_info",
+            return_value=[
+                MagicMock(path=["date"]),
+                MagicMock(path=["dimensions", "item", "model", "category"]),
+                MagicMock(path=["measures", "cost"]),
+            ],
+        ),
+        patch(
+            "fraiseql.db.execute_via_rust_pipeline",
+            new_callable=AsyncMock,
+            return_value=b'{"data":{"x":[]}}',
+        ) as mock_execute,
+    ):
+        await repo.find(view_name, info=info, **find_kwargs)
+
+    call = mock_execute.call_args[0]
+    return call[1].as_string(None), list(call[2] or [])
+
+
+class TestDateBoundInsideOrGroup:
+    @pytest.mark.asyncio
+    async def test_nested_date_bound_does_not_route_through_the_union(self) -> None:
+        _register("v_468_or_date")
+
+        rendered, params = await _rendered(
+            "v_468_or_date",
+            where={
+                "OR": [
+                    {"date": {"gte": "2025-01-15"}},
+                    {"status": {"eq": "active"}},
+                ]
+            },
+        )
+
+        assert "UNION ALL" not in rendered
+        # The whole OR group survives, exactly once, as the caller wrote it.
+        assert rendered.count(" OR ") == 1
+        assert rendered.count('"date"') >= 1
+        assert rendered.count('"status"') == 1
+        assert params == ["2025-01-15", "active"]
+
+    @pytest.mark.asyncio
+    async def test_a_top_level_bound_alongside_an_or_group_still_routes(self) -> None:
+        """The exclusion is about *where* the bound sits, not about OR being present."""
+        _register("v_468_or_date_mixed")
+
+        rendered, _ = await _rendered(
+            "v_468_or_date_mixed",
+            where={
+                "date": {"gte": "2025-01-15"},
+                "OR": [{"status": {"eq": "active"}}, {"status": {"eq": "pending"}}],
+            },
+        )
+
+        assert "UNION ALL" in rendered
+
+
+class TestOrJoinedTopLevelConditions:
+    @pytest.mark.asyncio
+    async def test_or_joined_conditions_do_not_route_through_the_union(self) -> None:
+        """``logical_op="OR"`` reaches here via a pre-built WhereClause (#468).
+
+        ``_normalize_where`` returns a ``WhereClause`` unchanged, so a caller can
+        hand one in directly. Its top-level conditions are then OR-joined, and
+        pulling the date bound out to per-branch ``AND`` literals would widen the
+        date filter into a mandatory one.
+        """
+        _register("v_468_or_joined")
+
+        where = WhereClause(
+            conditions=[
+                FieldCondition(
+                    field_path=["date"],
+                    operator="gte",
+                    value=date(2025, 1, 15),
+                    lookup_strategy="sql_column",
+                    target_column="date",
+                ),
+                FieldCondition(
+                    field_path=["status"],
+                    operator="eq",
+                    value="active",
+                    lookup_strategy="sql_column",
+                    target_column="status",
+                ),
+            ],
+            logical_op="OR",
+        )
+
+        rendered, params = await _rendered("v_468_or_joined", where=where)
+
+        assert "UNION ALL" not in rendered
+        assert " OR " in rendered
+        assert params == [date(2025, 1, 15), "active"]
+
+    @pytest.mark.asyncio
+    async def test_and_joined_conditions_still_route(self) -> None:
+        _register("v_468_and_joined")
+
+        where = WhereClause(
+            conditions=[
+                FieldCondition(
+                    field_path=["date"],
+                    operator="gte",
+                    value=date(2025, 1, 15),
+                    lookup_strategy="sql_column",
+                    target_column="date",
+                ),
+                FieldCondition(
+                    field_path=["status"],
+                    operator="eq",
+                    value="active",
+                    lookup_strategy="sql_column",
+                    target_column="status",
+                ),
+            ],
+            logical_op="AND",
+        )
+
+        rendered, _ = await _rendered("v_468_and_joined", where=where)
+
+        assert "UNION ALL" in rendered

--- a/tests/regression/issue_468/test_union_preserves_nested_clauses.py
+++ b/tests/regression/issue_468/test_union_preserves_nested_clauses.py
@@ -1,0 +1,192 @@
+"""Issue #468: the partial-period UNION path drops OR/NOT sub-clauses from the WHERE.
+
+``_build_partial_period_union_query`` is handed an ``extra_where`` rebuilt from the
+normalised clause's ``conditions`` only.  ``WhereClause`` carries three payloads —
+``conditions``, ``nested_clauses`` and ``not_clause`` — so every ``OR`` group and
+every ``NOT`` group is discarded and the UNION returns rows the filter excluded.
+
+It fails open twice over: when the *only* top-level condition is the date bound,
+``remaining_conditions`` is empty, ``extra_where`` is ``None``, and both branches
+run with no filter at all beyond the date range.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+
+COLUMNS = {"id", "data", "date", "status", "machine_id", "model_category"}
+MAPPING = {"dimensions.item.model.category": "model_category"}
+
+
+class _Stats:
+    """Stand-in for an aggregated analytics type."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    for view in [v for v in _table_metadata if v.startswith("v_468")]:
+        del _table_metadata[view]
+    for view in [v for v in _type_registry if v.startswith("v_468")]:
+        del _type_registry[view]
+
+
+def _register(view_name: str) -> None:
+    register_type_for_view(
+        view_name,
+        _Stats,
+        table_columns=COLUMNS,
+        has_jsonb_data=True,
+        jsonb_column="data",
+        aggregation={
+            "dimensions": "dimensions",
+            "measures": {"measures.cost": "SUM"},
+            "native_dimensions": ["date"],
+            "native_dimension_mapping": MAPPING,
+            "fine_grain_view": f"{view_name}_day",
+            "time_grain_column": "date",
+            "time_grain_trunc": "month",
+        },
+    )
+
+
+def _make_pool() -> Any:
+    mock_pool = MagicMock()
+    ctx = mock_pool.connection.return_value
+    ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_pool
+
+
+async def _rendered(view_name: str, **find_kwargs: Any) -> tuple[str, list[Any]]:
+    """Return (rendered SQL, params) for a ``find()`` that routes through the UNION."""
+    repo = FraiseQLRepository(_make_pool())
+    info = MagicMock()
+    info.schema = None
+
+    with (
+        patch(
+            "fraiseql.core.ast_parser.extract_field_paths_from_info",
+            return_value=[
+                MagicMock(path=["date"]),
+                MagicMock(path=["dimensions", "item", "model", "category"]),
+                MagicMock(path=["measures", "cost"]),
+            ],
+        ),
+        patch(
+            "fraiseql.db.execute_via_rust_pipeline",
+            new_callable=AsyncMock,
+            return_value=b'{"data":{"x":[]}}',
+        ) as mock_execute,
+    ):
+        await repo.find(view_name, info=info, **find_kwargs)
+
+    call = mock_execute.call_args[0]
+    return call[1].as_string(None), list(call[2] or [])
+
+
+def _branch_count(rendered: str) -> int:
+    return rendered.count("UNION ALL") + 1
+
+
+class TestOrGroupSurvives:
+    @pytest.mark.asyncio
+    async def test_or_group_reaches_every_branch(self) -> None:
+        """An OR group alongside a surviving flat condition is still dropped."""
+        _register("v_468_or_group")
+
+        rendered, params = await _rendered(
+            "v_468_or_group",
+            where={
+                "date": {"gte": "2025-01-15"},
+                "machine_id": {"eq": "m-1"},
+                "OR": [{"status": {"eq": "active"}}, {"status": {"eq": "pending"}}],
+            },
+        )
+
+        branches = _branch_count(rendered)
+        assert branches >= 2, "expected the partial-period UNION to be in play"
+        # The flat condition already survives today — it is the control.
+        assert rendered.count('"machine_id"') == branches
+        # The OR group must survive too, once per branch, parenthesised.
+        assert rendered.count('"status"') == 2 * branches
+        assert rendered.count(" OR ") == branches
+        assert params.count("active") == branches
+        assert params.count("pending") == branches
+
+    @pytest.mark.asyncio
+    async def test_or_only_filter_is_not_dropped_entirely(self) -> None:
+        """The fail-open case: the date bound is the *only* top-level condition.
+
+        ``remaining_conditions`` is empty, so ``extra_where`` is ``None`` and both
+        branches run with nothing but the per-branch date literals.
+        """
+        _register("v_468_or_only")
+
+        rendered, params = await _rendered(
+            "v_468_or_only",
+            where={
+                "date": {"gte": "2025-01-15"},
+                "OR": [{"status": {"eq": "active"}}, {"status": {"eq": "pending"}}],
+            },
+        )
+
+        branches = _branch_count(rendered)
+        assert branches >= 2
+        assert rendered.count('"status"') == 2 * branches
+        assert params.count("active") == branches
+
+
+class TestNotClauseSurvives:
+    @pytest.mark.asyncio
+    async def test_not_clause_reaches_every_branch(self) -> None:
+        _register("v_468_not_clause")
+
+        rendered, params = await _rendered(
+            "v_468_not_clause",
+            where={
+                "date": {"gte": "2025-01-15"},
+                "NOT": {"status": {"eq": "archived"}},
+            },
+        )
+
+        branches = _branch_count(rendered)
+        assert branches >= 2
+        assert rendered.count("NOT (") == branches
+        assert rendered.count('"status"') == branches
+        assert params.count("archived") == branches
+
+
+class TestNonUnionPathUnaffected:
+    @pytest.mark.asyncio
+    async def test_or_group_already_works_without_the_union(self) -> None:
+        """The same filter on a view with no ``fine_grain_view`` is the baseline."""
+        register_type_for_view(
+            "v_468_plain",
+            _Stats,
+            table_columns=COLUMNS,
+            has_jsonb_data=True,
+            jsonb_column="data",
+            aggregation={
+                "dimensions": "dimensions",
+                "measures": {"measures.cost": "SUM"},
+                "native_dimensions": ["date"],
+                "native_dimension_mapping": MAPPING,
+            },
+        )
+
+        rendered, params = await _rendered(
+            "v_468_plain",
+            where={
+                "date": {"gte": "2025-01-15"},
+                "OR": [{"status": {"eq": "active"}}, {"status": {"eq": "pending"}}],
+            },
+        )
+
+        assert "UNION ALL" not in rendered
+        assert rendered.count('"status"') == 2
+        assert "active" in params
+        assert "pending" in params

--- a/tests/unit/test_aggregation_registration_validation.py
+++ b/tests/unit/test_aggregation_registration_validation.py
@@ -1,0 +1,285 @@
+"""Registration-time validation of aggregation metadata (issue #467, part 2).
+
+``fk_relationships`` declared against a column that does not exist is a
+registration-time ``ValueError``.  ``native_dimension_mapping`` declared against
+a missing column used to be silence — the mapping simply never fired, and the
+query fell back to JSONB extraction with no diagnostic.  Same class of
+declaration, so the same treatment: raise under ``validate_fk_strict=True``
+(the default), warn under ``validate_fk_strict=False``.
+"""
+
+import logging
+
+import pytest
+
+from fraiseql.db import _table_metadata, _type_registry, register_type_for_view
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Keep the module-level registries clean between tests."""
+    yield
+    for view in [v for v in _table_metadata if v.startswith("v_agg_validation")]:
+        del _table_metadata[view]
+    for view in [v for v in _type_registry if v.startswith("v_agg_validation")]:
+        del _type_registry[view]
+
+
+class _Analytics:
+    """Stand-in for a @fraise_type decorated class."""
+
+
+class TestNativeDimensionMappingValidation:
+    """A mapping value must name a real column."""
+
+    def test_unknown_mapping_column_raises_in_strict_mode(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            register_type_for_view(
+                "v_agg_validation_strict",
+                _Analytics,
+                table_columns={"id", "data"},
+                aggregation={"native_dimension_mapping": {"dimensions.item.id": "nope"}},
+            )
+
+        message = str(exc_info.value)
+        assert "v_agg_validation_strict" in message
+        assert "dimensions.item.id" in message
+        assert "nope" in message
+        assert "native_dimension_mapping" in message
+        assert "validate_fk_strict=False" in message
+
+    def test_unknown_mapping_column_warns_in_lenient_mode(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="fraiseql.db"):
+            register_type_for_view(
+                "v_agg_validation_lenient",
+                _Analytics,
+                table_columns={"id", "data"},
+                aggregation={"native_dimension_mapping": {"dimensions.item.id": "nope"}},
+                validate_fk_strict=False,
+            )
+
+        assert "v_agg_validation_lenient" in _table_metadata
+        assert any("nope" in record.message for record in caplog.records)
+
+    def test_valid_mapping_column_is_accepted(self) -> None:
+        register_type_for_view(
+            "v_agg_validation_ok",
+            _Analytics,
+            table_columns={"id", "data", "item_id"},
+            aggregation={"native_dimension_mapping": {"dimensions.item.id": "item_id"}},
+        )
+
+        assert _table_metadata["v_agg_validation_ok"]["aggregation"][
+            "native_dimension_mapping"
+        ] == {"dimensions.item.id": "item_id"}
+
+
+class TestNativeMeasuresValidation:
+    """``native_measures`` values are columns too — same guard."""
+
+    def test_unknown_measure_column_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            register_type_for_view(
+                "v_agg_validation_measure",
+                _Analytics,
+                table_columns={"id", "data"},
+                aggregation={"native_measures": {"measures.volume": "nope"}},
+            )
+
+        message = str(exc_info.value)
+        assert "native_measures" in message
+        assert "measures.volume" in message
+        assert "nope" in message
+
+    def test_known_measure_column_is_accepted(self) -> None:
+        register_type_for_view(
+            "v_agg_validation_measure_ok",
+            _Analytics,
+            table_columns={"id", "data", "volume"},
+            aggregation={"native_measures": {"measures.volume": "volume"}},
+        )
+
+
+class TestNativeDimensionsValidation:
+    """``native_dimensions`` entries name columns directly — same guard."""
+
+    def test_unknown_native_dimension_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            register_type_for_view(
+                "v_agg_validation_dims",
+                _Analytics,
+                table_columns={"id", "data"},
+                aggregation={"native_dimensions": ["period_date"]},
+            )
+
+        message = str(exc_info.value)
+        assert "native_dimensions" in message
+        assert "period_date" in message
+
+    def test_known_native_dimension_is_accepted(self) -> None:
+        register_type_for_view(
+            "v_agg_validation_dims_ok",
+            _Analytics,
+            table_columns={"id", "data", "period_date"},
+            aggregation={"native_dimensions": ["period_date"]},
+        )
+
+
+class TestMissingTableColumns:
+    """No columns registered means nothing to validate against — warn, never raise."""
+
+    def test_no_table_columns_warns_and_does_not_raise(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="fraiseql.db"):
+            register_type_for_view(
+                "v_agg_validation_no_columns",
+                _Analytics,
+                aggregation={"native_dimension_mapping": {"dimensions.item.id": "item_id"}},
+            )
+
+        assert "v_agg_validation_no_columns" in _table_metadata
+        assert any(
+            "No table_columns registered for v_agg_validation_no_columns" in record.message
+            for record in caplog.records
+        )
+
+    def test_empty_table_columns_warns_and_does_not_raise(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="fraiseql.db"):
+            register_type_for_view(
+                "v_agg_validation_empty_columns",
+                _Analytics,
+                table_columns=set(),
+                aggregation={"native_dimension_mapping": {"dimensions.item.id": "item_id"}},
+            )
+
+        assert any(
+            "No table_columns registered for v_agg_validation_empty_columns" in record.message
+            for record in caplog.records
+        )
+
+    def test_no_native_declarations_does_not_warn(self, caplog) -> None:
+        """Aggregation without any column-naming key has nothing to validate."""
+        with caplog.at_level(logging.WARNING, logger="fraiseql.db"):
+            register_type_for_view(
+                "v_agg_validation_no_natives",
+                _Analytics,
+                aggregation={"measures": {"measures.cost": "SUM"}, "dimensions": "dimensions"},
+            )
+
+        assert not [r for r in caplog.records if "No table_columns registered" in r.message]
+
+
+class TestResolutionTimeGuard:
+    """Second guard, mirroring ``where_normalization.py:409-419``.
+
+    Registration validation can be bypassed (``validate_fk_strict=False``, or a
+    view registered before its columns were known), so the resolver re-checks:
+    strict views raise, lenient views warn once and fall back to JSONB.
+    """
+
+    def _register_dead_mapping(self, view_name: str, *, strict: bool) -> None:
+        """Register a mapping naming a missing column, bypassing the registration guard."""
+        register_type_for_view(
+            view_name,
+            _Analytics,
+            table_columns={"id", "data"},
+            has_jsonb_data=True,
+            jsonb_column="data",
+            aggregation={"native_dimension_mapping": {"dimensions.item.model.category": "nope"}},
+            validate_fk_strict=False,
+        )
+        _table_metadata[view_name]["validate_fk_strict"] = strict
+
+    @pytest.mark.xfail(
+        reason="Resolution-time guard lands with Phase 02 Cycle 2 (the column-mapping pass)",
+        strict=True,
+    )
+    def test_strict_view_raises_at_resolution(self) -> None:
+        from unittest.mock import MagicMock
+
+        from fraiseql.db import FraiseQLRepository
+
+        self._register_dead_mapping("v_agg_validation_resolve_strict", strict=True)
+        repo = FraiseQLRepository(MagicMock())
+
+        with pytest.raises(RuntimeError) as exc_info:
+            repo._normalize_where(
+                {"dimensions": {"item": {"model": {"category": {"eq": "x"}}}}},
+                "v_agg_validation_resolve_strict",
+                {"id", "data"},
+            )
+
+        assert "should have been caught during registration" in str(exc_info.value)
+
+    @pytest.mark.xfail(
+        reason="Resolution-time guard lands with Phase 02 Cycle 2 (the column-mapping pass)",
+        strict=True,
+    )
+    def test_lenient_view_warns_and_falls_back_to_jsonb(self, caplog) -> None:
+        from unittest.mock import MagicMock
+
+        from fraiseql.db import FraiseQLRepository
+
+        self._register_dead_mapping("v_agg_validation_resolve_lenient", strict=False)
+        repo = FraiseQLRepository(MagicMock())
+
+        with caplog.at_level(logging.WARNING, logger="fraiseql.where_normalization"):
+            clause = repo._normalize_where(
+                {"dimensions": {"item": {"model": {"category": {"eq": "x"}}}}},
+                "v_agg_validation_resolve_lenient",
+                {"id", "data"},
+            )
+
+        warnings = [r for r in caplog.records if "nope" in r.message]
+        assert len(warnings) == 1
+        assert "JSONB fallback" in warnings[0].message
+
+        condition = clause.conditions[0]
+        assert condition.lookup_strategy == "jsonb_path"
+        assert condition.target_column == "data"
+
+
+class TestUnreachableMappingKey:
+    """A key that cannot match any dimension path is dead weight — say so."""
+
+    def test_key_outside_dimensions_prefix_warns(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="fraiseql.db"):
+            register_type_for_view(
+                "v_agg_validation_unreachable",
+                _Analytics,
+                table_columns={"id", "data", "model_category"},
+                aggregation={
+                    "dimensions": "dimensions",
+                    "native_dimension_mapping": {"item.model.category": "model_category"},
+                },
+            )
+
+        warnings = [r for r in caplog.records if "item.model.category" in r.message]
+        assert len(warnings) == 1
+        assert "dimensions" in warnings[0].message
+
+    def test_custom_dimensions_prefix_is_respected(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="fraiseql.db"):
+            register_type_for_view(
+                "v_agg_validation_custom_prefix",
+                _Analytics,
+                table_columns={"id", "data", "model_category"},
+                aggregation={
+                    "dimensions": "dims",
+                    "native_dimension_mapping": {"dims.item.model.category": "model_category"},
+                },
+            )
+
+        assert not [r for r in caplog.records if "dims.item.model.category" in r.message]
+
+    def test_reachable_key_does_not_warn(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="fraiseql.db"):
+            register_type_for_view(
+                "v_agg_validation_reachable",
+                _Analytics,
+                table_columns={"id", "data", "model_category"},
+                aggregation={
+                    "native_dimension_mapping": {"dimensions.item.model.category": "model_category"}
+                },
+            )
+
+        assert not caplog.records

--- a/tests/unit/test_aggregation_registration_validation.py
+++ b/tests/unit/test_aggregation_registration_validation.py
@@ -189,10 +189,6 @@ class TestResolutionTimeGuard:
         )
         _table_metadata[view_name]["validate_fk_strict"] = strict
 
-    @pytest.mark.xfail(
-        reason="Resolution-time guard lands with Phase 02 Cycle 2 (the column-mapping pass)",
-        strict=True,
-    )
     def test_strict_view_raises_at_resolution(self) -> None:
         from unittest.mock import MagicMock
 
@@ -210,10 +206,6 @@ class TestResolutionTimeGuard:
 
         assert "should have been caught during registration" in str(exc_info.value)
 
-    @pytest.mark.xfail(
-        reason="Resolution-time guard lands with Phase 02 Cycle 2 (the column-mapping pass)",
-        strict=True,
-    )
     def test_lenient_view_warns_and_falls_back_to_jsonb(self, caplog) -> None:
         from unittest.mock import MagicMock
 
@@ -229,7 +221,11 @@ class TestResolutionTimeGuard:
                 {"id", "data"},
             )
 
-        warnings = [r for r in caplog.records if "nope" in r.message]
+        warnings = [
+            r
+            for r in caplog.records
+            if r.name == "fraiseql.where_normalization" and "nope" in r.message
+        ]
         assert len(warnings) == 1
         assert "JSONB fallback" in warnings[0].message
 

--- a/tests/unit/test_column_mapping_audit.py
+++ b/tests/unit/test_column_mapping_audit.py
@@ -1,0 +1,183 @@
+"""Phase 08 audit: the properties the column-mapping work has to keep.
+
+Three questions a reviewer of #467 / #468 would ask, answered by assertions rather
+than by reading the diff:
+
+* can a GraphQL document steer the rewrite?
+* does the resolved column reach SQL as an identifier, or as text?
+* is the ``fk_column`` / ``sql_column`` choice deliberate, or an accident that a
+  passing integration test happens to cover?
+"""
+
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from psycopg.sql import Identifier
+
+from fraiseql.db import (
+    FraiseQLRepository,
+    _table_metadata,
+    _type_registry,
+    register_type_for_view,
+)
+from fraiseql.sql.native_columns import resolve_native_column
+from fraiseql.where_normalization import _mapped_lookup_strategy
+
+VIEW = "v_audit_mapping"
+COLUMNS = {"id", "data", "model_category", "owner_id", "status"}
+MAPPING = {
+    "dimensions.item.model.category": "model_category",
+    "dimensions.item.owner": "owner_id",
+}
+
+
+class _Stats:
+    """Stand-in for a registered analytics type."""
+
+
+@pytest.fixture(autouse=True)
+def _registered():
+    register_type_for_view(
+        VIEW,
+        _Stats,
+        table_columns=COLUMNS,
+        has_jsonb_data=True,
+        jsonb_column="data",
+        column_mapping=MAPPING,
+    )
+    yield
+    _table_metadata.pop(VIEW, None)
+    _type_registry.pop(VIEW, None)
+
+
+def _normalize(where: dict):
+    return FraiseQLRepository(MagicMock())._normalize_where(where, VIEW, COLUMNS)
+
+
+class TestTheMappingIsNotUserInput:
+    """The rewrite reads registration metadata only. A query cannot add to it."""
+
+    def test_a_where_key_shaped_like_a_mapping_entry_does_not_become_one(self) -> None:
+        """`status` is a real column but is not declared in the mapping.
+
+        It still resolves to a column — by the existing column rules, not by the
+        mapping — which is the point: the mapping adds nothing a document asked for.
+        """
+        clause = _normalize({"dimensions": {"item": {"model": {"name": {"eq": "X1"}}}}})
+
+        rendered = clause.to_sql()[0].as_string(None)
+        assert "model_category" not in rendered
+        assert "->" in rendered, "an undeclared deep path must stay in JSONB"
+
+    def test_an_undeclared_path_cannot_reach_an_arbitrary_column(self) -> None:
+        """Naming a real column inside a JSONB path does not redirect the lookup."""
+        clause = _normalize({"dimensions": {"owner_id": {"eq": str(uuid4())}}})
+
+        rendered = clause.to_sql()[0].as_string(None)
+        assert rendered.startswith('"data"'), rendered
+
+    def test_the_mapping_dict_is_never_mutated_by_a_query(self) -> None:
+        before = dict(_table_metadata[VIEW]["column_mapping"])
+
+        _normalize({"dimensions": {"item": {"model": {"category": {"eq": "a"}}}}})
+        _normalize({"whatever": {"eq": "b"}})
+
+        assert _table_metadata[VIEW]["column_mapping"] == before
+
+
+class TestColumnsReachSqlAsIdentifiers:
+    def test_a_mapped_condition_renders_the_column_quoted(self) -> None:
+        clause = _normalize({"dimensions": {"item": {"model": {"category": {"eq": "a"}}}}})
+        rendered = clause.to_sql()[0].as_string(None)
+
+        assert rendered.startswith('"model_category"'), rendered
+
+    def test_a_column_name_that_needs_quoting_is_quoted_not_interpolated(self) -> None:
+        """The proof that this is `Identifier`, not string formatting.
+
+        A column name carrying a double quote round-trips through `Identifier`'s
+        escaping. Interpolated text would emit it raw and break the statement —
+        or worse.
+        """
+        hostile = 'weird"; DROP TABLE x --'
+        register_type_for_view(
+            "v_audit_quoting",
+            _Stats,
+            table_columns={"id", "data", hostile},
+            has_jsonb_data=True,
+            jsonb_column="data",
+            column_mapping={"dimensions.x": hostile},
+        )
+        try:
+            clause = FraiseQLRepository(MagicMock())._normalize_where(
+                {"dimensions": {"x": {"eq": "v"}}}, "v_audit_quoting", {"id", "data", hostile}
+            )
+            rendered = clause.to_sql()[0].as_string(None)
+            assert rendered.startswith('"weird""; DROP TABLE x --"'), rendered
+            assert Identifier(hostile).as_string(None) in rendered
+        finally:
+            _table_metadata.pop("v_audit_quoting", None)
+            _type_registry.pop("v_audit_quoting", None)
+
+
+class TestLookupStrategyChoice:
+    """Phase 02's `fk_column` vs `sql_column` rule, asserted directly.
+
+    `fk_column` is what the ltree `*_of_id` operators and the UUID coercion path
+    key on, so downgrading a foreign key to `sql_column` breaks the hierarchy
+    operators silently.
+    """
+
+    @pytest.mark.parametrize(
+        ("column", "value", "expected"),
+        [
+            ("owner_id", "not-a-uuid", "fk_column"),
+            ("model_category", uuid4(), "fk_column"),
+            ("model_category", [uuid4(), uuid4()], "fk_column"),
+            ("model_category", "printer", "sql_column"),
+            ("model_category", 42, "sql_column"),
+            ("model_category", [], "sql_column"),
+            ("model_category", ["a", "b"], "sql_column"),
+            ("model_category", [uuid4(), "a"], "sql_column"),
+        ],
+    )
+    def test_strategy(self, column: str, value: object, expected: str) -> None:
+        assert _mapped_lookup_strategy(column, value) == expected
+
+    def test_a_mapped_uuid_path_keeps_fk_column_end_to_end(self) -> None:
+        clause = _normalize({"dimensions": {"item": {"owner": {"eq": UUID(int=1)}}}})
+
+        assert clause.conditions[0].lookup_strategy == "fk_column"
+        assert clause.conditions[0].target_column == "owner_id"
+
+    def test_a_mapped_text_path_uses_sql_column(self) -> None:
+        clause = _normalize({"dimensions": {"item": {"model": {"category": {"eq": "a"}}}}})
+
+        assert clause.conditions[0].lookup_strategy == "sql_column"
+        assert clause.conditions[0].target_column == "model_category"
+
+
+class TestOneResolverForEveryClause:
+    """GROUP BY, WHERE and ORDER BY have to agree on what a path resolves to."""
+
+    def test_a_field_that_is_itself_a_column_wins_over_a_mapped_path(self) -> None:
+        assert (
+            resolve_native_column(
+                "date", native_columns={"date"}, column_mapping={"date": "other_column"}
+            )
+            == "date"
+        )
+
+    def test_a_mapped_path_wins_over_a_measure_of_the_same_name(self) -> None:
+        assert (
+            resolve_native_column(
+                "measures.cost",
+                column_mapping={"measures.cost": "mapped_cost"},
+                native_measures={"measures.cost": "measure_cost"},
+            )
+            == "mapped_cost"
+        )
+
+    def test_an_undeclared_path_resolves_to_nothing(self) -> None:
+        assert resolve_native_column("dimensions.nope", column_mapping=MAPPING) is None

--- a/tests/unit/test_dependency_floors.py
+++ b/tests/unit/test_dependency_floors.py
@@ -1,0 +1,104 @@
+"""Declared floors for packages with published security advisories.
+
+A `uv.lock` bump fixes *our* installs. It does nothing for a downstream resolver,
+which reads `pyproject.toml` — so every advisory we close has to move the declared
+floor too, or the next person to `pip install fraiseql` under their own constraints
+can resolve straight back onto the vulnerable version.
+
+The floors below are the Dependabot alerts open on `dev` at 1.23.12 (#465 track).
+Each entry names why the package is in the tree, because the exposure differs: a
+core dependency of every install is not the same finding as an optional extra.
+"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+# package -> (first patched version, why it is in the tree)
+REQUIRED_FLOORS = {
+    "sqlparse": ("0.6.0", "dev-only: used by scripts/, imported nowhere in src/"),
+    "nltk": ("3.10.0", "optional: transitive through the llamaindex extra"),
+    "pypdf": ("6.15.0", "optional: declared by the llamaindex extra"),
+    "cryptography": ("50.0.0", "core in practice: pulled in by pyjwt[crypto]"),
+    "aiohttp": ("3.14.3", "optional: dev extra, and transitive via llama-index-core"),
+    # Not a Dependabot alert — found by making the pip-audit CI gate authoritative,
+    # which is the point of that change. `click.edit()` is a command injection, and
+    # FraiseQL's CLI never calls it; the floor moves because the package is core.
+    "click": ("8.3.3", "core: the CLI's argument parser"),
+}
+
+
+@pytest.fixture(scope="module")
+def pyproject() -> dict:
+    return tomllib.loads(PYPROJECT.read_text())
+
+
+def _declarations(pyproject: dict, package: str) -> list[tuple[str, Requirement]]:
+    """Every place *package* is declared, as (location, requirement)."""
+    found: list[tuple[str, Requirement]] = []
+
+    def scan(location: str, requirements: list[str]) -> None:
+        for raw in requirements:
+            req = Requirement(raw)
+            if req.name.lower() == package:
+                found.append((location, req))
+
+    project = pyproject["project"]
+    scan("project.dependencies", project.get("dependencies", []))
+    for extra, requirements in project.get("optional-dependencies", {}).items():
+        scan(f"project.optional-dependencies.{extra}", requirements)
+    for group, requirements in pyproject.get("dependency-groups", {}).items():
+        scan(f"dependency-groups.{group}", requirements)
+    return found
+
+
+def _floor(specifier: SpecifierSet) -> Version | None:
+    """The lowest version the specifier admits, as declared by its `>=` / `==` bound."""
+    lower = [Version(s.version) for s in specifier if s.operator in (">=", "==")]
+    return max(lower) if lower else None
+
+
+@pytest.mark.parametrize(("package", "fixed", "why"), [(p, *v) for p, v in REQUIRED_FLOORS.items()])
+def test_every_declaration_is_at_or_above_the_fixed_version(
+    pyproject: dict, package: str, fixed: str, why: str
+) -> None:
+    declarations = _declarations(pyproject, package)
+    assert declarations, f"{package} is no longer declared anywhere ({why})"
+
+    for location, req in declarations:
+        floor = _floor(req.specifier)
+        assert floor is not None, f"{location}: {req} has no lower bound ({why})"
+        assert floor >= Version(fixed), (
+            f"{location}: {req} admits a version below the fixed {fixed} ({why})"
+        )
+
+
+def test_sqlparse_is_not_a_runtime_dependency(pyproject: dict) -> None:
+    """It is imported nowhere in ``src/`` — only by ``scripts/validate_code_examples.py``,
+    which already degrades gracefully when it is absent.
+
+    Declaring it under ``project.dependencies`` put four advisories in the runtime
+    surface of every install for a script-only tool. It still arrives transitively
+    via ``fraiseql-confiture``, so moving it does not remove the package — it moves
+    where the floor is enforced and what the scope of the finding is.
+    """
+    runtime = [name for name, _ in _declarations(pyproject, "sqlparse")]
+    assert "project.dependencies" not in runtime
+
+
+def test_cryptography_floor_is_declared_on_the_default_install(pyproject: dict) -> None:
+    """``pyjwt[crypto]`` is a core dependency, so cryptography is installed by default.
+
+    The advisory (a Bleichenbacher oracle in PKCS#7 ``EnvelopedData`` decryption) is
+    not code FraiseQL calls, but the package is in every install's tree and the
+    ``kms`` extras are the only place a floor was declared. An extras-only floor
+    leaves a default install free to resolve a vulnerable version.
+    """
+    runtime = [name for name, _ in _declarations(pyproject, "cryptography")]
+    assert "project.dependencies" in runtime

--- a/tests/unit/test_dependency_floors.py
+++ b/tests/unit/test_dependency_floors.py
@@ -5,7 +5,7 @@ which reads `pyproject.toml` — so every advisory we close has to move the decl
 floor too, or the next person to `pip install fraiseql` under their own constraints
 can resolve straight back onto the vulnerable version.
 
-The floors below are the Dependabot alerts open on `dev` at 1.23.12 (#465 track).
+The floors below are the Dependabot alerts open on `dev` at 1.23.12, cleared in 1.24.0.
 Each entry names why the package is in the tree, because the exposure differs: a
 core dependency of every install is not the same finding as an optional extra.
 """

--- a/tests/unit/test_group_by_native_dimension_mapping.py
+++ b/tests/unit/test_group_by_native_dimension_mapping.py
@@ -54,3 +54,94 @@ class TestBuildFindQueryNativeDimensionMapping:
         assert aggregations == {"measures.volume": "SUM(measures.volume)"}
         assert native_dims == set()
         assert native_dim_mapping == {"dimensions.category.id": "category_id"}
+
+
+class TestNativeDimensionMappingKeyCasing:
+    """Mapping keys are matched against snake_case field paths (issue #467, D2).
+
+    Field paths are built with ``transform_path=to_snake_case``, so a key
+    declared in GraphQL spelling (``dimensions.dateInfo.date``) could never
+    match one. Keys are normalized segment-wise at registration instead, so
+    both spellings resolve to the same entry and every consumer sees one.
+    """
+
+    CAMEL = "dimensions.dateInfo.date"
+    SNAKE = "dimensions.date_info.date"
+
+    def setup_method(self) -> None:
+        self.mock_conn = MagicMock()
+        self.repo = FraiseQLRepository(self.mock_conn)
+
+    def teardown_method(self) -> None:
+        from fraiseql.db import _table_metadata, _type_registry
+
+        for registry in (_table_metadata, _type_registry):
+            for view in [v for v in registry if v.startswith("v_casing")]:
+                del registry[view]
+
+    def _register(self, view_name: str, key: str) -> dict:
+        from fraiseql.db import _table_metadata, register_type_for_view
+
+        register_type_for_view(
+            view_name,
+            type("Stats", (), {}),
+            table_columns={"id", "data", "period_date"},
+            aggregation={
+                "measures": {"measures.cost": "SUM"},
+                "dimensions": "dimensions",
+                "native_dimension_mapping": {key: "period_date"},
+            },
+        )
+        return _table_metadata[view_name]["aggregation"]
+
+    def test_camel_case_key_is_normalized_at_registration(self) -> None:
+        agg = self._register("v_casing_camel", self.CAMEL)
+
+        assert agg["native_dimension_mapping"] == {self.SNAKE: "period_date"}
+
+    def test_both_spellings_register_identically(self) -> None:
+        camel = self._register("v_casing_camel_eq", self.CAMEL)
+        snake = self._register("v_casing_snake_eq", self.SNAKE)
+
+        assert camel["native_dimension_mapping"] == snake["native_dimension_mapping"]
+
+    def test_registration_does_not_mutate_the_caller_dict(self) -> None:
+        from fraiseql.db import register_type_for_view
+
+        mapping = {self.CAMEL: "period_date"}
+        aggregation = {"dimensions": "dimensions", "native_dimension_mapping": mapping}
+
+        register_type_for_view(
+            "v_casing_no_mutation",
+            type("Stats", (), {}),
+            table_columns={"id", "data", "period_date"},
+            aggregation=aggregation,
+        )
+
+        assert mapping == {self.CAMEL: "period_date"}
+        assert aggregation["native_dimension_mapping"] is mapping
+
+    def test_camel_case_key_reaches_group_by_as_native_column(self) -> None:
+        """End to end: the declared column lands in GROUP BY, not a JSONB path."""
+        from fraiseql.db import _derive_auto_aggregation
+
+        agg = self._register("v_casing_group_by", self.CAMEL)
+        field_paths = [["dimensions", "date_info", "date"], ["measures", "cost"]]
+
+        derived = _derive_auto_aggregation(field_paths, agg)
+        assert derived is not None
+        group_by, aggregations, native_dims, native_dim_mapping = derived
+        assert native_dim_mapping == {self.SNAKE: "period_date"}
+
+        query = self.repo._build_find_query(
+            "v_casing_group_by",
+            group_by=group_by,
+            aggregations=aggregations,
+            native_dimensions=native_dims,
+            native_dimension_mapping=native_dim_mapping,
+            jsonb_column="data",
+        )
+        sql_str = query.statement.as_string(None)
+
+        assert '"t"."period_date"' in sql_str
+        assert "->'date_info'" not in sql_str

--- a/tests/unit/test_optional_extras_import.py
+++ b/tests/unit/test_optional_extras_import.py
@@ -1,0 +1,63 @@
+"""Import guards for the optional extras whose versions moved in a security bump.
+
+The existing integration tests for the LangChain and LlamaIndex vector stores fall
+back to ``Mock`` when the upstream import fails, so a broken extra reads as a pass.
+That is the right behaviour for a suite that must run without the extras installed
+— but it means nothing checks the upgraded libraries actually import.
+
+These tests skip when the extra is absent and **fail** when it is present but
+broken, which is the shape that catches API drift from a version bump.
+"""
+
+import importlib
+
+import pytest
+
+# module under test -> the upstream import it needs, and the extra that provides it
+INTEGRATIONS = [
+    ("fraiseql.integrations.langchain", "langchain_core.documents", "langchain"),
+    ("fraiseql.integrations.llamaindex", "llama_index.core.schema", "llamaindex"),
+]
+
+
+@pytest.mark.parametrize(("module", "upstream", "extra"), INTEGRATIONS)
+def test_integration_module_imports_with_its_upstream(
+    module: str, upstream: str, extra: str
+) -> None:
+    pytest.importorskip(upstream, reason=f"the {extra} extra is not installed")
+    importlib.import_module(module)
+
+
+def test_pypdf_reader_api_is_present() -> None:
+    """``pypdf`` moved 6.14 → 6.16 for GHSA-fp3f-mc75-235c / GHSA-fwg2-594c-jp42."""
+    pypdf = pytest.importorskip("pypdf", reason="the llamaindex extra is not installed")
+    assert hasattr(pypdf, "PdfReader")
+
+
+def test_nltk_data_load_is_present() -> None:
+    """``nltk`` moved 3.9 → 3.10 for four path-traversal / SSRF / ReDoS advisories.
+
+    ``nltk.data.load`` is the function three of them are about; it is reached
+    through LlamaIndex's sentence splitting, never called by FraiseQL directly.
+    """
+    pytest.importorskip("nltk", reason="the llamaindex extra is not installed")
+    import nltk.data
+
+    assert callable(nltk.data.load)
+
+
+def test_aesgcm_still_imports_from_cryptography() -> None:
+    """``cryptography`` moved 49 → 50 for GHSA-g6cj-pr64-35w5.
+
+    That advisory is a Bleichenbacher oracle in PKCS#7 ``EnvelopedData`` decryption,
+    which FraiseQL does not call — the only cryptography API it uses is AES-GCM, in
+    the KMS key manager and its local provider. This is the import that has to keep
+    working for every install, since ``pyjwt[crypto]`` puts cryptography in the
+    default dependency tree.
+    """
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    key = AESGCM.generate_key(bit_length=256)
+    aead = AESGCM(key)
+    nonce = b"\x00" * 12
+    assert aead.decrypt(nonce, aead.encrypt(nonce, b"payload", None), None) == b"payload"

--- a/tests/unit/test_order_by_column_mapping.py
+++ b/tests/unit/test_order_by_column_mapping.py
@@ -1,0 +1,143 @@
+"""ORDER BY on a declared column mapping — the third leg (issue #467, adjacent).
+
+``native_columns`` is a *set of column names*, so it can express "this top-level
+field is a flat column" and nothing more. A declared mapping is a *path → column*
+dict, which does not fit that shape, so it was never passed to the ORDER BY
+generator at all: sorting on ``dimensions.item.model.category`` re-ran the whole
+``jsonb_build_object`` per row, on a key the SELECT list had already computed
+natively.
+
+The expression this produces must be byte-identical to the one the GROUP BY
+builder produces for the same path — PostgreSQL requires a sort key to be grouped
+or functionally determined by the grouping, and two different expressions for one
+logical field is exactly how that constraint gets violated.
+"""
+
+import pytest
+
+from fraiseql.sql.order_by_generator import OrderBy, OrderBySet, OrderDirection
+
+MAPPING = {"dimensions.item.model.category": "model_category"}
+
+
+def _sql(order_by: OrderBy, **kwargs: object) -> str:
+    return order_by.to_sql("data", **kwargs).as_string(None)
+
+
+class TestOrderByColumnMapping:
+    def test_mapped_path_sorts_on_the_column(self) -> None:
+        rendered = _sql(OrderBy(field="dimensions.item.model.category"), column_mapping=MAPPING)
+
+        assert rendered == '"t"."model_category" ASC'
+
+    def test_direction_is_preserved(self) -> None:
+        rendered = _sql(
+            OrderBy(field="dimensions.item.model.category", direction=OrderDirection.DESC),
+            column_mapping=MAPPING,
+        )
+
+        assert rendered == '"t"."model_category" DESC'
+
+    def test_string_direction_is_preserved(self) -> None:
+        rendered = _sql(
+            OrderBy(field="dimensions.item.model.category", direction="desc"),
+            column_mapping=MAPPING,
+        )
+
+        assert rendered == '"t"."model_category" DESC'
+
+    def test_unmapped_path_is_unchanged(self) -> None:
+        """Byte-identical to today for anything the mapping does not name."""
+        order_by = OrderBy(field="dimensions.item.model.name")
+
+        assert _sql(order_by, column_mapping=MAPPING) == _sql(order_by)
+        assert _sql(order_by) == "data -> 'dimensions' -> 'item' -> 'model' -> 'name' ASC"
+
+    def test_no_mapping_is_unchanged(self) -> None:
+        order_by = OrderBy(field="dimensions.item.model.category")
+
+        assert _sql(order_by, column_mapping=None) == _sql(order_by)
+
+    def test_column_identifier_is_quoted(self) -> None:
+        """The target comes from a registration, but it still goes through Identifier."""
+        rendered = _sql(OrderBy(field="x"), column_mapping={"x": 'weird"; DROP TABLE t; --'})
+
+        assert "DROP TABLE t" in rendered
+        assert rendered.startswith('"t"."weird""; DROP TABLE t; --"')
+
+
+class TestPrecedence:
+    """Same precedence as the GROUP BY builder, or the two expressions diverge."""
+
+    def test_native_column_wins_over_a_mapping_on_the_same_field(self) -> None:
+        rendered = _sql(
+            OrderBy(field="date"),
+            native_columns={"date"},
+            column_mapping={"date": "period_date"},
+        )
+
+        assert rendered == '"t"."date" ASC'
+
+    def test_mapping_applies_where_native_columns_does_not_reach(self) -> None:
+        rendered = _sql(
+            OrderBy(field="dimensions.item.model.category"),
+            native_columns={"date"},
+            column_mapping=MAPPING,
+        )
+
+        assert rendered == '"t"."model_category" ASC'
+
+
+class TestMatchesGroupByExpression:
+    """The sort key must render exactly as the GROUP BY key for the same path."""
+
+    @pytest.mark.parametrize(
+        ("field", "native_columns", "column_mapping"),
+        [
+            ("date", {"date"}, MAPPING),
+            ("dimensions.item.model.category", {"date"}, MAPPING),
+        ],
+    )
+    def test_expression_matches_build_field(
+        self, field: str, native_columns: set[str], column_mapping: dict[str, str]
+    ) -> None:
+        from fraiseql.db import _build_non_jsonb_field_expr
+
+        expected_column = field if field in native_columns else column_mapping[field]
+        group_by_expr = _build_non_jsonb_field_expr(expected_column, "t").as_string(None)
+
+        rendered = _sql(
+            OrderBy(field=field),
+            native_columns=native_columns,
+            column_mapping=column_mapping,
+        )
+
+        assert rendered == f"{group_by_expr} ASC"
+
+
+class TestOrderBySet:
+    def test_set_threads_the_mapping_to_every_instruction(self) -> None:
+        order_set = OrderBySet(
+            [
+                OrderBy(field="date", direction="asc"),
+                OrderBy(field="dimensions.item.model.category", direction="desc"),
+                OrderBy(field="dimensions.item.model.name", direction="asc"),
+            ]
+        )
+
+        rendered = order_set.to_sql(
+            "data", native_columns={"date"}, column_mapping=MAPPING
+        ).as_string(None)
+
+        assert rendered == (
+            'ORDER BY "t"."date" ASC, '
+            '"t"."model_category" DESC, '
+            "data -> 'dimensions' -> 'item' -> 'model' -> 'name' ASC"
+        )
+
+    def test_set_without_a_mapping_is_unchanged(self) -> None:
+        order_set = OrderBySet([OrderBy(field="dimensions.item.model.category")])
+
+        assert order_set.to_sql("data", column_mapping=None).as_string(None) == order_set.to_sql(
+            "data"
+        ).as_string(None)

--- a/tests/unit/test_where_column_mapping.py
+++ b/tests/unit/test_where_column_mapping.py
@@ -1,0 +1,250 @@
+"""The column-mapping rewrite pass (issue #467, part 1).
+
+``fk_relationships`` and the ``<parent>_id`` convention already resolve a nested
+filter onto a flat column.  A declared column mapping is the same idea for paths
+those two cannot reach — a leaf not named ``id``, or a column not named
+``<parent>_id`` — and until now it was honoured in GROUP BY and ignored in WHERE.
+
+This module tests the pass in isolation: given a normalized ``WhereClause`` and a
+mapping of dotted field paths to flat columns, every condition on a mapped path —
+at any depth, inside ``OR``/``AND``/``NOT`` groups too — is re-resolved onto its
+column, and everything else is left exactly as it was.
+"""
+
+import logging
+from uuid import UUID
+
+import pytest
+
+from fraiseql.where_clause import FieldCondition, WhereClause
+from fraiseql.where_normalization import _apply_column_mapping
+
+MAPPING = {"dimensions.item.model.category": "model_category"}
+COLUMNS = {"id", "data", "model_category", "item_id"}
+
+
+def _jsonb(*path: str, operator: str = "eq", value: object = "x") -> FieldCondition:
+    """A condition the normalizer would have produced for a deep JSONB path."""
+    return FieldCondition(
+        field_path=list(path),
+        operator=operator,
+        value=value,
+        lookup_strategy="jsonb_path",
+        target_column="data",
+        jsonb_path=list(path),
+    )
+
+
+class TestFlatConditions:
+    """A mapped path at the top level of the clause."""
+
+    def test_mapped_path_becomes_a_column(self) -> None:
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "model", "category")])
+
+        result = _apply_column_mapping(clause, MAPPING, COLUMNS)
+
+        condition = result.conditions[0]
+        assert condition.lookup_strategy == "sql_column"
+        assert condition.target_column == "model_category"
+        assert condition.jsonb_path is None
+        assert condition.field_path == ["dimensions", "item", "model", "category"]
+
+    def test_unmapped_path_is_untouched(self) -> None:
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "model", "name")])
+
+        result = _apply_column_mapping(clause, MAPPING, COLUMNS)
+
+        condition = result.conditions[0]
+        assert condition.lookup_strategy == "jsonb_path"
+        assert condition.target_column == "data"
+        assert condition.jsonb_path == ["dimensions", "item", "model", "name"]
+
+    def test_partial_path_does_not_match(self) -> None:
+        """Only the full dotted path counts — a suffix must not match a mapping key."""
+        clause = WhereClause(conditions=[_jsonb("item", "model", "category")])
+
+        result = _apply_column_mapping(clause, MAPPING, COLUMNS)
+
+        assert result.conditions[0].lookup_strategy == "jsonb_path"
+
+    def test_empty_mapping_is_a_no_op(self) -> None:
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "model", "category")])
+
+        result = _apply_column_mapping(clause, {}, COLUMNS)
+
+        assert result is clause
+
+
+class TestNestedClauses:
+    """Rewriting only ``.conditions`` would leave every OR/NOT group on JSONB."""
+
+    def test_conditions_inside_an_or_group_are_rewritten(self) -> None:
+        clause = WhereClause(
+            nested_clauses=[
+                WhereClause(
+                    conditions=[
+                        _jsonb("dimensions", "item", "model", "category", value="a"),
+                        _jsonb("dimensions", "item", "model", "category", value="b"),
+                    ],
+                    logical_op="OR",
+                )
+            ]
+        )
+
+        result = _apply_column_mapping(clause, MAPPING, COLUMNS)
+
+        rewritten = result.nested_clauses[0].conditions
+        assert [c.target_column for c in rewritten] == ["model_category", "model_category"]
+        assert result.nested_clauses[0].logical_op == "OR"
+
+    def test_deeply_nested_groups_are_rewritten(self) -> None:
+        clause = WhereClause(
+            nested_clauses=[
+                WhereClause(
+                    nested_clauses=[
+                        WhereClause(
+                            conditions=[_jsonb("dimensions", "item", "model", "category")],
+                        )
+                    ],
+                    logical_op="OR",
+                )
+            ]
+        )
+
+        result = _apply_column_mapping(clause, MAPPING, COLUMNS)
+
+        condition = result.nested_clauses[0].nested_clauses[0].conditions[0]
+        assert condition.target_column == "model_category"
+
+    def test_conditions_inside_a_not_clause_are_rewritten(self) -> None:
+        clause = WhereClause(
+            conditions=[_jsonb("dimensions", "item", "model", "name")],
+            not_clause=WhereClause(conditions=[_jsonb("dimensions", "item", "model", "category")]),
+        )
+
+        result = _apply_column_mapping(clause, MAPPING, COLUMNS)
+
+        assert result.not_clause.conditions[0].target_column == "model_category"
+        assert result.conditions[0].target_column == "data"
+
+
+class TestStrategySelection:
+    """``fk_column`` is what the ltree ``*_of_id`` operators key on — keep it."""
+
+    def test_id_suffixed_target_keeps_fk_column(self) -> None:
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "id")])
+
+        result = _apply_column_mapping(clause, {"dimensions.item.id": "item_id"}, COLUMNS)
+
+        condition = result.conditions[0]
+        assert condition.lookup_strategy == "fk_column"
+        assert condition.target_column == "item_id"
+
+    def test_uuid_value_keeps_fk_column(self) -> None:
+        value = UUID("11111111-1111-1111-1111-111111111111")
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "ref", value=value)])
+
+        result = _apply_column_mapping(clause, {"dimensions.item.ref": "model_category"}, COLUMNS)
+
+        assert result.conditions[0].lookup_strategy == "fk_column"
+
+    def test_uuid_list_value_keeps_fk_column(self) -> None:
+        values = [UUID("11111111-1111-1111-1111-111111111111")]
+        clause = WhereClause(
+            conditions=[_jsonb("dimensions", "item", "ref", operator="in", value=values)]
+        )
+
+        result = _apply_column_mapping(clause, {"dimensions.item.ref": "model_category"}, COLUMNS)
+
+        assert result.conditions[0].lookup_strategy == "fk_column"
+
+    def test_plain_target_uses_sql_column(self) -> None:
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "model", "category")])
+
+        result = _apply_column_mapping(clause, MAPPING, COLUMNS)
+
+        assert result.conditions[0].lookup_strategy == "sql_column"
+
+
+class TestPrecedence:
+    """An explicit declaration beats a convention, as ``fk_relationships`` does."""
+
+    def test_mapping_overrides_the_parent_id_convention(self) -> None:
+        convention = FieldCondition(
+            field_path=["dimensions", "item", "id"],
+            operator="eq",
+            value="x",
+            lookup_strategy="fk_column",
+            target_column="item_id",
+        )
+        clause = WhereClause(conditions=[convention])
+
+        result = _apply_column_mapping(
+            clause,
+            {"dimensions.item.id": "declared_item_id"},
+            COLUMNS | {"declared_item_id"},
+        )
+
+        assert result.conditions[0].target_column == "declared_item_id"
+        assert result.conditions[0].lookup_strategy == "fk_column"
+
+
+class TestPurity:
+    """The same normalized clause is re-read by the partial-period bound extractors."""
+
+    def test_input_clause_is_not_mutated(self) -> None:
+        original = _jsonb("dimensions", "item", "model", "category")
+        clause = WhereClause(
+            conditions=[original],
+            nested_clauses=[
+                WhereClause(conditions=[_jsonb("dimensions", "item", "model", "category")])
+            ],
+        )
+
+        result = _apply_column_mapping(clause, MAPPING, COLUMNS)
+
+        assert result is not clause
+        assert original.lookup_strategy == "jsonb_path"
+        assert original.target_column == "data"
+        assert original.jsonb_path == ["dimensions", "item", "model", "category"]
+        assert clause.nested_clauses[0].conditions[0].target_column == "data"
+
+
+class TestResolutionGuard:
+    """Registration validation is bypassable, so the resolver re-checks the target."""
+
+    def test_missing_column_raises_in_strict_mode(self) -> None:
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "model", "category")])
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _apply_column_mapping(
+                clause, {"dimensions.item.model.category": "nope"}, COLUMNS, strict=True
+            )
+
+        message = str(exc_info.value)
+        assert "nope" in message
+        assert "should have been caught during registration" in message
+
+    def test_missing_column_warns_and_falls_back_in_lenient_mode(self, caplog) -> None:
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "model", "category")])
+
+        with caplog.at_level(logging.WARNING, logger="fraiseql.where_normalization"):
+            result = _apply_column_mapping(
+                clause, {"dimensions.item.model.category": "nope"}, COLUMNS, strict=False
+            )
+
+        warnings = [r for r in caplog.records if "nope" in r.message]
+        assert len(warnings) == 1
+        assert "JSONB fallback" in warnings[0].message
+
+        condition = result.conditions[0]
+        assert condition.lookup_strategy == "jsonb_path"
+        assert condition.target_column == "data"
+
+    def test_unknown_columns_skip_validation(self) -> None:
+        """With nothing to validate against, trust the declaration rather than raise."""
+        clause = WhereClause(conditions=[_jsonb("dimensions", "item", "model", "category")])
+
+        result = _apply_column_mapping(clause, MAPPING, None, strict=True)
+
+        assert result.conditions[0].target_column == "model_category"

--- a/tests/unit/test_where_column_mapping_operators.py
+++ b/tests/unit/test_where_column_mapping_operators.py
@@ -1,0 +1,128 @@
+"""Every operator on a mapped path must emit column SQL, not a JSONB extraction.
+
+The rewrite changes only where a condition reads from — the operator, the value
+and the field path are untouched — so the sweep is a guard against a per-strategy
+gap in ``FieldCondition.to_sql()``: an operator handled under ``jsonb_path`` but
+missing from the ``sql_column`` / ``fk_column`` branches would silently change
+shape here.
+"""
+
+from uuid import UUID
+
+import pytest
+
+from fraiseql.where_clause import FieldCondition, WhereClause
+from fraiseql.where_normalization import _apply_column_mapping
+
+PATH = ["dimensions", "item", "model", "category"]
+MAPPING = {"dimensions.item.model.category": "model_category"}
+COLUMNS = {"id", "data", "model_category", "item_id"}
+
+
+def _render(operator: str, value: object, mapping: dict[str, str] = MAPPING) -> str:
+    path = next(iter(mapping)).split(".")
+    clause = WhereClause(
+        conditions=[
+            FieldCondition(
+                field_path=path,
+                operator=operator,
+                value=value,
+                lookup_strategy="jsonb_path",
+                target_column="data",
+                jsonb_path=path,
+            )
+        ]
+    )
+    sql, _params = _apply_column_mapping(clause, mapping, COLUMNS).to_sql()
+    return sql.as_string(None)
+
+
+@pytest.mark.parametrize(
+    ("operator", "value"),
+    [
+        ("eq", "laser"),
+        ("neq", "laser"),
+        ("in", ["laser", "inkjet"]),
+        ("nin", ["laser", "inkjet"]),
+        # 'notin' is an alias outside CONTAINMENT_OPERATORS, so to_sql() emits a
+        # single placeholder for the whole list — a pre-existing gap shared by
+        # the JSONB and column branches alike. The sweep asserts only that the
+        # rewrite reaches it; expanding it is not this phase's business.
+        ("notin", ["laser", "inkjet"]),
+        ("isnull", True),
+        ("contains", "las"),
+        ("gt", "a"),
+        ("gte", "a"),
+        ("lt", "z"),
+        ("lte", "z"),
+        ("startswith", "las"),
+        ("icontains", "LAS"),
+    ],
+)
+def test_operator_emits_column_sql(operator: str, value: object) -> None:
+    rendered = _render(operator, value)
+
+    assert '"model_category"' in rendered
+    assert '"data"' not in rendered
+    assert "->" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("operator", "value"),
+    [
+        ("eq", UUID("11111111-1111-1111-1111-111111111111")),
+        ("in", [UUID("11111111-1111-1111-1111-111111111111")]),
+        ("isnull", False),
+    ],
+)
+def test_fk_target_operators_emit_column_sql(operator: str, value: object) -> None:
+    rendered = _render(operator, value, {"dimensions.item.id": "item_id"})
+
+    assert '"item_id"' in rendered
+    assert '"data"' not in rendered
+    assert "->" not in rendered
+
+
+def test_containment_keeps_one_placeholder_per_value() -> None:
+    """psycopg3 needs individual placeholders — the rewrite must not collapse them."""
+    path = ["dimensions", "item", "model", "category"]
+    clause = WhereClause(
+        conditions=[
+            FieldCondition(
+                field_path=path,
+                operator="in",
+                value=["laser", "inkjet"],
+                lookup_strategy="jsonb_path",
+                target_column="data",
+                jsonb_path=path,
+            )
+        ]
+    )
+
+    sql, params = _apply_column_mapping(clause, MAPPING, COLUMNS).to_sql()
+
+    assert sql.as_string(None).count("%s") == 2
+    assert params == ["laser", "inkjet"]
+
+
+def test_values_are_no_longer_stringified() -> None:
+    """JSONB text extraction coerces every value to str; a real column must not."""
+    path = ["dimensions", "item", "model", "count"]
+    clause = WhereClause(
+        conditions=[
+            FieldCondition(
+                field_path=path,
+                operator="gte",
+                value=42,
+                lookup_strategy="jsonb_path",
+                target_column="data",
+                jsonb_path=path,
+            )
+        ]
+    )
+
+    _sql, params = _apply_column_mapping(
+        clause, {"dimensions.item.model.count": "model_count"}, COLUMNS | {"model_count"}
+    ).to_sql()
+
+    assert params == [42]

--- a/uv.lock
+++ b/uv.lock
@@ -74,33 +74,33 @@ dependencies = [
   {name = "yarl"}
 ]
 name = "aiohttp"
-sdist = {url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "3.14.1"
+version = "3.14.3"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z"},
-  {url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z"},
-  {url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z"},
-  {url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z"},
-  {url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z"},
-  {url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z"},
-  {url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z"},
-  {url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z"},
-  {url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z"},
-  {url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z"},
-  {url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z"},
-  {url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z"},
-  {url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z"},
-  {url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z"},
-  {url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z"},
-  {url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z"},
-  {url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z"},
-  {url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z"},
-  {url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z"},
-  {url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z"},
-  {url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z"},
-  {url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z"},
-  {url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z"}
+  {url = "https://files.pythonhosted.org/packages/57/be/5afd201cc0ab139029aadb75392efe85a293403d9dd3a3226161c21ce00c/aiohttp-3.14.3-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:2e9878ae68e4a5f1c0abe4dd497dbc3d51946f5837b56759e2a02e78fa90ef86", size = 506269, upload-time = "2026-07-23T01:54:49.075Z"},
+  {url = "https://files.pythonhosted.org/packages/22/09/dec8189d62b45ade009f6792a2264b942a90cb88aeaf181239933cd72c3c/aiohttp-3.14.3-cp313-cp313-android_21_x86_64.whl", hash = "sha256:f3d2669fe7dec7fc359ecdb5984b29b50d85d5d00f8c1cb61de4f4a24ee42627", size = 515166, upload-time = "2026-07-23T01:54:51.894Z"},
+  {url = "https://files.pythonhosted.org/packages/28/24/2854869d29ed8a8b19d74f9ec6629515f7e04d02dd329d9d179201e58e47/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:cc7cb243a68167172f48c1fd43cee91ec4b1d40cefd190edd43369d1a6bc9c82", size = 486263, upload-time = "2026-07-23T01:54:54.223Z"},
+  {url = "https://files.pythonhosted.org/packages/d4/dd/57187c8be2a35aea65eaee3bd2c3dcbbcf0204f5106c89637e3610380cd1/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:78253b573e6ffab5028924fc98bc281aae05445969982a10864bc360dea2016c", size = 492299, upload-time = "2026-07-23T01:54:56.236Z"},
+  {url = "https://files.pythonhosted.org/packages/b9/11/06ae6ed8f0d414edf4068861e233d8fe23ee699bfd4b3ceb8663db948a62/aiohttp-3.14.3-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7041d52c3a7fa20c9e8c182b534704abb19502c8bdcbde7ab23bfda6f642394f", size = 502235, upload-time = "2026-07-23T01:54:58.377Z"},
+  {url = "https://files.pythonhosted.org/packages/7e/a3/559639c34a345d2cf7c52dff6838119f2eaf29eb508227b5b83f573af813/aiohttp-3.14.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac74facc01463f138b0da5580329cfcc82818dea5656e83ddcd11268fc12ff80", size = 750883, upload-time = "2026-07-23T01:55:00.65Z"},
+  {url = "https://files.pythonhosted.org/packages/91/cd/41e131f13afd1e7b0172a9d9eda085ef90eb8439f41f0d279db81ed3ae60/aiohttp-3.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d6218d92e450824e9b4881f44e8c09f1853b490f9a64130801024a4793b1b3b0", size = 508473, upload-time = "2026-07-23T01:55:02.945Z"},
+  {url = "https://files.pythonhosted.org/packages/bc/6b/e7f13410d391c6e55b4c007a8de024355389d7d459e3d64c42b2d33617e5/aiohttp-3.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:11fb37ef075669eee52ab1928fbf6e1741fada40409fa309ebde9607a962aebf", size = 509190, upload-time = "2026-07-23T01:55:05.173Z"},
+  {url = "https://files.pythonhosted.org/packages/97/21/6464573e53d69672cc1eada3e5c5cb2d2efa82701e8305a0f2047a576967/aiohttp-3.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55bdcc472aafe2de4a253045cc128007a64f1e0264fb675791e132ea5edaa3bd", size = 1761478, upload-time = "2026-07-23T01:55:07.383Z"},
+  {url = "https://files.pythonhosted.org/packages/1a/81/d217043a4c17fbce360905e3b2bdd20139ebc9a2de836d035d179c4da006/aiohttp-3.14.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c39846c3aad97a8530c89d7a3869a8f8e9e3762c6ac0504481e5c80948f7e807", size = 1735092, upload-time = "2026-07-23T01:55:09.803Z"},
+  {url = "https://files.pythonhosted.org/packages/a1/66/e13a02d0eeb1a9a502402a977abb4e4abff9fe4051c26f80558c57a7c975/aiohttp-3.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5895ef58c4620afe02fa16044f023dc4dafec08158f9d08874a46a7dbc0341b8", size = 1800546, upload-time = "2026-07-23T01:55:12.012Z"},
+  {url = "https://files.pythonhosted.org/packages/26/5e/57d42fca1d18cb5acc1cad945d017fabc5d6ae71d8a08ad66be8dc3ee544/aiohttp-3.14.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa9467a8113aa69d3d7c55a70ef0b7c636010a40993f3df9d9d0d73b3eb7ef24", size = 1895250, upload-time = "2026-07-23T01:55:14.357Z"},
+  {url = "https://files.pythonhosted.org/packages/ca/1c/7da8d08e74d56f00070822f9638ff3f1c563f8ad87d1efa996c87bfc8644/aiohttp-3.14.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d2deec16eeedf55f2c7cf75b521ea3856a5177e123844f8fd0f114ce252cb5", size = 1789289, upload-time = "2026-07-23T01:55:16.668Z"},
+  {url = "https://files.pythonhosted.org/packages/cd/0f/cf16bcf56896981c1a0319f5d5db9337994b5165730c48a8fa07e9b34be6/aiohttp-3.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dd54d0e8717de95939766febac482ac0474d8ac3b048115f9f2b1d23a16e7db4", size = 1586706, upload-time = "2026-07-23T01:55:18.913Z"},
+  {url = "https://files.pythonhosted.org/packages/fe/6f/76eac12a7f2480e1e304f842efdb07db33256b0d9165b866b6ef0806c202/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:df82f3787c940c94986b34222d59c9e38843fba85139f36e85255a82ad5355a9", size = 1724652, upload-time = "2026-07-23T01:55:21.296Z"},
+  {url = "https://files.pythonhosted.org/packages/39/b6/19c8c592baeeb94b75f966547d40c02ac7590902306ec5863d5c027cf506/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:42a67efc36300d052fb4508a53e8b6901b9284b599ae63945c377569c5fcc1e1", size = 1756239, upload-time = "2026-07-23T01:55:23.705Z"},
+  {url = "https://files.pythonhosted.org/packages/dc/c9/4e9383150296f97f873b680c4de8fb2cd88608fb9f48c79edcb111611abc/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7a75aa63cbf9b21cfaf60dc2657e19df2c2867d91707d653fee171ffeedd1371", size = 1769161, upload-time = "2026-07-23T01:55:26.082Z"},
+  {url = "https://files.pythonhosted.org/packages/aa/1e/147bdc6cc5de5f3ab011be8bf5d6e786633249f22c20bae06f85e45f5387/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e92eb8acc45eb6a9f4935071a77edf5b85cc6f8dfad5cd99e97653c26593cdde", size = 1578759, upload-time = "2026-07-23T01:55:28.846Z"},
+  {url = "https://files.pythonhosted.org/packages/fd/31/78388a9d6040ece2e11df62ea229a822cf5e52d238374b220ae9975b2623/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b014a6ed7cf912e787149fdc529166d3ceabac23f26efeea3158c9aba2354e7e", size = 1792025, upload-time = "2026-07-23T01:55:31.457Z"},
+  {url = "https://files.pythonhosted.org/packages/03/51/a3d29fdf2c25d796746af8ad6fe56a45d6256c38b0a8a2ed752e1160b3a2/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d4f72af88ac2474bb5bca640030320e3d38a0163a1d7533500e87be458eef71", size = 1768477, upload-time = "2026-07-23T01:55:33.87Z"},
+  {url = "https://files.pythonhosted.org/packages/29/a6/442e18b5afeade534d877a2dc3c3e392aff8d49787890b0cf84790410267/aiohttp-3.14.3-cp313-cp313-win32.whl", hash = "sha256:5f08ec777f35ee70720233b8b9811d3bb5d728137f30ac91b7457709c3261ac0", size = 451069, upload-time = "2026-07-23T01:55:36.121Z"},
+  {url = "https://files.pythonhosted.org/packages/9d/69/3d876ac02659f271cf7f6769f14a8e3de5b6e888ed8b5a7e998086a4cec8/aiohttp-3.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:dff9461ec275f22135650d5ba4b4931a11f3958df7dfbb8db630000d4dee0883", size = 476518, upload-time = "2026-07-23T01:55:38.303Z"},
+  {url = "https://files.pythonhosted.org/packages/b2/0e/50d6e6471cd31edce8b282bdec59375a3a69124d8a989a0b1313355cae52/aiohttp-3.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:ddcac3c6b382e81f1dd0499199d4136b877beb4cb5ef770bbbfba56c4b8f55d2", size = 447676, upload-time = "2026-07-23T01:55:40.451Z"}
 ]
 
 [[package]]
@@ -427,15 +427,12 @@ wheels = [
 ]
 
 [[package]]
-dependencies = [
-  {name = "colorama", marker = "sys_platform == 'win32'"}
-]
 name = "click"
-sdist = {url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "8.3.1"
+version = "8.5.0"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z"}
+  {url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z"}
 ]
 
 [[package]]
@@ -487,36 +484,36 @@ dependencies = [
   {name = "cffi", marker = "platform_python_implementation != 'PyPy'"}
 ]
 name = "cryptography"
-sdist = {url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "49.0.0"
+version = "50.0.1"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z"},
-  {url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z"},
-  {url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z"},
-  {url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z"},
-  {url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z"},
-  {url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z"},
-  {url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z"},
-  {url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z"},
-  {url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z"},
-  {url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z"},
-  {url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z"},
-  {url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z"},
-  {url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z"},
-  {url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z"},
-  {url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z"},
-  {url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z"},
-  {url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z"},
-  {url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z"},
-  {url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z"},
-  {url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z"},
-  {url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z"},
-  {url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z"},
-  {url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z"},
-  {url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z"},
-  {url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z"},
-  {url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z"}
+  {url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z"},
+  {url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z"},
+  {url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z"},
+  {url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z"},
+  {url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z"},
+  {url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z"},
+  {url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z"},
+  {url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z"},
+  {url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z"},
+  {url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z"},
+  {url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z"},
+  {url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z"},
+  {url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z"},
+  {url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z"},
+  {url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z"},
+  {url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z"},
+  {url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z"},
+  {url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z"},
+  {url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z"},
+  {url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z"},
+  {url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z"},
+  {url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z"},
+  {url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z"},
+  {url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z"},
+  {url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z"},
+  {url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z"}
 ]
 
 [[package]]
@@ -720,6 +717,7 @@ wheels = [
 dependencies = [
   {name = "aiosqlite"},
   {name = "click"},
+  {name = "cryptography"},
   {name = "fastapi"},
   {name = "fraiseql-confiture"},
   {name = "graphql-core"},
@@ -735,7 +733,6 @@ dependencies = [
   {name = "python-dotenv"},
   {name = "pyyaml"},
   {name = "rich"},
-  {name = "sqlparse"},
   {name = "starlette"},
   {name = "structlog"},
   {name = "typer"},
@@ -760,6 +757,7 @@ dev = [
   {name = "pytest-asyncio"},
   {name = "pytest-cov"},
   {name = "pytest-forked"},
+  {name = "sqlparse"},
   {name = "testcontainers"},
   {name = "twine"},
   {name = "ty"}
@@ -782,17 +780,18 @@ requires-dist = [
   {name = "aioboto3", marker = "extra == 'all'", specifier = ">=15.5.0"},
   {name = "aioboto3", marker = "extra == 'kms-all'", specifier = ">=15.5.0"},
   {name = "aioboto3", marker = "extra == 'kms-aws'", specifier = ">=15.5.0"},
-  {name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.14.1"},
+  {name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.14.3"},
   {name = "aiosqlite", specifier = ">=0.22.1"},
   {name = "banks", marker = "extra == 'llamaindex'", specifier = ">=2.4.2"},
   {name = "black", marker = "extra == 'dev'", specifier = ">=26.5.1"},
   {name = "boto3", marker = "extra == 'all'", specifier = ">=1.38.0"},
   {name = "boto3", marker = "extra == 'aws'", specifier = ">=1.38.0"},
   {name = "build", marker = "extra == 'dev'", specifier = ">=1.4.0"},
-  {name = "click", specifier = ">=8.3.0"},
-  {name = "cryptography", marker = "extra == 'all'", specifier = ">=48.0.1"},
-  {name = "cryptography", marker = "extra == 'kms'", specifier = ">=48.0.1"},
-  {name = "cryptography", marker = "extra == 'kms-all'", specifier = ">=48.0.1"},
+  {name = "click", specifier = ">=8.3.3"},
+  {name = "cryptography", specifier = ">=50.0.0"},
+  {name = "cryptography", marker = "extra == 'all'", specifier = ">=50.0.0"},
+  {name = "cryptography", marker = "extra == 'kms'", specifier = ">=50.0.0"},
+  {name = "cryptography", marker = "extra == 'kms-all'", specifier = ">=50.0.0"},
   {name = "cyclonedx-python-lib", marker = "extra == 'all'", specifier = ">=11.10.0,<12.0"},
   {name = "cyclonedx-python-lib", marker = "extra == 'sbom'", specifier = ">=11.10.0,<12.0"},
   {name = "docker", marker = "extra == 'dev'", specifier = ">=7.1.0"},
@@ -827,6 +826,7 @@ requires-dist = [
   {name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7.6"},
   {name = "mkdocs-redirects", marker = "extra == 'docs'", specifier = ">=1.2.2"},
   {name = "moto", extras = ["kms"], marker = "extra == 'dev'", specifier = ">=5.1.21"},
+  {name = "nltk", marker = "extra == 'llamaindex'", specifier = ">=3.10.0"},
   {name = "opentelemetry-api", marker = "extra == 'all'", specifier = ">=1.41.1"},
   {name = "opentelemetry-api", marker = "extra == 'tracing'", specifier = ">=1.39.0"},
   {name = "opentelemetry-exporter-otlp", marker = "extra == 'all'", specifier = ">=1.41.1"},
@@ -851,7 +851,7 @@ requires-dist = [
   {name = "pyjwt", extras = ["crypto"], marker = "extra == 'all'", specifier = ">=2.13.0"},
   {name = "pyjwt", extras = ["crypto"], marker = "extra == 'auth0'", specifier = ">=2.13.0"},
   {name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0.1"},
-  {name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.13.3"},
+  {name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.15.0"},
   {name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3"},
   {name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0"},
   {name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.2.3"},
@@ -866,7 +866,6 @@ requires-dist = [
   {name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.2"},
   {name = "rich", specifier = ">=14.0.0"},
   {name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12"},
-  {name = "sqlparse", specifier = ">=0.5.5"},
   {name = "starlette", specifier = ">=1.3.1"},
   {name = "structlog", specifier = ">=25.5.0"},
   {name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.14.2"},
@@ -896,6 +895,7 @@ dev = [
   {name = "pytest-asyncio", specifier = ">=1.3.0"},
   {name = "pytest-cov", specifier = ">=7.1.0"},
   {name = "pytest-forked", specifier = ">=1.6.0"},
+  {name = "sqlparse", specifier = ">=0.6.0"},
   {name = "testcontainers", specifier = ">=4.14.2"},
   {name = "twine", specifier = ">=6.2.0"},
   {name = "ty", specifier = ">=0.0.35"}
@@ -928,6 +928,7 @@ all = [
   {name = "langsmith"},
   {name = "llama-index"},
   {name = "llama-index-core"},
+  {name = "nltk"},
   {name = "opentelemetry-api"},
   {name = "opentelemetry-exporter-otlp"},
   {name = "opentelemetry-instrumentation-psycopg"},
@@ -1009,6 +1010,7 @@ llamaindex = [
   {name = "banks"},
   {name = "llama-index"},
   {name = "llama-index-core"},
+  {name = "nltk"},
   {name = "pillow"},
   {name = "pypdf"}
 ]
@@ -1021,6 +1023,7 @@ llm = [
   {name = "langsmith"},
   {name = "llama-index"},
   {name = "llama-index-core"},
+  {name = "nltk"},
   {name = "pillow"},
   {name = "pypdf"}
 ]
@@ -2188,16 +2191,17 @@ wheels = [
 [[package]]
 dependencies = [
   {name = "click"},
+  {name = "defusedxml"},
   {name = "joblib"},
   {name = "regex"},
   {name = "tqdm"}
 ]
 name = "nltk"
-sdist = {url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "3.9.4"
+version = "3.10.3"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z"}
+  {url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z"}
 ]
 
 [[package]]
@@ -2856,11 +2860,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-sdist = {url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/44/66/54212e75406afd9f3e933d0dda23072f6aecc55c5a273077dc2e0b028b23/pypdf-6.16.2.tar.gz", hash = "sha256:595647f6191de6f402cfde1d0c455d6cbccbd509aac32b34783009c032de5d6e", size = 7008996, upload-time = "2026-08-23T13:50:07.135Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "6.14.2"
+version = "6.16.2"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z"}
+  {url = "https://files.pythonhosted.org/packages/13/f1/a2da3b55acd4ab737bf728c97edaaed5ec1d3c1236acb639dcdfa97e42c7/pypdf-6.16.2-py3-none-any.whl", hash = "sha256:c8b09a59399062fb45a1b8156c18a787a10a3dae03ac9674397a226712c94604", size = 385060, upload-time = "2026-08-23T13:50:05.349Z"}
 ]
 
 [[package]]
@@ -3519,11 +3523,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-sdist = {url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "0.5.5"
+version = "0.6.0"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z"}
+  {url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z"}
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -530,11 +530,11 @@ dependencies = [
   {name = "sortedcontainers"}
 ]
 name = "cyclonedx-python-lib"
-sdist = {url = "https://files.pythonhosted.org/packages/a7/54/40d741cb605229cddcf9ec689b0fd401e39e2e70c2fe9cc728923b983b8e/cyclonedx_python_lib-11.10.0.tar.gz", hash = "sha256:d03d6ea271e26feaf123b8b1b34468a305f33a338c5763f56e397a8408f9b290", size = 1429036, upload-time = "2026-06-11T10:36:27.633Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/17/40/6509e6cfd7f2f3255501690f46375fdd224949e21fd1e96f4f4c8a9041b1/cyclonedx_python_lib-11.12.0.tar.gz", hash = "sha256:16767c4039de90c04e9f03348f8f0ed4b8ff842eaa7eefcad3a95685f970dacf", size = 1445378, upload-time = "2026-08-13T07:52:18.675Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "11.10.0"
+version = "11.12.0"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/a3/21/01c9b957ec3a778de86e010c1b54ea433ebf2fc50b810a3ca0ce8000782f/cyclonedx_python_lib-11.10.0-py3-none-any.whl", hash = "sha256:ffb9510b8d00a0896cfbe0a78b97c545d28f7d2a54e9d9dd5e5dc6e91ca9b375", size = 527798, upload-time = "2026-06-11T10:36:25.985Z"}
+  {url = "https://files.pythonhosted.org/packages/cf/f0/b2cb999244f2f4194df63ecff6939228178fa63a33be809c412684ca8db7/cyclonedx_python_lib-11.12.0-py3-none-any.whl", hash = "sha256:0e807521a921a5c3cb8ce1153f8a61d29eedfe76a46aac2796b7c6b573391a54", size = 529453, upload-time = "2026-08-13T07:52:16.836Z"}
 ]
 
 [[package]]
@@ -792,8 +792,8 @@ requires-dist = [
   {name = "cryptography", marker = "extra == 'all'", specifier = ">=50.0.0"},
   {name = "cryptography", marker = "extra == 'kms'", specifier = ">=50.0.0"},
   {name = "cryptography", marker = "extra == 'kms-all'", specifier = ">=50.0.0"},
-  {name = "cyclonedx-python-lib", marker = "extra == 'all'", specifier = ">=11.10.0,<12.0"},
-  {name = "cyclonedx-python-lib", marker = "extra == 'sbom'", specifier = ">=11.10.0,<12.0"},
+  {name = "cyclonedx-python-lib", marker = "extra == 'all'", specifier = ">=11.11.0,<12.0"},
+  {name = "cyclonedx-python-lib", marker = "extra == 'sbom'", specifier = ">=11.11.0,<12.0"},
   {name = "docker", marker = "extra == 'dev'", specifier = ">=7.1.0"},
   {name = "email-validator", marker = "extra == 'dev'", specifier = ">=2.3.0"},
   {name = "faker", marker = "extra == 'dev'", specifier = ">=40.23.0"},
@@ -804,9 +804,9 @@ requires-dist = [
   {name = "fraiseql", extras = ["llamaindex"], marker = "extra == 'all'"},
   {name = "fraiseql", extras = ["llamaindex"], marker = "extra == 'llm'"},
   {name = "fraiseql-confiture", specifier = ">=0.5.2"},
-  {name = "google-cloud-kms", marker = "extra == 'all'", specifier = ">=3.11.0"},
-  {name = "google-cloud-kms", marker = "extra == 'kms-all'", specifier = ">=3.11.0"},
-  {name = "google-cloud-kms", marker = "extra == 'kms-gcp'", specifier = ">=3.11.0"},
+  {name = "google-cloud-kms", marker = "extra == 'all'", specifier = ">=3.16.0"},
+  {name = "google-cloud-kms", marker = "extra == 'kms-all'", specifier = ">=3.16.0"},
+  {name = "google-cloud-kms", marker = "extra == 'kms-gcp'", specifier = ">=3.16.0"},
   {name = "graphql-core", specifier = ">=3.2.11"},
   {name = "httpx", specifier = ">=0.28.0"},
   {name = "httpx", marker = "extra == 'all'", specifier = ">=0.28.0"},
@@ -823,7 +823,7 @@ requires-dist = [
   {name = "llama-index", marker = "extra == 'llamaindex'", specifier = ">=0.14.21"},
   {name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.14.21"},
   {name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1"},
-  {name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7.6"},
+  {name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7.7"},
   {name = "mkdocs-redirects", marker = "extra == 'docs'", specifier = ">=1.2.2"},
   {name = "moto", extras = ["kms"], marker = "extra == 'dev'", specifier = ">=5.1.21"},
   {name = "nltk", marker = "extra == 'llamaindex'", specifier = ">=3.10.0"},
@@ -870,12 +870,12 @@ requires-dist = [
   {name = "structlog", specifier = ">=25.5.0"},
   {name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.14.2"},
   {name = "testcontainers", extras = ["vault"], marker = "extra == 'dev'", specifier = ">=4.14.2"},
-  {name = "tox", marker = "extra == 'dev'", specifier = ">=4.55.1"},
+  {name = "tox", marker = "extra == 'dev'", specifier = ">=4.58.0"},
   {name = "twine", marker = "extra == 'dev'", specifier = ">=6.2.0"},
   {name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.35"},
   {name = "typer", specifier = ">=0.24.0"},
   {name = "urllib3", specifier = ">=2.7.0"},
-  {name = "uvicorn", specifier = ">=0.49.0"},
+  {name = "uvicorn", specifier = ">=0.52.0"},
   {name = "werkzeug", marker = "extra == 'dev'", specifier = ">=3.1.6"},
   {name = "wrapt", marker = "extra == 'all'", specifier = ">=1.16.0"},
   {name = "wrapt", marker = "extra == 'tracing'", specifier = ">=1.16.0"}
@@ -902,7 +902,7 @@ dev = [
 ]
 docs = [
   {name = "mkdocs", specifier = ">=1.6.1"},
-  {name = "mkdocs-material", specifier = ">=9.7.6"},
+  {name = "mkdocs-material", specifier = ">=9.7.7"},
   {name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3"},
   {name = "mkdocs-minify-plugin", specifier = ">=0.8.0"},
   {name = "mkdocs-redirects", specifier = ">=1.2.2"},
@@ -1168,11 +1168,11 @@ dependencies = [
   {name = "protobuf"}
 ]
 name = "google-cloud-kms"
-sdist = {url = "https://files.pythonhosted.org/packages/ae/7d/a13ba13808c08c467b315f71a74189848a3305ebb5c098f5f0386e209cec/google_cloud_kms-3.11.0.tar.gz", hash = "sha256:5f7d7bdb347f13a8a2b7bad6cbdf3846a51690df7215586845b62851b88839f7", size = 434866, upload-time = "2026-02-19T16:03:11.932Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/73/53/4bde1d2c31e72e898c2bdfac25ac27da52c3b4e1936a411fbe96f01d65a4/google_cloud_kms-3.16.0.tar.gz", hash = "sha256:c89c66ccffc1358f973801ed1b45bd92b35ddbbc2545db9032af6d4643b20c76", size = 448119, upload-time = "2026-07-16T20:36:20.6Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "3.11.0"
+version = "3.16.0"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/f2/55/8c6e5f6b5d4768faecc69554d43417c07af94a09079b737ceacde0cbf14e/google_cloud_kms-3.11.0-py3-none-any.whl", hash = "sha256:07f2829e4ed986220802d013219fe159ecbdecec35907a6ddeea37ea9daecd8d", size = 350118, upload-time = "2026-02-19T16:02:43.539Z"}
+  {url = "https://files.pythonhosted.org/packages/76/b0/f102b5c077df60cfeac7ace7a1ccbe6d5e934dfadf37ff8b8ddbcdce8a24/google_cloud_kms-3.16.0-py3-none-any.whl", hash = "sha256:ad3c102961ba58179f7261814d9cd28dded93603bd33c8224b4b072897bbe81e", size = 359027, upload-time = "2026-07-16T20:35:57.575Z"}
 ]
 
 [[package]]
@@ -2004,11 +2004,11 @@ dependencies = [
   {name = "requests"}
 ]
 name = "mkdocs-material"
-sdist = {url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "9.7.6"
+version = "9.7.7"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z"}
+  {url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z"}
 ]
 
 [[package]]
@@ -3032,15 +3032,14 @@ wheels = [
 
 [[package]]
 dependencies = [
-  {name = "filelock"},
-  {name = "platformdirs"}
+  {name = "filelock"}
 ]
 name = "python-discovery"
-sdist = {url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/91/96/0f93e27c9f60a650838f2118159aa115fd5732c0716247917b7ba7ede665/python_discovery-1.6.0.tar.gz", hash = "sha256:6393b4eae1be8b2182670635e7baff89ac21cb9f8e86fd1ff40c7b1144febb4c", size = 82849, upload-time = "2026-08-28T17:30:02.366Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "1.4.2"
+version = "1.6.0"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z"}
+  {url = "https://files.pythonhosted.org/packages/43/5e/21abf578182fb15006a57faf3711a1e659e29d600d19b6e557eae908c81d/python_discovery-1.6.0-py3-none-any.whl", hash = "sha256:d4e244cf17b8b29819ed78003d55fbacf86eda23425b075454fff9271b79377a", size = 38451, upload-time = "2026-08-28T17:30:01.236Z"}
 ]
 
 [[package]]
@@ -3634,11 +3633,11 @@ dependencies = [
   {name = "virtualenv"}
 ]
 name = "tox"
-sdist = {url = "https://files.pythonhosted.org/packages/79/5b/4f09156a3f7bf3c4fa23212717f097c59126d81e2c557e6fd872a62db38a/tox-4.55.1.tar.gz", hash = "sha256:0678fbf26dd5b559b1ef128fa4388325920219322ebc8cc5f3497627c00f4472", size = 280676, upload-time = "2026-06-03T20:01:03.487Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/d6/04/e24b26eebc152f497761387108996c241492b5ac0455ad7effac9fd7b2f2/tox-4.61.1.tar.gz", hash = "sha256:d41ff6eb434d71763740ec90d869cb82688e6ff9204c913d8bea13fb75fc8f9a", size = 306574, upload-time = "2026-08-28T23:00:23.877Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "4.55.1"
+version = "4.61.1"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/bb/fd/394f00f3d3e23d87eb7b20276d88fe835e48780d3eb30e6f362428bb80c8/tox-4.55.1-py3-none-any.whl", hash = "sha256:e2084be6dfdef96ba1bed4948e6a1f73613d6952e1477be5dca45653d4c053c8", size = 215360, upload-time = "2026-06-03T20:01:01.967Z"}
+  {url = "https://files.pythonhosted.org/packages/5a/6d/779b14c03ad40a2bfd4ba22316aa1153772fb72f3b1acde229130820518b/tox-4.61.1-py3-none-any.whl", hash = "sha256:90bf9cf074d38ab87bff1753183d96c07e9e99d04acc2230d21f42f7aa89d1c6", size = 227932, upload-time = "2026-08-28T23:00:22.189Z"}
 ]
 
 [[package]]
@@ -3793,11 +3792,11 @@ dependencies = [
   {name = "h11"}
 ]
 name = "uvicorn"
-sdist = {url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z"}
+sdist = {url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z"}
 source = {registry = "https://pypi.org/simple"}
-version = "0.49.0"
+version = "0.52.4"
 wheels = [
-  {url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z"}
+  {url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z"}
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.23.12"
+version = "1.24.0"
 
 [package.dev-dependencies]
 dev = [


### PR DESCRIPTION
Closes #467. Closes #468. Closes #443.

Two independent tracks that ship together as **1.24.0**: the column-mapping fix
behind #467/#468, and the security backlog (15 Dependabot alerts, 205 code-scanning
alerts, 10 open Dependabot PRs).

---

## 1 — One column resolver (#467, #468)

`native_dimension_mapping` was honoured in `GROUP BY` and ignored everywhere else,
so a query could **group on the flat column while filtering on the JSONB snapshot**.
A mapping key that matched nothing was a silent no-op.

- **`column_mapping=` on `register_type_for_view`** — the top-level peer of
  `fk_relationships` the reporter asked for (D1), applied unconditionally to
  `GROUP BY`, `WHERE` and `ORDER BY` alike. `aggregation["native_dimension_mapping"]`
  is superseded, keeps working, and feeds the same resolver.
- **Keys are normalised segment-wise to `snake_case` at registration** (D2), so a
  mapping written for the Rust engine (`dimensions.dateInfo.date`) works here
  unchanged. Value-validation alone would *not* have closed this: with
  `dimensions.dateInfo.date` the value is a real column and only the key is the
  wrong shape, so a value guard passes and the mapping still never fires.
- **A key that matches no field now raises at registration** under
  `validate_fk_strict=True`, warns otherwise.
- **`fraiseql.sql.native_columns.resolve_native_column`** — one answer to "does this
  field path have a flat SQL column?". It had been spelled **six** ways: three
  `build_field` closures, three `is_native` checks beside them, and
  `OrderBy._flat_column`. That is how a new resolution rule reached two of three
  call sites and nobody noticed.

Found while tracing #467, fixed here as **#468**: the partial-period `UNION ALL` path
rebuilt its WHERE from top-level conditions alone, **discarding every `OR`/`NOT`
group**, and never passed `order_by` (the statement always ended `ORDER BY 1`). When
the date bound was the only top-level condition it failed open entirely. A date bound
that is not a top-level conjunct no longer triggers the rewrite at all —
`date >= X OR status = 'a'` was being rewritten into `date in [branch] AND status = 'a'`,
dropping every row that matched on the date alone.

### The observable behaviour change

`ORDER BY` on a mapped path now sorts the flat column. Measured against a live
database rather than assumed — the visible effect is **NULL placement**, not row order:

| snapshot holds | non-null order | NULL placement (ASC) |
|---|---|---|
| ISO date `YYYY-MM-DD` | **identical** | jsonb null first → SQL NULL last |
| JSON number | **identical** | jsonb null first → SQL NULL last |
| number written as a string | **differs** — `9,10,100` vs `"10","100","9"` | same flip |
| ISO timestamp, per-row offsets | **differs** | same flip |

ISO dates sort lexicographically in chronological order by construction, and the
generator uses `->` not `->>` so a JSON number keeps its type. Filtering on a mapped
path likewise reads the column, so results change where the column and the frozen
snapshot disagree. Both are corrections and both are observable — hence a minor bump.

---

## 2 — Fifteen Dependabot advisories, with the exposure triage

Recorded verbatim from the phase plan. **This is the difference between an honest
security note and a scary one** — not all fifteen are in a default install.

- **sqlparse** — declared in core `dependencies` (floor `>=0.5.5`) but **imported
  nowhere in `src/`**. The only use in the repo is `scripts/validate_code_examples.py`,
  which already degrades gracefully when it is absent. It also arrives transitively via
  `fraiseql-confiture` (`sqlparse>=0.5.0`), so removing our declaration does not remove
  the package. Action: **move it from `dependencies` to the `dev` group and raise the
  floor to `>=0.6.0`** — the floor is what actually forces the resolver off 0.5.5.
- **nltk, pypdf** — only reachable through the optional `llamaindex` / `langchain` /
  `llm` / `all` extras. `nltk` is transitive (`llama-index`, `llama-index-core`);
  `pypdf` is declared directly in the `llamaindex` extra. Not installed by a default
  `pip install fraiseql`.
- **cryptography** — declared in `kms` / `kms-all` / `all`, **but also pulled into the
  core install by `pyjwt[crypto]`**, which is in `dependencies`. So it is effectively a
  runtime dependency of every install. The advisory is PKCS#7 `EnvelopedData`
  decryption, which FraiseQL does not call — but the floor must move regardless.
- **aiohttp** — `dev` extra floor plus transitive via `llama-index-core`. Not in a
  default install.

### The audit gate was vacuously green

`pip-audit ... || true` swallowed the exit code, **and** the follow-up "critical
vulnerabilities" check filtered on `.vulnerabilities[].severity` — pip-audit emits
`{"dependencies": [{"name","version","vulns":[...]}]}` and carries **no severity field
at all**. The filter matched nothing, printed `✅ No critical or high-severity
vulnerabilities found`, and exited 0 through ten open HIGH advisories. pip-audit's own
exit code is now authoritative and the report check is written against the real schema,
so a future schema change surfaces as a disagreement between the two steps rather than
as silence.

Its first honest run flagged **click 8.3.1** (PYSEC-2026-2132 / CVE-2026-7246, command
injection in `click.edit()`). FraiseQL's CLI never calls `click.edit`, so exposure is
nil — but the package is core, so the floor moved to `>=8.3.3` (locked 8.5.0). That
finding is this change's own evidence for why repairing the gate was worth doing.

---

## 3 — Container attack surface (#443)

`trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM,LOW --ignorefile .trivyignore`
against the image built from `Dockerfile --target runtime`:

|        | findings | CRITICAL | HIGH | MEDIUM | LOW |
|--------|----------|----------|------|--------|-----|
| before | 139      | 0        | 13   | 76     | 50  |
| after  | 81       | 0        | 0    | 43     | 38  |

**Findings with a `FixedVersion` remaining after: 0.** That number matters more than
the count — there is no un-suppressed finding left that we could fix and have not.

Packages whose findings disappeared entirely: libcurl4t64 (17), curl (17),
libssh2-1t64 (6), libsystemd0 (2), libudev1 (2), setuptools (2), libsqlite3-0 (2),
libp11-kit0 (2), libpam-runtime (1), libpam0g (1), libpam-modules-bin (1), msgpack (1),
bash-completion (1), libgnutls30t64 (1), libnghttp2-14 (1), libpam-modules (1).
**Newly appearing findings: 0.**

- `curl` existed only to answer the `HEALTHCHECK`, which now probes with the
  interpreter already in the image.
- `pip` and `setuptools` are removed in the same layer that installs the wheel — that
  also removes the only msgpack in the image, which was `pip/_vendor/msgpack` rather
  than a resolved dependency. (setuptools is not even *importable* in the base image,
  but Trivy finds it by its dist-info, which is why the removal has to be `&&`-chained
  into the same layer.)
- **krb5 and openldap stay.** They are `libpq5`'s dependencies, not curl's. ~28 alerts
  are the price of talking to PostgreSQL, and
  `test_libpq5_and_its_dependencies_are_still_present` pins that so a future "cut more
  packages" pass cannot trade connectivity for a lower alert count.
- `security-alerts.yml` no longer pulls and scans
  `gcr.io/distroless/python3-debian12:nonroot`, dropped from the container-security
  matrix months ago — it was raising HIGH/CRITICAL alert levels for an image nothing
  builds from.
- The compliance gate's HIGH branch ended in `if [ "$label" == "Distroless (Production)" ]`,
  a matrix label that no longer exists: dead code guarding a no-op `exit 0`. Replaced
  with a stated policy — CRITICAL fails; HIGH in a **language** package fails (it comes
  from our own wheel, so there is always something to bump); HIGH in an **OS** package
  reports and does not, because trixie routinely ships HIGHs with no fix and a
  permanently-red gate is an ignored gate.

GitHub reports 205 alerts where the local scan reports 139 — SARIF carries one result
per location. The ratio is stable, so expect roughly **120** code-scanning alerts after
this lands, not 81.

Also: `.dockerignore` `target/` → `**/target/`. The bare pattern matches only a
*top-level* directory, so `fraiseql_rs/target/` (21 GB of local Rust artifacts) was
copied into the build context and `docker build --target runtime` died with "no space
left on device" on a developer machine. CI never noticed because it builds from a clean
checkout — which means none of the above could be *measured* until this was fixed.

---

## 4 — The ten open Dependabot PRs

Applied here as one relock rather than ten branch pushes. Dependabot bumps a
`pyproject.toml` floor without relocking, and #465's `uv lock --check` then fails every
one of the five Python PRs; fixing that per-PR means pushing a relock to each branch,
five times, each producing a lock diff the next invalidates.

- **#449–#453** (Python): uvicorn `>=0.52.0`, google-cloud-kms `>=3.16.0` (three
  declarations), tox `>=4.58.0`, cyclonedx-python-lib `>=11.11.0`, mkdocs-material
  `>=9.7.7`. Package count unchanged at 258.
- **#456, #457** (Rust): itertools 0.15, mockall 0.15 — no source changes.
- **#458** (Rust, the flagged risk): **jsonwebtoken 11.0 needed no source change.**
  Every breaking item in its changelog lands on API this crate does not use — the
  `non_exhaustive` enums are only constructed (`Algorithm::RS256`) and matched with a
  `_` arm; `Jwk.thumbprint`, `Header.extras`, `insecure_disable_signature_validation`
  and the removed key accessors have no callers, since `src/auth/jwt.rs` builds its key
  with `DecodingKey::from_jwk`.
- **#454 / #455 resolve to a *removal*, not an upgrade.** `testcontainers` and
  `testcontainers-modules` are **imported by nothing**. The only mentions in the crate
  are two comments promising a "Phase 1" implementation that never landed, beside a
  `TestDatabase` placeholder whose every method returns
  `Err("... not implemented in Phase 0.2")` and whose own unit tests assert that it
  does. Migrating 12 and 13 minor versions of a harness that was never written is not
  work worth doing; both declarations are removed. **Those two PRs close with that
  reason rather than as merges.**

---

## Verification

- `tests/unit` + `tests/regression` — **3985 passed** (baseline 3859 + 2 xfailed).
- `tests/integration` — **2407 passed**, 1 failed: `test_nested_organization_without_tenant_id`,
  a known pre-existing failure on `dev`.
- `tests/container` — 10 passed (opt-in via `-m container`; it builds Docker images).
- Full `pytest tests/` — 7424 passed / 5 failed, run twice. Only two failures repeat
  across runs and both are pre-existing (the one above, plus a `DATABASE_URL` test-pollution
  case filed separately). The chaos failures are **different tests each run** and all
  assert load-sensitive thresholds against a machine that was concurrently building
  Docker images and running Trivy scans; they pass in isolation.
- Load-bearing checks, not just green suites: stubbing the mapping to `{}` fails 3 of 4
  "should pass unchanged" tests; stubbing `_build_extra_where` back to conditions-only
  fails 7 of the new #468 tests.
- `uv lock --check` clean. `pip-audit` over `uv export --all-extras`: no known
  vulnerabilities.
- `ruff check` / `ruff format` clean on every touched file.
- `uv run ty check` reports 348 errors on this branch and 348 on `dev` — pre-existing
  noise, delta zero.

## Follow-ups found and deliberately not fixed

Filed as separate issues rather than widened into this change: `DATABASE_URL` leaking
between tests; `fraiseql_rs/benches/` not compiling (12 errors, invisible because CI
runs clippy and build without `--all-targets`);
`_build_partial_period_union_query` not splitting schema-qualified view names;
`src/fraiseql/security/startup_checks.py` never being called;
`aiosqlite` being a core dependency with no importer; the list-of-dicts `order_by` form
not recursing; the flat-column `ORDER BY` branch dropping an explicit collation; and
`aggregation["measures"]` / `["native_measures"]` carrying the same casing trap #467 was
about.
