### PR TITLE
fix(sql): recurse into nested fields in the list-of-dicts order_by form

### DIFF
--- a/src/fraiseql/sql/graphql_order_by_generator.py
+++ b/src/fraiseql/sql/graphql_order_by_generator.py
@@ -5,6 +5,7 @@ for ordering. These types can be used directly in GraphQL resolvers and are
 automatically converted to SQL ORDER BY clauses.
 """
 
+import warnings
 from dataclasses import make_dataclass
 from typing import Any, Optional, TypeVar, Union, get_args, get_origin, get_type_hints
 
@@ -175,6 +176,71 @@ def _apply_collation_default(
     return None
 
 
+# Only the operators OrderBy.to_sql can actually render. jaccard_distance is
+# deliberately absent: it exists on VectorOrderBy and the __gql_fields__ branch
+# emits it, but to_sql has no case for it, so the instruction degrades into a
+# plain JSONB path sort and the query fails. Adding it here has to wait for
+# to_sql to support it -- see #483.
+_VECTOR_OPERATORS = ("cosine_distance", "l2_distance", "inner_product")
+
+
+def _collect_dict_order_by(
+    obj_dict: dict[str, Any],
+    instructions: list[OrderBy],
+    prefix: str = "",
+) -> None:
+    """Walk a dict-shaped ``order_by``, appending one ``OrderBy`` per leaf.
+
+    The recursion is the point. ``{"measures": {"cost": "desc"}}`` has to reach
+    ``measures.cost DESC``; the list-of-dicts branch used to parse dicts with its
+    own shallower loop, which handed a nested dict to
+    :func:`_normalize_order_direction`, got the ASC default back, and sorted by
+    the wrong field in the wrong direction without a word (#475).
+
+    One parser now serves both dict shapes, so ``{...}`` and ``[{...}]`` cannot
+    drift apart again.
+    """
+    from fraiseql.utils.casing import to_snake_case
+
+    for field_name, value in obj_dict.items():
+        if value is None:
+            continue
+
+        snake_field_name = to_snake_case(field_name)
+        field_path = f"{prefix}.{snake_field_name}" if prefix else snake_field_name
+
+        # Nested object: recurse so the leaf carries the full dotted path.
+        if isinstance(value, dict):
+            _collect_dict_order_by(value, instructions, field_path)
+        # A VectorOrderBy names the distance operator it wants.
+        elif hasattr(value, "__gql_fields__") and hasattr(value, "cosine_distance"):
+            for operator in _VECTOR_OPERATORS:
+                operand = getattr(value, operator, None)
+                if operand is not None:
+                    instructions.append(
+                        OrderBy(
+                            field=f"{field_path}.{operator}",
+                            direction=OrderDirection.ASC,  # ASC for vectors
+                            value=operand,
+                        )
+                    )
+                    break
+        # A direction: a string, an OrderDirection, or any enum-like carrying one.
+        elif isinstance(value, (OrderDirection, str)) or hasattr(value, "value"):
+            instructions.append(
+                OrderBy(field=field_path, direction=_normalize_order_direction(value))
+            )
+        else:
+            # Defaulting to ASC here would mean "sorted by something else
+            # entirely", silently. Say so and drop the key instead.
+            warnings.warn(
+                f"order_by: ignoring {field_path!r} - cannot read a sort direction from "
+                f"{type(value).__name__}. Expected a direction, a nested dict, or None.",
+                UserWarning,
+                stacklevel=3,
+            )
+
+
 def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> OrderBySet | None:
     """Convert GraphQL order by input to SQL OrderBySet with optional collation.
 
@@ -223,30 +289,11 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
                 instructions.append(
                     OrderBy(field=item.field, direction=direction, collation=collation)
                 )
-            # Handle dictionary items like {'ipAddress': 'asc'}
+            # Handle dictionary items like {'ipAddress': 'asc'}, which may nest.
+            # A dict carries no per-field collation, so none is set -- see
+            # _apply_collation_default.
             elif isinstance(item, dict):
-                for field_name, value in item.items():
-                    if value is not None:
-                        # Convert camelCase field names to snake_case for database fields
-                        from fraiseql.utils.casing import to_snake_case
-
-                        snake_field_name = to_snake_case(field_name)
-
-                        # Handle OrderDirection enum or string
-                        direction = _normalize_order_direction(value)
-
-                        # A dict carries no per-field collation, so this
-                        # resolves to None -- see _apply_collation_default.
-                        global_collation = config.default_string_collation if config else None
-                        collation = _apply_collation_default(None, global_collation, False)
-
-                        instructions.append(
-                            OrderBy(
-                                field=snake_field_name,
-                                direction=direction,
-                                collation=collation,
-                            )
-                        )
+                _collect_dict_order_by(item, instructions)
         return OrderBySet(instructions=instructions) if instructions else None
 
     # Handle object with field-specific order directions
@@ -329,53 +376,7 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
 
     # Handle plain dict (common from GraphQL frameworks)
     elif isinstance(order_by_input, dict):
-
-        def process_dict_order_by(obj_dict: dict[str, Any], prefix: str = "") -> None:
-            """Process dictionary-style order by input."""
-            for field_name, value in obj_dict.items():
-                if value is not None:
-                    # Convert camelCase field names to snake_case for database fields
-                    from fraiseql.utils.casing import to_snake_case
-
-                    snake_field_name = to_snake_case(field_name)
-                    field_path = f"{prefix}.{snake_field_name}" if prefix else snake_field_name
-
-                    # Handle OrderDirection enum or string
-                    if isinstance(value, (OrderDirection, str)):
-                        direction = _normalize_order_direction(value)
-                        instructions.append(OrderBy(field=field_path, direction=direction))
-                    # Check if this is a VectorOrderBy input
-                    elif hasattr(value, "__gql_fields__") and hasattr(value, "cosine_distance"):
-                        # This is a VectorOrderBy - check which distance operator is set
-                        if value.cosine_distance is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.cosine_distance",
-                                    direction=OrderDirection.ASC,  # ASC for vectors
-                                    value=value.cosine_distance,
-                                )
-                            )
-                        elif value.l2_distance is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.l2_distance",
-                                    direction=OrderDirection.ASC,
-                                    value=value.l2_distance,
-                                )
-                            )
-                        elif value.inner_product is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.inner_product",
-                                    direction=OrderDirection.ASC,
-                                    value=value.inner_product,
-                                )
-                            )
-                    # Handle nested dict
-                    elif isinstance(value, dict):
-                        process_dict_order_by(value, field_path)
-
-        process_dict_order_by(order_by_input)
+        _collect_dict_order_by(order_by_input, instructions)
 
     return OrderBySet(instructions=instructions) if instructions else None
 

