### PR TITLE
fix(sql): make ORDER BY collation reach the sort on every path

### DIFF
--- a/docs/core/queries-and-mutations.md
+++ b/docs/core/queries-and-mutations.md
@@ -251,6 +251,13 @@ FraiseQL supports PostgreSQL collation for locale-aware text sorting in `orderBy
 
 **Global Default Collation**:
 
+!!! warning "Not currently applied"
+    This setting has no effect yet. Applying it safely needs field *types* in the
+    ORDER BY builder, which does not distinguish a text field from a numeric one --
+    and collating a numeric field either sorts it lexicographically or fails
+    outright. Only a per-field collation reaches the SQL today. This has always
+    been its effective behaviour.
+
 Configure a default collation for all text sorting:
 
 ```python
@@ -294,9 +301,10 @@ query {
 **Collation Precedence**:
 
 1. Per-field explicit value (highest priority)
-2. Explicit `null` (skips global default)
-3. Global `default_string_collation`
-4. PostgreSQL database default (lowest priority)
+2. Explicit `null`
+3. PostgreSQL database default (lowest priority)
+
+`default_string_collation` is not part of this chain today -- see the warning above.
 
 **Common Collations**:
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -533,6 +533,13 @@ extensions; `"postgis"` is the most accurate but requires the PostGIS extension.
 PostgreSQL collation applied to text `ORDER BY` clauses, e.g. `"fr_FR.utf8"` or
 `"C"`.
 
+!!! warning "Not currently applied"
+    This setting has no effect yet. Applying it safely needs field *types* in the
+    ORDER BY builder, which does not distinguish a text field from a numeric one --
+    and collating a numeric field either sorts it lexicographically or fails
+    outright. Only a per-field collation reaches the SQL today. This has always
+    been its effective behaviour.
+
 ### `session_variables`
 
 **Type**: `dict[str, str]`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -122,6 +122,13 @@ config = FraiseQLConfig(
 
 Applied to all text fields in ORDER BY unless overridden per-field in queries.
 
+!!! warning "Not currently applied"
+    This setting has no effect yet. Applying it safely needs field *types* in the
+    ORDER BY builder, which does not distinguish a text field from a numeric one --
+    and collating a numeric field either sorts it lexicographically or fails
+    outright. Only a per-field collation reaches the SQL today. This has always
+    been its effective behaviour.
+
 **Common Values**:
 
 - `"C"` - Byte-order sorting (fastest, case-sensitive)

--- a/src/fraiseql/fastapi/config.py
+++ b/src/fraiseql/fastapi/config.py
@@ -323,7 +323,13 @@ class FraiseQLConfig(BaseSettings):
     default_string_collation: str | None = None
     """Default PostgreSQL collation for string ORDER BY clauses.
 
-    Applied to all text fields in ORDER BY unless overridden per-field.
+    .. warning::
+       Not currently applied. Honouring it needs field *types* plumbed into the
+       ORDER BY builder, because nothing there distinguishes a text field from a
+       numeric one -- and collating a numeric field either sorts it
+       lexicographically or fails outright. Until then only a per-field
+       collation reaches the SQL; see ``_apply_collation_default``. This has
+       always been its effective behaviour, so nothing changed in #476.
 
     Examples:
     - "en_US.utf8" - US English locale-aware sorting

--- a/src/fraiseql/sql/graphql_order_by_generator.py
+++ b/src/fraiseql/sql/graphql_order_by_generator.py
@@ -119,18 +119,36 @@ def _normalize_order_direction(direction: Any) -> OrderDirection:
 
 
 def _apply_collation_default(
-    field_collation: str | None, global_collation: str | None, was_explicitly_set: bool = False
+    field_collation: str | None,
+    global_collation: str | None,
+    was_explicitly_set: bool = False,
 ) -> str | None:
-    """Apply collation precedence rules.
+    """Resolve the collation for one sort key. The single place that decides.
 
-    Precedence (highest to lowest):
-    1. Per-field explicit value (including explicit None)
-    2. Global default collation
-    3. Database default (None)
+    Precedence:
+    1. Per-field explicit value, including an explicit None
+    2. Nothing -- the database default
+
+    Why the global default is dropped
+    ---------------------------------
+    ``default_string_collation`` is documented as applying to "all *text* fields",
+    but nothing here tracks which fields are text: it was applied to every field,
+    numeric ones included. That was harmless only for as long as a collation
+    never reached the sort. Since #476 one does, and honouring a blanket default
+    would now
+
+    * make a numeric JSONB sort lexicographic -- 1, 10, 2 -- silently, and
+    * make a numeric flat column fail outright with
+      "collations are not supported by type integer".
+
+    Dropping it leaves the setting exactly as effective as it has always been,
+    which is not at all, so this is a no-op for every existing deployment. The
+    parameter stays because making the setting work needs field *types* plumbed
+    down to here, and that is the change that will use it.
 
     Args:
         field_collation: Collation from field/input
-        global_collation: Global default from config
+        global_collation: Global default from config; deliberately not applied
         was_explicitly_set: True if field_collation was explicitly set
                            (even if set to None)
 
@@ -138,24 +156,23 @@ def _apply_collation_default(
         Collation to use, or None for database default
 
     Examples:
-        # Explicit per-field value (highest priority)
+        # Explicit per-field value
         _apply_collation_default("en_US.utf8", "fr_FR.utf8", True) -> "en_US.utf8"
 
-        # Explicit None skips global default
+        # Explicit None
         _apply_collation_default(None, "fr_FR.utf8", True) -> None
 
-        # No field value, use global default
-        _apply_collation_default(None, "fr_FR.utf8", False) -> "fr_FR.utf8"
+        # No field value: the global default is not applied
+        _apply_collation_default(None, "fr_FR.utf8", False) -> None
 
         # No field value, no global default
         _apply_collation_default(None, None, False) -> None
     """
-    # If field collation was explicitly set (even to None), use it
+    # Only a collation the caller asked for on this field reaches the SQL.
     if was_explicitly_set:
         return field_collation
 
-    # Otherwise, fall back to global default
-    return global_collation or None
+    return None
 
 
 def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> OrderBySet | None:
@@ -218,14 +235,16 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
                         # Handle OrderDirection enum or string
                         direction = _normalize_order_direction(value)
 
-                        # Dict format doesn't support explicit collation, only global default
+                        # A dict carries no per-field collation, so this
+                        # resolves to None -- see _apply_collation_default.
                         global_collation = config.default_string_collation if config else None
+                        collation = _apply_collation_default(None, global_collation, False)
 
                         instructions.append(
                             OrderBy(
                                 field=snake_field_name,
                                 direction=direction,
-                                collation=global_collation,
+                                collation=collation,
                             )
                         )
         return OrderBySet(instructions=instructions) if instructions else None
@@ -294,13 +313,13 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
                     if isinstance(value, (OrderDirection, str)):
                         direction = _normalize_order_direction(value)
 
-                        # Apply global collation default (no per-field override in this format)
+                        # No per-field override in this format, so this
+                        # resolves to None -- see _apply_collation_default.
                         global_collation = config.default_string_collation if config else None
+                        collation = _apply_collation_default(None, global_collation, False)
 
                         instructions.append(
-                            OrderBy(
-                                field=field_path, direction=direction, collation=global_collation
-                            )
+                            OrderBy(field=field_path, direction=direction, collation=collation)
                         )
                     # If it's a nested order by input, process recursively
                     elif hasattr(value, "__gql_fields__"):

--- a/src/fraiseql/sql/order_by_generator.py
+++ b/src/fraiseql/sql/order_by_generator.py
@@ -56,6 +56,13 @@ class OrderBy:
     - fr_FR.utf8: French locale-aware sorting (accents, case)
     - C: Byte-order sorting (fastest)
 
+    A collation is honoured on every path: a flat column collates directly, and
+    a JSONB field is extracted as text (``->>``) so the collation has something
+    to apply to. Requesting one therefore selects a *text* ordering -- which is
+    what a collation means -- so do not set one on a numeric field. It also
+    makes an explicit JSON ``null`` sort with an absent key (both become SQL
+    NULL) rather than ahead of every string, as ``->`` does.
+
     Attributes:
         field: The field name or nested path (e.g., 'amount' or 'profile.age')
                For vector distance: 'embedding.cosine_distance'
@@ -65,7 +72,7 @@ class OrderBy:
 
     Examples:
         OrderBy('amount') -> "data -> 'amount' ASC"
-        OrderBy('name', collation='fr_FR.utf8') -> "data -> 'name' COLLATE "fr_FR.utf8" ASC"
+        OrderBy('name', collation='fr_FR.utf8') -> "(data ->> 'name') COLLATE "fr_FR.utf8" ASC"
         OrderBy('profile.age', 'desc') -> "data -> 'profile' -> 'age' DESC"
         OrderBy('embedding.cosine_distance', 'asc', [0.1, 0.2, 0.3]) ->
             "(data -> 'embedding') <=> '[0.1,0.2,0.3]'::vector ASC"
@@ -75,6 +82,21 @@ class OrderBy:
     direction: OrderDirection = OrderDirection.ASC
     value: list[float] | None = None
     collation: str | None = None
+
+    def _collated(self, expr: sql.Composed | sql.SQL) -> sql.Composed | sql.SQL:
+        """Append ``COLLATE "name"`` to *expr*, or return it untouched.
+
+        The collation name is rendered with :class:`~psycopg.sql.Identifier`, not
+        :class:`~psycopg.sql.Literal`: PostgreSQL's syntax is ``COLLATE "name"``,
+        and the name reaches here from configuration.
+
+        Every branch of :meth:`to_sql` that can carry a collation routes through
+        this, because the two flat-column branches used to return before the
+        collation was applied at all (#476).
+        """
+        if self.collation is None:
+            return expr
+        return expr + sql.SQL(" COLLATE ") + sql.Identifier(self.collation)
 
     def _direction_sql(self) -> sql.SQL:
         """Render the sort direction, accepting either the enum or a bare string."""
@@ -135,11 +157,12 @@ class OrderBy:
         For vector distance operations like 'embedding.cosine_distance', uses:
         ({table_ref} -> 'embedding') <=> '[0.1,0.2,...]'::vector
         """
-        # Flat column short-circuit: use t."col" instead of JSONB extraction
+        # Flat column short-circuit: use t."col" instead of JSONB extraction.
+        # A collation applies here exactly as it would to any text column.
         flat_column = self._flat_column(native_columns, column_mapping)
         if flat_column is not None:
             col_expr = sql.SQL("{}.{}").format(sql.Identifier("t"), sql.Identifier(flat_column))
-            return col_expr + sql.SQL(" ") + self._direction_sql()
+            return self._collated(col_expr) + sql.SQL(" ") + self._direction_sql()
 
         # Check if this is a vector distance operation
         if "." in self.field and self.value is not None:
@@ -151,25 +174,35 @@ class OrderBy:
                         field_name, operator, self.value, table_ref
                     )
 
-        # Standard JSONB extraction for regular fields
+        # Standard JSONB extraction for regular fields.
+        #
+        # The leaf is extracted with -> (jsonb) so numbers sort numerically
+        # rather than lexicographically -- except when a collation is asked
+        # for. jsonb has no collation, so the leaf must come out as text for
+        # the request to mean anything, and the whole extraction has to be
+        # parenthesised: COLLATE binds tighter than ->, so the unparenthesised
+        # `data -> 'name' COLLATE "x"` parses as `data -> ('name' COLLATE "x")`,
+        # attaching the collation to the *key literal*. PostgreSQL accepts that
+        # and silently ignores it, which is how it went unnoticed (#476).
+        #
+        # Asking for a collation is asking for a text ordering, so -> is only
+        # traded for ->> on the branch that requested one; an uncollated sort
+        # keeps its previous SQL byte for byte.
         path = self.field.split(".")
         json_path = sql.SQL(" -> ").join(sql.Literal(p) for p in path[:-1])
         last_key = sql.Literal(path[-1])
+        leaf_op = sql.SQL(" ->> ") if self.collation is not None else sql.SQL(" -> ")
         if path[:-1]:
-            # For nested fields: {table_ref} -> 'profile' -> 'age' (all JSONB)
-            data_expr = sql.SQL(table_ref + " -> ") + json_path + sql.SQL(" -> ") + last_key
+            # For nested fields: {table_ref} -> 'profile' -> 'age'
+            data_expr = sql.SQL(table_ref + " -> ") + json_path + leaf_op + last_key
         else:
-            # For simple fields: {table_ref} -> 'field' (JSONB)
-            data_expr = sql.SQL(table_ref + " -> ") + last_key
+            # For simple fields: {table_ref} -> 'field'
+            data_expr = sql.SQL(table_ref) + leaf_op + last_key
 
-        # Apply COLLATE clause if specified
-        # IMPORTANT: Use sql.Identifier() for collation name (NOT sql.Literal())
-        # PostgreSQL syntax: COLLATE "name" (identifier), not COLLATE 'name' (string)
         if self.collation is not None:
-            collation_clause = sql.SQL(" COLLATE ") + sql.Identifier(self.collation)
-            data_expr = data_expr + collation_clause
+            data_expr = sql.SQL("({})").format(data_expr)
 
-        return data_expr + sql.SQL(" ") + self._direction_sql()
+        return self._collated(data_expr) + sql.SQL(" ") + self._direction_sql()
 
     def _build_vector_distance_sql(
         self,

--- a/tests/integration/database/sql/test_order_by_collation_execution.py
+++ b/tests/integration/database/sql/test_order_by_collation_execution.py
@@ -1,0 +1,173 @@
+"""Issue #476: the ORDER BY collation, executed against a live database.
+
+The unit tests assert on SQL text, and for this bug that is not enough. The
+JSONB branch emitted ``t -> 'name' COLLATE "x"`` for years and every string
+assertion passed -- but PostgreSQL parses that as ``t -> ('name' COLLATE "x")``,
+attaching the collation to the *key literal*, comparing ``jsonb``, and ignoring
+the collation entirely. It does not error, so nothing caught it.
+
+So these tests never look at the generated SQL. They run the same query twice
+under two collations that disagree about case, and assert the row order
+actually differs. A dropped collation (the old flat-column branches) and a
+misbound one (the old JSONB branch) both fail that: they return the same order
+both times.
+"""
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from psycopg.sql import SQL
+
+from fraiseql.sql.order_by_generator import OrderBy
+
+pytestmark = pytest.mark.database
+
+TABLE = "t_476_collation"
+
+# Byte order puts uppercase first ("B" < "a" < "c"); a linguistic collation
+# orders case-insensitively ("a" < "B" < "c"). Any collation pair that
+# disagrees about these three rows proves the collation reached the sort.
+ROWS = ["a", "B", "c"]
+BYTE_ORDER = ["B", "a", "c"]
+
+
+async def _linguistic_collation(pool: Any) -> str | None:
+    """A collation available on this server that disagrees with ``"C"``.
+
+    Which ones exist depends on how the server was built and which locales the
+    host has, so it is discovered rather than assumed, and the tests skip when
+    none is usable instead of failing on an unrelated environment difference.
+    """
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        for candidate in ("en-US-x-icu", "und-x-icu", "en_US.utf8", "en_US.UTF-8"):
+            await cursor.execute(
+                "SELECT 1 FROM pg_collation WHERE collname = %s LIMIT 1", (candidate,)
+            )
+            if await cursor.fetchone() is None:
+                continue
+            try:
+                await cursor.execute(
+                    SQL("SELECT v FROM unnest(%s::text[]) AS s(v) ORDER BY v COLLATE {}").format(
+                        SQL('"{}"'.format(candidate.replace('"', '""')))
+                    ),
+                    (ROWS,),
+                )
+            except Exception:
+                await conn.rollback()
+                continue
+            if [r[0] for r in await cursor.fetchall()] != BYTE_ORDER:
+                return candidate
+            await conn.rollback()
+    return None
+
+
+@pytest.fixture
+async def collation_rows(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """Three rows carrying the same text as a flat column and inside JSONB."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {test_schema}")
+        await cursor.execute(
+            f"CREATE TABLE IF NOT EXISTS {TABLE} "
+            f"(id UUID PRIMARY KEY, name TEXT NOT NULL, data JSONB NOT NULL)"
+        )
+        for name in ROWS:
+            await cursor.execute(
+                f"INSERT INTO {TABLE} (id, name, data) VALUES (%s, %s, %s::jsonb)",
+                (uuid.uuid4(), name, f'{{"name": "{name}", "profile": {{"last_name": "{name}"}}}}'),
+            )
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {test_schema}")
+        await cursor.execute(f"DROP TABLE IF EXISTS {TABLE} CASCADE")
+        await conn.commit()
+
+
+async def _order(pool: Any, schema: str, instruction: OrderBy, **to_sql_kwargs: Any) -> list[str]:
+    """Run one ``OrderBy`` against the table and return the names, in row order.
+
+    ``table_ref`` is the JSONB column, which is what the repository passes for a
+    JSONB view (``db.py``: ``table_ref = jsonb_column if ... else "t"``); the
+    flat-column branch renders ``t."col"`` and relies on the alias instead.
+    """
+    to_sql_kwargs.setdefault("table_ref", "data")
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {schema}")
+        await cursor.execute(
+            SQL("SELECT name FROM {} AS t ORDER BY ").format(SQL(TABLE))
+            + instruction.to_sql(**to_sql_kwargs)
+        )
+        return [row[0] for row in await cursor.fetchall()]
+
+
+@pytest.mark.database
+class TestCollationReachesTheSort:
+    """One assertion, three times: a different collation must give a different order."""
+
+    async def _pair(self, pool: Any, schema: str, **to_sql_kwargs: Any) -> tuple[list, list, str]:
+        linguistic = await _linguistic_collation(pool)
+        if linguistic is None:
+            pytest.skip('no collation on this server disagrees with "C" about case')
+        byte = await _order(pool, schema, OrderBy(field="name", collation="C"), **to_sql_kwargs)
+        ling = await _order(
+            pool, schema, OrderBy(field="name", collation=linguistic), **to_sql_kwargs
+        )
+        return byte, ling, linguistic
+
+    async def test_native_column_path(self, class_db_pool, test_schema, collation_rows) -> None:
+        byte, ling, name = await self._pair(class_db_pool, test_schema, native_columns={"name"})
+        assert byte == BYTE_ORDER
+        assert ling != byte, f"collation {name!r} did not reach the sort on the flat-column path"
+
+    async def test_column_mapping_path(self, class_db_pool, test_schema, collation_rows) -> None:
+        byte, ling, name = await self._pair(
+            class_db_pool, test_schema, column_mapping={"name": "name"}
+        )
+        assert byte == BYTE_ORDER
+        assert ling != byte, f"collation {name!r} did not reach the sort on the mapping path"
+
+    async def test_jsonb_path(self, class_db_pool, test_schema, collation_rows) -> None:
+        byte, ling, name = await self._pair(class_db_pool, test_schema)
+        assert byte == BYTE_ORDER
+        assert ling != byte, f"collation {name!r} did not reach the sort on the JSONB path"
+
+    async def test_nested_jsonb_path(self, class_db_pool, test_schema, collation_rows) -> None:
+        """The nested path extracts a leaf, so it must collate the leaf."""
+        linguistic = await _linguistic_collation(class_db_pool)
+        if linguistic is None:
+            pytest.skip('no collation on this server disagrees with "C" about case')
+        nested = OrderBy(field="profile.last_name", collation="C")
+        byte = await _order(class_db_pool, test_schema, nested)
+        ling = await _order(
+            class_db_pool,
+            test_schema,
+            OrderBy(field="profile.last_name", collation=linguistic),
+        )
+        assert byte == BYTE_ORDER
+        assert ling != byte
+
+
+@pytest.mark.database
+class TestUncollatedOrderingUnchanged:
+    """The no-collation paths must keep the behaviour they had."""
+
+    async def test_jsonb_numeric_ordering_survives(
+        self, class_db_pool, test_schema, collation_rows
+    ) -> None:
+        """``->`` is used without a collation precisely to keep numeric sorts numeric."""
+        async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+            await cursor.execute(f"SET search_path TO {test_schema}")
+            await cursor.execute(f"DELETE FROM {TABLE}")
+            for n in (2, 10, 1):
+                await cursor.execute(
+                    f"INSERT INTO {TABLE} (id, name, data) VALUES (%s, %s, %s::jsonb)",
+                    (uuid.uuid4(), str(n), f'{{"amount": {n}}}'),
+                )
+            await conn.commit()
+
+        order = await _order(class_db_pool, test_schema, OrderBy(field="amount"))
+        assert order == ["1", "2", "10"], "numeric JSONB ordering must not become lexicographic"

--- a/tests/unit/sql/test_order_by_collate.py
+++ b/tests/unit/sql/test_order_by_collate.py
@@ -10,10 +10,17 @@ class TestOrderByCollate:
     """Test COLLATE clause generation."""
 
     def test_simple_field_with_collation(self):
-        """Test basic collation on simple field."""
+        """Test basic collation on simple field.
+
+        This asserted ``t -> 'name' COLLATE "en_US.utf8"`` until #476. That form
+        parses as ``t -> ('name' COLLATE "en_US.utf8")`` -- the collation lands
+        on the key literal, the comparison is still ``jsonb``, and the collation
+        has no effect. PostgreSQL accepts it without complaint, which is why the
+        assertion passed while the feature did nothing.
+        """
         ob = OrderBy(field="name", collation="en_US.utf8")
         result = ob.to_sql().as_string(None)
-        assert 't -> \'name\' COLLATE "en_US.utf8" ASC' in result
+        assert '(t ->> \'name\') COLLATE "en_US.utf8" ASC' in result
 
     def test_nested_field_with_collation(self):
         """Test collation on nested field."""

--- a/tests/unit/sql/test_order_by_collation.py
+++ b/tests/unit/sql/test_order_by_collation.py
@@ -17,8 +17,11 @@ cannot tell an applied collation from one attached to the wrong operand; see
 half of this that only a live database can answer.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
+from fraiseql.sql.graphql_order_by_generator import _convert_order_by_input_to_sql
 from fraiseql.sql.order_by_generator import OrderBy, OrderBySet, OrderDirection
 
 COLLATION = "fr_FR.utf8"
@@ -108,3 +111,59 @@ class TestJsonbCollation:
         result = ob.to_sql().as_string(None)
         assert "COLLATE" not in result
         assert "<=>" in result
+
+
+@pytest.mark.unit
+class TestGlobalDefaultCollationStaysInert:
+    """``default_string_collation`` must not reach the SQL until it knows types.
+
+    The setting is documented as applying to "all text fields", but nothing in
+    the order_by pipeline tracks which fields are text -- it is applied to every
+    field. That was harmless only while a collation was inert. Now that one
+    reaches the sort, honouring a blanket default would silently make a numeric
+    JSONB sort lexicographic (1, 10, 2) and would make a numeric flat column
+    fail outright with "collations are not supported by type integer".
+
+    So a collation is honoured when a caller asked for it on a field, and a
+    global default is dropped -- which is exactly its effect today, making this
+    a no-op for every existing deployment.
+    """
+
+    @staticmethod
+    def _config() -> SimpleNamespace:
+        return SimpleNamespace(default_string_collation="fr_FR.utf8")
+
+    def test_list_of_dicts_ignores_the_global_default(self) -> None:
+        order_set = _convert_order_by_input_to_sql([{"amount": "asc"}], config=self._config())
+        assert order_set is not None
+        assert order_set.to_sql().as_string(None) == "ORDER BY t -> 'amount' ASC"
+
+    def test_global_default_does_not_collate_a_flat_column(self) -> None:
+        """A numeric native column would raise, not merely sort oddly."""
+        order_set = _convert_order_by_input_to_sql([{"amount": "asc"}], config=self._config())
+        assert order_set is not None
+        result = order_set.to_sql(native_columns={"amount"}).as_string(None)
+        assert result == 'ORDER BY "t"."amount" ASC'
+        assert "COLLATE" not in result
+
+    def test_order_by_item_without_a_collation_attribute_ignores_the_default(self) -> None:
+        item = SimpleNamespace(field="name", direction="asc")
+        order_set = _convert_order_by_input_to_sql([item], config=self._config())
+        assert order_set is not None
+        assert "COLLATE" not in order_set.to_sql().as_string(None)
+
+    def test_an_explicit_field_collation_is_still_honoured(self) -> None:
+        """The point of #476: a deliberate per-field collation reaches the sort."""
+        item = SimpleNamespace(field="name", direction="asc", collation="fr_FR.utf8")
+        order_set = _convert_order_by_input_to_sql([item], config=self._config())
+        assert order_set is not None
+        assert (
+            order_set.to_sql().as_string(None)
+            == 'ORDER BY (t ->> \'name\') COLLATE "fr_FR.utf8" ASC'
+        )
+
+    def test_explicit_none_still_beats_the_default(self) -> None:
+        item = SimpleNamespace(field="name", direction="asc", collation=None)
+        order_set = _convert_order_by_input_to_sql([item], config=self._config())
+        assert order_set is not None
+        assert "COLLATE" not in order_set.to_sql().as_string(None)

--- a/tests/unit/sql/test_order_by_collation_flat_columns.py
+++ b/tests/unit/sql/test_order_by_collation_flat_columns.py
@@ -1,0 +1,110 @@
+"""Issue #476: an explicit ORDER BY collation must survive every resolution path.
+
+``OrderBy.to_sql`` has three ways to render a sort key, and a collation was
+honoured by none of them in a way that reaches PostgreSQL:
+
+* the ``native_columns`` flat-column branch returned before the COLLATE block;
+* the ``column_mapping`` flat-column branch mirrors it exactly (#467), so it
+  dropped the collation the same way;
+* the JSONB branch *emitted* ``COLLATE`` but bound it to the key literal --
+  ``data -> ('name' COLLATE "x")`` -- which is a no-op, because the sort still
+  compares ``jsonb``.
+
+The last one is why these assertions check the shape of the expression and not
+merely that the substring ``COLLATE`` appears somewhere. A text assertion
+cannot tell an applied collation from one attached to the wrong operand; see
+``tests/integration/database/sql/test_order_by_collation_execution.py`` for the
+half of this that only a live database can answer.
+"""
+
+import pytest
+
+from fraiseql.sql.order_by_generator import OrderBy, OrderBySet, OrderDirection
+
+COLLATION = "fr_FR.utf8"
+
+
+@pytest.mark.unit
+class TestFlatColumnCollation:
+    """The two flat-column routes: ``native_columns`` and ``column_mapping``."""
+
+    def test_native_column_keeps_collation(self) -> None:
+        ob = OrderBy(field="name", collation=COLLATION)
+        assert (
+            ob.to_sql(native_columns={"name"}).as_string(None)
+            == '"t"."name" COLLATE "fr_FR.utf8" ASC'
+        )
+
+    def test_column_mapping_keeps_collation(self) -> None:
+        ob = OrderBy(field="profile.last_name", direction=OrderDirection.DESC, collation=COLLATION)
+        result = ob.to_sql(column_mapping={"profile.last_name": "last_name"}).as_string(None)
+        assert result == '"t"."last_name" COLLATE "fr_FR.utf8" DESC'
+
+    def test_both_flat_routes_agree(self) -> None:
+        """The two branches deliberately match, so they must not diverge here."""
+        ob = OrderBy(field="name", collation=COLLATION)
+        assert ob.to_sql(native_columns={"name"}).as_string(None) == ob.to_sql(
+            column_mapping={"name": "name"}
+        ).as_string(None)
+
+    def test_flat_column_without_collation_unchanged(self) -> None:
+        """Regression: the no-collation flat column keeps its exact previous SQL."""
+        ob = OrderBy(field="name", direction=OrderDirection.DESC)
+        assert ob.to_sql(native_columns={"name"}).as_string(None) == '"t"."name" DESC'
+        assert "COLLATE" not in ob.to_sql(column_mapping={"name": "name"}).as_string(None)
+
+    def test_collation_name_is_quoted_as_an_identifier(self) -> None:
+        """COLLATE takes an identifier, not a string literal -- and it is injectable."""
+        ob = OrderBy(field="name", collation='x" ; DROP TABLE t --')
+        result = ob.to_sql(native_columns={"name"}).as_string(None)
+        assert 'COLLATE "x"" ; DROP TABLE t --"' in result
+
+    def test_order_by_set_collates_flat_columns(self) -> None:
+        obs = OrderBySet(
+            [
+                OrderBy(field="country", collation="C"),
+                OrderBy(field="name", collation=COLLATION),
+                OrderBy(field="age"),
+            ]
+        )
+        result = obs.to_sql(native_columns={"country", "name", "age"}).as_string(None)
+        assert '"t"."country" COLLATE "C" ASC' in result
+        assert '"t"."name" COLLATE "fr_FR.utf8" ASC' in result
+        assert '"t"."age" ASC' in result
+        assert result.count("COLLATE") == 2
+
+
+@pytest.mark.unit
+class TestJsonbCollation:
+    """A collation is a *text* ordering, so the JSONB branch must extract text."""
+
+    def test_jsonb_collation_binds_to_the_extracted_value(self) -> None:
+        """``->>`` and parentheses, so the collation applies to the value.
+
+        ``t -> 'name' COLLATE "x"`` parses as ``t -> ('name' COLLATE "x")``:
+        PostgreSQL accepts it, the result is still ``jsonb``, and the collation
+        is silently ignored.
+        """
+        ob = OrderBy(field="name", collation=COLLATION)
+        assert ob.to_sql().as_string(None) == "(t ->> 'name') COLLATE \"fr_FR.utf8\" ASC"
+
+    def test_nested_jsonb_collation_binds_to_the_leaf(self) -> None:
+        ob = OrderBy(field="profile.last_name", direction=OrderDirection.DESC, collation=COLLATION)
+        assert (
+            ob.to_sql().as_string(None)
+            == "(t -> 'profile' ->> 'last_name') COLLATE \"fr_FR.utf8\" DESC"
+        )
+
+    def test_jsonb_without_collation_keeps_typed_extraction(self) -> None:
+        """Regression: no collation means ``->``, which preserves numeric ordering."""
+        assert OrderBy(field="amount").to_sql().as_string(None) == "t -> 'amount' ASC"
+        assert (
+            OrderBy(field="profile.age", direction=OrderDirection.DESC).to_sql().as_string(None)
+            == "t -> 'profile' -> 'age' DESC"
+        )
+
+    def test_vector_distance_still_ignores_collation(self) -> None:
+        ob = OrderBy(field="embedding.cosine_distance", value=[0.1, 0.2, 0.3], collation=COLLATION)
+        result = ob.to_sql().as_string(None)
+        assert "COLLATE" not in result
+        assert "<=>" in result


### PR DESCRIPTION
Closes #476.

## The issue understated it: all three paths were broken, not two

#476 reports that the collation is honoured on the JSONB path and dropped on the flat-column
paths. The flat half is exactly right. The JSONB half is not — it was silently a no-op too, and
that is the more interesting bug.

`OrderBy.to_sql` emitted `data -> 'name' COLLATE "x"`. PostgreSQL parses that as:

```sql
data -> ('name' COLLATE "x")
```

`COLLATE` binds tighter than `->`, so the collation attached to the **key literal**. The
comparison stayed `jsonb`, the collation did nothing, and no error was raised. Parenthesising it
to what the code meant proves it could never have worked:

```
=> SELECT ... ORDER BY (data -> 'name') COLLATE "C";
ERROR:  collations are not supported by type jsonb
```

Measured on PG 18 and on the PG 16 test container, sorting `a`, `B`, `c`:

| expression | `C` | `en-US-x-icu` |
|---|---|---|
| `data -> 'name' COLLATE …` (before) | `B,a,c` | `B,a,c` — identical, collation ignored |
| `t."name" COLLATE …` (before) | collation dropped entirely | — |
| `(data ->> 'name') COLLATE …` (after) | `B,a,c` | `a,B,c` ✅ |

## Commit 1 — make an explicit collation reach the sort

- One `_collated()` helper, and every collatable branch routes through it.
- **Flat columns** — both `native_columns` (#337) and the `column_mapping` route that
  deliberately mirrors it (#467) — collate directly: `t."name" COLLATE "fr_FR.utf8" ASC`. They
  move together, as the issue requires, and a test pins that they agree.
- **JSONB** extracts its leaf as `->>` and parenthesises, **only when a collation was requested**.
  An uncollated sort keeps its previous SQL byte for byte, so numeric JSONB ordering is untouched
  (there is a live test pinning `1, 2, 10`).

## Commit 2 — and stop the global default from going live with it

Making the collation work exposed a second defect in the same feature, which had to be handled
in the same change or this PR would break running deployments.

`default_string_collation` is documented as applying to "all **text** fields", but nothing in the
pipeline tracks which fields are text — it was applied to *every* field. Harmless only while a
collation was inert. After commit 1, any deployment that had merely set the option would get:

```
numeric JSONB field   (t ->> 'amount') COLLATE "x"   -> 1, 10, 2, silently
numeric flat column   t."amount" COLLATE "x"         -> ERROR: collations are not
                                                        supported by type integer
```

So: a collation is honoured when a caller asked for it **on a field**, and one sourced from the
global default is dropped. That is precisely its effect today — it has never once reached a query
— which makes this a **no-op for every existing deployment** rather than a behaviour change.

```
global default, JSONB   ORDER BY t -> 'amount' ASC
global default, native  ORDER BY "t"."amount" ASC
explicit, JSONB         ORDER BY (t ->> 'name') COLLATE "fr_FR.utf8" ASC
explicit, flat          ORDER BY "t"."name" COLLATE "fr_FR.utf8" ASC
```

`_apply_collation_default` is now the single place that decides; the two sites that bypassed it
(dict items in a list, and the `__gql_fields__` branch) route through it. The `global_collation`
parameter stays, because making the setting work needs field *types* plumbed down to it — that is
the follow-up, and it is what will use the parameter.

The config docstring and three docs pages promised the setting applies. They described behaviour
it has never had, and are corrected here.

## Verification

A text assertion cannot distinguish an applied collation from one bound to the wrong operand —
which is precisely how this survived: the existing unit test asserted that exact string and
passed for years while the feature did nothing.

So `tests/integration/database/sql/test_order_by_collation_execution.py` never looks at the
generated SQL. It runs the same query under two collations that disagree about case and asserts
**the row order actually differs**. A dropped collation and a misbound one both fail that. All
four path tests fail on `dev` and pass here.

- ✅ 1359 tests pass (`tests/unit/sql`, `tests/unit/fastapi`, `tests/integration/database/sql`)
- ✅ 20 targeted tests, of which 9 fail on `dev`
- ✅ `ruff check` + `ruff format` clean
- ✅ `ty` delta 0

One existing assertion pinned the old no-op output and is updated, with the reason recorded in
its docstring so it is not restored.

## Behaviour note

A collated sort is a text sort — that is what a collation means. So on the collated branch an
explicit JSON `null` now sorts with an absent key (both become SQL NULL) instead of ahead of
every string. This is unavoidable: `jsonb` has no collation. It is documented on the class.

Unrelated but worth recording: `ty check` measures **538** diagnostics on `dev` with the current
venv, not the 348 in the working notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N