### PR TITLE
fix(ci): count unpatched container findings against the key Trivy actually emits

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -187,10 +187,22 @@ jobs:
          echo "- 🔵 Low: $LOW" >> security-report.md
          echo "" >> security-report.md
 
-         # Check for unpatched vulnerabilities
-         UNPATCHED=$(jq '[.Results[]?.Vulnerabilities[]? | select(.FixedVersion=="")] | length' trivy-${{ matrix.dockerfile.label }}-detailed.json)
+         # Patch availability.
+         #
+         # Trivy OMITS FixedVersion entirely when upstream has no fix - it does
+         # not emit an empty string - so the key reads as null and any `== ""`
+         # test matches nothing. Both counts below default the missing key
+         # through `// ""` for that reason.
+         #
+         # FIXABLE is the number the gate cares about: a finding that carries a
+         # FixedVersion is one we can act on, so it should stay at 0. UNPATCHED
+         # is context - base-OS CVEs with no upstream patch, each accepted one
+         # justified in .trivyignore.
+         UNPATCHED=$(jq '[.Results[]?.Vulnerabilities[]? | select((.FixedVersion // "") == "")] | length' trivy-${{ matrix.dockerfile.label }}-detailed.json)
+         FIXABLE=$(jq '[.Results[]?.Vulnerabilities[]? | select((.FixedVersion // "") != "")] | length' trivy-${{ matrix.dockerfile.label }}-detailed.json)
          echo "## Patch Availability" >> security-report.md
-         echo "- Unpatched vulnerabilities: $UNPATCHED" >> security-report.md
+         echo "- Findings with a fix available (actionable): $FIXABLE" >> security-report.md
+         echo "- Findings with no upstream fix: $UNPATCHED" >> security-report.md
          echo "" >> security-report.md
 
          # Government compliance gate.


### PR DESCRIPTION
Closes #478.

The container compliance report's "Unpatched vulnerabilities" counter used
`select(.FixedVersion == "")`. Trivy **omits** `FixedVersion` entirely when upstream has no fix —
it does not emit an empty string — so the key reads as `null`, the test matches nothing, and the
counter was structurally incapable of returning anything but `0`. In an artifact stamped
"Compliance Level: Government Agency Ready", that states the inverse of the truth: every one of
the 81 findings is unpatched.

Same bug class as the `pip-audit` filter fixed in #469, one file over.

## Changes

- Default the missing key through `// ""` so unpatched findings are actually counted.
- Add the complement, `FIXABLE` — findings that *do* carry a `FixedVersion`. That is the number
  the gate cares about and Phase 06's success criterion: it should stay at 0, and unlike the old
  counter it can move.
- Relabel both report lines so a reader can tell which number is actionable.
- Comment why the `// ""` is load-bearing, so it does not get "simplified" back out.

## Verification

Measured, not assumed. Extracted the patched block verbatim from the workflow and ran it against
`trivy-Standard-detailed.json` from run
[33299606547](https://github.com/fraiseql/fraiseql-python/actions/runs/33299606547) — the same
artifact that produced the "0" report on `dev` at 1.24.0:

```
total vulnerabilities:      81
FixedVersion key absent:    81
FixedVersion empty string:   0

old expression:              0
```

Rendered by the patched block:

```
## Patch Availability
- Findings with a fix available (actionable): 0
- Findings with no upstream fix: 81
```

The real situation is fine — every remaining finding is a base-OS CVE with no upstream patch,
which is why the gate accepts them — but now the report says so instead of the opposite.

- ✅ YAML parses
- ✅ Repo swept for other `.FixedVersion == ""` filters — none remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N