--- a/tests/unit/sql/test_order_by_list_dict_nesting.py
+++ b/tests/unit/sql/test_order_by_list_dict_nesting.py
@@ -1,0 +1,89 @@
+"""Issue #475: the list-of-dicts order_by form must recurse like the bare-dict one.
+
+``order_by`` accepts several shapes, and two of them are dicts:
+
+    {"measures": {"cost": "desc"}}      # bare dict   -> measures.cost DESC
+    [{"measures": {"cost": "desc"}}]    # in a list   -> measures ASC
+
+The bare-dict branch carried a prefix and recursed. The list branch had its own
+shallower loop that fed the nested dict straight to ``_normalize_order_direction``,
+which does not recognise a dict and returned the ASC default -- so the same input
+sorted by the wrong field, in the wrong direction, depending only on whether the
+caller wrapped it in a list. No error, no warning.
+
+These tests pin that the two shapes agree, and that a value neither branch can
+interpret is reported rather than silently defaulted.
+"""
+
+import pytest
+
+from fraiseql.sql.graphql_order_by_generator import (
+    OrderDirection,
+    _convert_order_by_input_to_sql,
+)
+
+
+def _instructions(order_by):
+    order_set = _convert_order_by_input_to_sql(order_by)
+    return [] if order_set is None else list(order_set.instructions)
+
+
+@pytest.mark.unit
+class TestListOfDictsRecurses:
+    def test_nested_dict_in_a_list_resolves_the_leaf(self) -> None:
+        (instr,) = _instructions([{"measures": {"cost": "desc"}}])
+        assert instr.field == "measures.cost"
+        assert instr.direction == OrderDirection.DESC
+
+    def test_list_and_bare_dict_agree(self) -> None:
+        """The same nesting must not depend on being wrapped in a list."""
+        nested = {"measures": {"totalCost": "desc"}}
+        assert _instructions([nested]) == _instructions(nested)
+
+    def test_deeply_nested_path(self) -> None:
+        (instr,) = _instructions([{"dimensions": {"dateInfo": {"date": "asc"}}}])
+        assert instr.field == "dimensions.date_info.date"
+        assert instr.direction == OrderDirection.ASC
+
+    def test_camel_case_segments_are_snake_cased_at_every_level(self) -> None:
+        (instr,) = _instructions([{"orderDetails": {"unitPrice": "desc"}}])
+        assert instr.field == "order_details.unit_price"
+
+    def test_flat_list_dict_still_works(self) -> None:
+        """The shape the branch was written for (#... v0.3.5) is unchanged."""
+        (instr,) = _instructions([{"ipAddress": "asc"}])
+        assert instr.field == "ip_address"
+        assert instr.direction == OrderDirection.ASC
+
+    def test_multiple_keys_and_items_keep_their_order(self) -> None:
+        instrs = _instructions([{"status": "asc"}, {"measures": {"cost": "desc"}}])
+        assert [(i.field, i.direction) for i in instrs] == [
+            ("status", OrderDirection.ASC),
+            ("measures.cost", OrderDirection.DESC),
+        ]
+
+    def test_enum_direction_survives_in_both_shapes(self) -> None:
+        """The list branch accepted an OrderDirection; unifying must not lose that."""
+        (instr,) = _instructions([{"name": OrderDirection.DESC}])
+        assert instr.field == "name"
+        assert instr.direction == OrderDirection.DESC
+
+    def test_none_values_are_skipped(self) -> None:
+        assert _instructions([{"name": None}]) == []
+
+
+@pytest.mark.unit
+class TestUninterpretableValuesWarn:
+    """A silent ASC default here means "sorted by something else entirely"."""
+
+    def test_unrecognised_value_warns_in_a_list(self) -> None:
+        with pytest.warns(UserWarning, match="order_by"):
+            _instructions([{"name": 42}])
+
+    def test_unrecognised_value_warns_in_a_bare_dict(self) -> None:
+        with pytest.warns(UserWarning, match="order_by"):
+            _instructions({"name": 42})
+
+    def test_unrecognised_value_is_not_silently_ascending(self) -> None:
+        with pytest.warns(UserWarning):
+            assert _instructions([{"name": 42}]) == []


