### PR TITLE
fix(sql): split schema-qualified view names on the partial-period UNION path

### DIFF
--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -8,7 +8,7 @@ from datetime import UTC
 from typing import Any, Optional, TypeVar, Union, get_args, get_origin
 
 from psycopg.rows import dict_row
-from psycopg.sql import SQL, Composed
+from psycopg.sql import SQL, Composed, Identifier
 from psycopg_pool import AsyncConnectionPool
 
 from fraiseql.audit import get_security_logger
@@ -83,6 +83,23 @@ def _make_mandatory_conditions(
         parts.append(Composed([Identifier(col), SQL(" = "), SQL("%s")]))
         params.append(val)
     return parts, params
+
+
+def _view_identifier(view_name: str) -> Identifier:
+    """Render a registered view name as the identifier PostgreSQL resolves.
+
+    A schema-qualified name has to become two identifiers — ``"myschema"."v_stats"``.
+    Passed whole to a single-argument ``Identifier`` it renders as
+    ``"myschema.v_stats"``, one quoted relation name containing a dot, and the
+    statement fails with ``relation "myschema.v_stats" does not exist`` (#472).
+
+    Every path that names a view goes through here, so the two renderings cannot
+    drift apart again.
+    """
+    if "." in view_name:
+        schema_name, table_name = view_name.split(".", 1)
+        return Identifier(schema_name, table_name)
+    return Identifier(view_name)
 
 
 def _is_rust_response_null(response: RustResponseBytes) -> bool:
@@ -446,7 +463,7 @@ def _build_fine_grain_branch(
     """
     from psycopg.sql import SQL, Composed, Identifier, Literal
 
-    table_id = Identifier(fine_grain_view)
+    table_id = _view_identifier(fine_grain_view)
     col_id = Identifier(time_grain_column)
 
     def build_field(fp: str) -> SQL | Composed:
@@ -540,7 +557,7 @@ def _build_coarse_branch(
     """
     from psycopg.sql import SQL, Composed, Identifier, Literal
 
-    table_id = Identifier(coarse_view)
+    table_id = _view_identifier(coarse_view)
     col_id = Identifier(time_grain_column)
 
     def build_field(fp: str) -> SQL | Composed:
@@ -2126,7 +2143,7 @@ class FraiseQLRepository:
             total = await db.count("v_products")
             tenant_count = await db.count("v_orders", mandatory_filters={"tenant_id": "tenant-123"})
         """
-        from psycopg.sql import SQL, Composed, Identifier
+        from psycopg.sql import SQL, Composed
 
         # Extract mandatory_filters before _build_where_clause (#344)
         mandatory_filters = self._consume_mandatory_filters(kwargs)
@@ -2138,12 +2155,7 @@ class FraiseQLRepository:
         # Build WHERE clause (extracted to helper method for reuse)
         where_parts, params = self._build_where_clause(view_name, **kwargs)
 
-        # Handle schema-qualified table names
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build COUNT(*) query
         query_parts = [SQL("SELECT COUNT(*) FROM "), table_identifier]
@@ -2198,7 +2210,7 @@ class FraiseQLRepository:
                 where={"email": {"eq": "test@example.com"}, "status": {"eq": "active"}}
             )
         """
-        from psycopg.sql import SQL, Composed, Identifier
+        from psycopg.sql import SQL, Composed
 
         # Extract mandatory_filters before _build_where_clause (#344)
         mandatory_filters = self._consume_mandatory_filters(kwargs)
@@ -2210,12 +2222,7 @@ class FraiseQLRepository:
         # Build WHERE clause using existing helper
         where_parts, params = self._build_where_clause(view_name, **kwargs)
 
-        # Handle schema-qualified table names
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build EXISTS query
         query_parts = [SQL("SELECT EXISTS(SELECT 1 FROM "), table_identifier]
@@ -2279,11 +2286,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build SUM query
         query_parts = [
@@ -2342,11 +2345,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build AVG query
         query_parts = [
@@ -2401,12 +2400,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        # Handle schema-qualified table names
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build MIN query
         query_parts = [SQL("SELECT MIN("), Identifier(field), SQL(") FROM "), table_identifier]
@@ -2456,12 +2450,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        # Handle schema-qualified table names
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build MAX query
         query_parts = [SQL("SELECT MAX("), Identifier(field), SQL(") FROM "), table_identifier]
@@ -2515,12 +2504,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        # Handle schema-qualified table names
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build DISTINCT query
         query_parts = [SQL("SELECT DISTINCT "), Identifier(field), SQL(" FROM "), table_identifier]
@@ -2586,11 +2570,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         query_parts = [SQL("SELECT "), Identifier(field), SQL(" FROM "), table_identifier]
 
@@ -2649,7 +2629,7 @@ class FraiseQLRepository:
             #     "order_count": 500
             # }
         """
-        from psycopg.sql import SQL, Composed, Identifier
+        from psycopg.sql import SQL, Composed
 
         if not aggregations:
             return {}
@@ -2662,12 +2642,7 @@ class FraiseQLRepository:
 
         where_parts, params = self._build_where_clause(view_name, **kwargs)
 
-        # Handle schema-qualified table names
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build SELECT clause with all aggregations
         agg_clauses = [SQL(f"{expr} AS {name}") for name, expr in aggregations.items()]
@@ -2736,12 +2711,7 @@ class FraiseQLRepository:
 
         where_parts, where_params = self._build_where_clause(view_name, **kwargs)
 
-        # Handle schema-qualified table names
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build query to select existing IDs
         query_parts = [SQL("SELECT "), Identifier(field), SQL(" FROM "), table_identifier]
@@ -3111,12 +3081,7 @@ class FraiseQLRepository:
             column_mapping=native_dimension_mapping,
         )
 
-        # Handle schema-qualified table names
-        if "." in view_name:
-            schema_name, table_name = view_name.split(".", 1)
-            table_identifier = Identifier(schema_name, table_name)
-        else:
-            table_identifier = Identifier(view_name)
+        table_identifier = _view_identifier(view_name)
 
         # Build SELECT clause — different when GROUP BY + aggregations are used
         if group_by:

--- a/tests/integration/database/sql/test_schema_qualified_views.py
+++ b/tests/integration/database/sql/test_schema_qualified_views.py
@@ -1,0 +1,194 @@
+"""Issue #472: schema-qualified view names, resolved by a real PostgreSQL.
+
+A view registered as ``"myschema.v_stats"`` has to render as two identifiers —
+``"myschema"."v_stats"``. Handed whole to a single-argument ``Identifier`` it
+renders as ``"myschema.v_stats"``: one quoted relation name that happens to
+contain a dot, which PostgreSQL cannot resolve. The partial-period UNION
+branches did exactly that while every other path split the name, so one
+registration worked on the single-statement path and failed on the UNION one.
+
+The two renderings differ by a single quote character and both read as plausible
+in a diff, so a text assertion cannot tell them apart — only the server can. The
+schema built here is therefore deliberately kept *off* the search path (unlike
+the #468 tests, which set ``search_path`` precisely to dodge this bug), so a
+mis-quoted or unqualified name has nothing to resolve against.
+"""
+
+import json
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import date
+from typing import Any
+
+import psycopg
+import pytest
+
+from fraiseql.db import FraiseQLRepository, _build_partial_period_union_query
+
+pytestmark = pytest.mark.database
+
+COARSE = "v_472_month"
+FINE = "v_472_day"
+
+# Deterministic, so batch_exists() has an id to ask about.
+ROW_IDS = [uuid.UUID(int=i) for i in range(1, 6)]
+
+# (date, category, status, cost)
+FINE_ROWS = [
+    ("2025-01-10", "A", "active", 5),  # below the lower bound
+    ("2025-01-20", "A", "active", 10),
+    ("2025-02-10", "A", "active", 20),
+]
+
+# The same data pre-aggregated to month starts.
+COARSE_ROWS = [
+    ("2025-01-01", "A", "active", 15),
+    ("2025-02-01", "A", "active", 20),
+]
+
+# Mid-January through the end of February: the lower bound is not month-aligned,
+# so branch 1 is fine-grain [01-15, 02-01) and branch 2 is coarse [02-01, 03-01).
+# Both branch builders run, so both Identifier sites are exercised.
+UNION_QUERY: dict[str, Any] = {
+    "time_grain_column": "date",
+    "time_grain_trunc": "month",
+    "group_by": ["date", "dimensions.category"],
+    "aggregations": {"measures.cost": "SUM(measures.cost)"},
+    "native_dimensions": {"date"},
+    "native_measures": {"measures.cost": "cost"},
+    "native_dimension_mapping": {"dimensions.category": "model_category"},
+    "jsonb_col": "data",
+    "extra_where": None,
+    "lower_bound": date(2025, 1, 15),
+    "upper_bound_exclusive": date(2025, 3, 1),
+    "today": date(2025, 3, 15),
+}
+
+# One call per method that renders a view name of its own (#472 names five; the
+# repository has ten). They all work today — they are here so the shared helper
+# cannot regress any of them unnoticed.
+SIBLING_CALLS: list[tuple[str, Callable[[FraiseQLRepository, str], Awaitable[Any]]]] = [
+    ("count", lambda repo, view: repo.count(view)),
+    ("exists", lambda repo, view: repo.exists(view)),
+    ("sum", lambda repo, view: repo.sum(view, "cost")),
+    ("avg", lambda repo, view: repo.avg(view, "cost")),
+    ("min", lambda repo, view: repo.min(view, "cost")),
+    ("max", lambda repo, view: repo.max(view, "cost")),
+    ("distinct", lambda repo, view: repo.distinct(view, "status")),
+    ("pluck", lambda repo, view: repo.pluck(view, "cost")),
+    ("aggregate", lambda repo, view: repo.aggregate(view, {"total": "SUM(cost)"})),
+    ("batch_exists", lambda repo, view: repo.batch_exists(view, [ROW_IDS[0]])),
+]
+
+
+def _snapshot(day: str, category: str, status: str, cost: int) -> dict:
+    return {
+        "date": day,
+        "status": status,
+        "dimensions": {"category": category},
+        "measures": {"cost": cost},
+    }
+
+
+@pytest.fixture
+async def qualified_views(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """Build the two tables inside ``test_schema`` and leave it off the search path."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        for table in (COARSE, FINE):
+            await cursor.execute(f"""
+                CREATE TABLE IF NOT EXISTS {test_schema}.{table} (
+                    id UUID PRIMARY KEY,
+                    date DATE NOT NULL,
+                    status TEXT NOT NULL,
+                    model_category TEXT NOT NULL,
+                    cost INTEGER NOT NULL,
+                    data JSONB NOT NULL
+                )
+            """)
+        for table, rows in ((FINE, FINE_ROWS), (COARSE, COARSE_ROWS)):
+            for row_id, (day, category, status, cost) in zip(ROW_IDS, rows, strict=False):
+                await cursor.execute(
+                    f"INSERT INTO {test_schema}.{table} "
+                    f"(id, date, status, model_category, cost, data) "
+                    f"VALUES (%s, %s, %s, %s, %s, %s::jsonb)",
+                    (
+                        row_id,
+                        day,
+                        status,
+                        category,
+                        cost,
+                        json.dumps(_snapshot(day, category, status, cost)),
+                    ),
+                )
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        for table in (COARSE, FINE):
+            await cursor.execute(f"DROP TABLE IF EXISTS {test_schema}.{table} CASCADE")
+        await conn.commit()
+
+
+async def _execute(pool: Any, query: Any) -> list[tuple]:
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(query.statement, query.params)
+        return await cursor.fetchall()
+
+
+class TestSearchPathIsClean:
+    """Without this, every test below could pass for the wrong reason."""
+
+    async def test_the_unqualified_name_does_not_resolve(
+        self, class_db_pool, test_schema, qualified_views
+    ) -> None:
+        repo = FraiseQLRepository(class_db_pool)
+
+        with pytest.raises(psycopg.errors.UndefinedTable):
+            await repo.count(COARSE)
+
+
+class TestPartialPeriodUnionPath:
+    """The reported break: both branch builders render a view name."""
+
+    async def test_both_branches_resolve_their_qualified_view(
+        self, class_db_pool, test_schema, qualified_views
+    ) -> None:
+        query = _build_partial_period_union_query(
+            coarse_view=f"{test_schema}.{COARSE}",
+            fine_grain_view=f"{test_schema}.{FINE}",
+            **UNION_QUERY,
+        )
+
+        rows = [json.loads(row[0]) for row in await _execute(class_db_pool, query)]
+
+        assert sorted(
+            (r["date"], r["dimensions"]["category"], r["measures"]["cost"]) for r in rows
+        ) == [
+            # Branch 1, recomputed from the daily table: only 2025-01-20's 10.
+            ("2025-01-01", "A", 10),
+            # Branch 2, read straight from the monthly table.
+            ("2025-02-01", "A", 20),
+        ]
+
+
+class TestSingleStatementPaths:
+    """The paths that already split the name, held in place across the refactor."""
+
+    async def test_find_resolves_the_qualified_view(
+        self, class_db_pool, test_schema, qualified_views
+    ) -> None:
+        repo = FraiseQLRepository(class_db_pool)
+        query = repo._build_find_query(f"{test_schema}.{FINE}", jsonb_column="data")
+
+        rows = await _execute(class_db_pool, query)
+
+        assert len(rows) == len(FINE_ROWS)
+
+    @pytest.mark.parametrize(("name", "call"), SIBLING_CALLS, ids=[n for n, _ in SIBLING_CALLS])
+    async def test_repository_method_resolves_the_qualified_view(
+        self, class_db_pool, test_schema, qualified_views, name, call
+    ) -> None:
+        repo = FraiseQLRepository(class_db_pool)
+
+        await call(repo, f"{test_schema}.{FINE}")


### PR DESCRIPTION
Closes #472.

A view registered as `myschema.v_stats` has to render as two identifiers — `"myschema"."v_stats"`. Both partial-period UNION branch builders passed the whole string to a single-argument `Identifier`, which renders one quoted relation name containing a dot, so the statement failed with `relation "myschema.v_stats" does not exist`. The same registration worked on every other path, which is what made it confusing: only a coarse view with `fine_grain_view` metadata, queried with a date lower bound, hit it.

## Changes

- Add `_view_identifier()` — the single place a registered view name becomes a psycopg `Identifier`.
- Use it at all thirteen sites: the two UNION branch builders (the bug), plus the eleven that repeated the same five lines inline. The issue counted five of those eleven — `_build_find_query` and four siblings; the actual repetition is `_build_find_query` plus all ten `FraiseQLRepository` query methods (`count`, `exists`, `sum`, `avg`, `min`, `max`, `distinct`, `pluck`, `aggregate`, `batch_exists`).
- Live-database tests in `tests/integration/database/sql/test_schema_qualified_views.py`.

## On the tests

`"myschema.v_stats"` and `"myschema"."v_stats"` differ by one quote character and both read as plausible in a diff, so a text assertion cannot tell them apart — only the server can. The tests build their tables in the class's own schema and deliberately leave it **off** the search path (unlike the #468 tests, which set `search_path` precisely to dodge this bug), so a mis-quoted or unqualified name has nothing to resolve against.

- `TestSearchPathIsClean` asserts the bare name raises `UndefinedTable`. Without it every other test here could pass for the wrong reason.
- `TestPartialPeriodUnionPath` is the reported break: the window straddles a month boundary so both branch kinds contribute, exercising both `Identifier` sites. Before the fix it failed with the reported error verbatim:
  `psycopg.errors.UndefinedTable: relation "test_testpartialperiodunionpath_fef02709.v_472_day" does not exist`
- `TestSingleStatementPaths` covers `_build_find_query` and all ten repository methods parametrically. These already worked — they are here so the shared helper cannot regress any of them unnoticed.

## Not in scope

`CursorPaginator.paginate` and `_get_total_count` (`src/fraiseql/cqrs/pagination.py:105`, `:225`) have the identical defect — bare `Identifier(view_name)`, reachable from `@connection` queries via `CQRSRepository.paginate`. Filed as #486 rather than widened into this PR.

## Verification

✅ RED reproduced the reported error, then passed
✅ `uv run pytest tests/unit/ tests/integration/ -q` → 5966 passed, 1 pre-existing failure (`test_nested_organization_without_tenant_id`, fails on dev)
✅ ruff check + format clean
✅ `uv run ty check` → 538 diagnostics, unchanged from dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N