### PR DESCRIPTION
Closes #475.

`order_by` accepts a dict two ways, and only one of them recursed:

```python
{"measures": {"cost": "desc"}}      # bare dict -> measures.cost DESC   ✅
[{"measures": {"cost": "desc"}}]    # in a list -> measures      ASC    ❌
```

The list branch kept its own shallower parser, which handed the nested dict to
`_normalize_order_direction`. That does not recognise a dict, so it hit the unconditional ASC
fallback: **wrong field and wrong direction**, with no error and no warning. Whether the same
input worked depended only on whether the caller wrapped it in a list.

## Changes

- One `_collect_dict_order_by` walks both dict shapes, so they cannot drift apart again. It
  **replaces** the second parser rather than teaching it to recurse, which is what the issue asks
  for.
- Unifying kept the broader of the two behaviours at each point where they differed:
  - the list branch accepted any enum-like direction and the bare-dict branch silently dropped
    it, so the shared parser accepts it;
  - the bare-dict branch handled `VectorOrderBy` and the list branch did not, so the shared
    parser does.
- A value neither shape can read now **warns and is dropped** instead of silently defaulting to
  ASC — a silent default here means "sorted by something else entirely".

Collation needed no special handling: after #481 both dict shapes resolve to no collation, so
there is no asymmetry left to preserve.

## A gap this exposed, deliberately not widened into

`VectorOrderBy` carries `jaccard_distance` and the `__gql_fields__` branch emits it, but
`OrderBy.to_sql` has no case for that operator — the instruction degrades into a plain JSONB path
sort and the statement fails with `operator does not exist: test_fingerprints -> unknown`.

I hit this by briefly including `jaccard_distance` in the shared parser, which turned
`test_binary_vector_jaccard_distance_order_by` red. The dict path has never emitted it, so
`_VECTOR_OPERATORS` keeps the three `to_sql` can render, with a comment saying why. Filed as
**#483**, which also notes that the e2e test only asserts a row count and so cannot fail for the
reason it is named after.

## Verification

- ✅ 5953 tests pass (`tests/unit` + `tests/integration`)
- ✅ 11 new tests, 8 of which fail on `dev`
- ✅ `ruff check` + `ruff format` clean

The one remaining failure,
`tests/integration/database/repository/test_nested_tenant_integration.py::test_nested_organization_without_tenant_id`,
fails identically on `dev` and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N