### PR TITLE
fix(cqrs): split schema-qualified view names in cursor pagination (#486)

### DIFF
--- a/src/fraiseql/cqrs/pagination.py
+++ b/src/fraiseql/cqrs/pagination.py
@@ -8,7 +8,9 @@ import base64
 from typing import Any, TypeVar
 
 from psycopg import AsyncConnection
-from psycopg.sql import SQL, Identifier, Literal
+from psycopg.sql import SQL, Literal
+
+from fraiseql.db import _view_identifier
 
 from .repository import CQRSRepository
 
@@ -102,7 +104,7 @@ class CursorPaginator:
             Dictionary with edges, page_info, and optional total_count
         """
         # Build the main query
-        query_parts = [SQL("SELECT id, data FROM {}").format(Identifier(view_name))]
+        query_parts = [SQL("SELECT id, data FROM {}").format(_view_identifier(view_name))]
         query_params = []
         where_clauses = []
 
@@ -222,7 +224,7 @@ class CursorPaginator:
         Returns:
             Total count of matching items
         """
-        query_parts = [SQL("SELECT COUNT(*) FROM {}").format(Identifier(view_name))]
+        query_parts = [SQL("SELECT COUNT(*) FROM {}").format(_view_identifier(view_name))]
         query_params = []
 
         if filters:

--- a/tests/integration/database/repository/test_schema_qualified_pagination.py
+++ b/tests/integration/database/repository/test_schema_qualified_pagination.py
@@ -1,0 +1,121 @@
+"""Issue #486: schema-qualified view names in cursor pagination, resolved by a real PostgreSQL.
+
+The same defect as #472, in a different module. ``CursorPaginator.paginate`` and
+``CursorPaginator._get_total_count`` handed the whole view name to a
+single-argument ``Identifier``, so ``"myschema.v_posts"`` rendered as
+``"myschema.v_posts"`` — one quoted relation name that happens to contain a dot,
+which PostgreSQL cannot resolve — instead of ``"myschema"."v_posts"``.
+
+The two renderings differ by a single quote character and both read as plausible
+in a diff, so a text assertion cannot tell them apart; only the server can. The
+schema built here is therefore deliberately kept *off* the search path, so a
+mis-quoted or unqualified name has nothing to resolve against.
+
+Reachable in production from any ``@connection`` query, which resolves a view
+name and hands it to ``CQRSRepository.paginate`` → ``paginate_query`` →
+``CursorPaginator``.
+"""
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+
+import psycopg
+import pytest
+
+# Import database fixtures for this database test
+from tests.fixtures.database.database_conftest import *  # noqa: F403
+
+from fraiseql.cqrs.pagination import CursorPaginator, PaginationParams
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+VIEW = "v_486_posts"
+
+# (title, author) — ordered by title, so the cursor field is unique and stable.
+ROWS = [
+    ("post-a", "alice"),
+    ("post-b", "bob"),
+    ("post-c", "alice"),
+]
+
+ROW_IDS = [uuid.UUID(int=i) for i in range(1, len(ROWS) + 1)]
+
+
+@pytest.fixture
+async def qualified_view(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """Build the table inside ``test_schema`` and leave it off the search path."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"""
+            CREATE TABLE IF NOT EXISTS {test_schema}.{VIEW} (
+                id UUID PRIMARY KEY,
+                data JSONB NOT NULL
+            )
+        """)
+        for row_id, (title, author) in zip(ROW_IDS, ROWS, strict=True):
+            await cursor.execute(
+                f"INSERT INTO {test_schema}.{VIEW} (id, data) VALUES (%s, %s::jsonb)",
+                (row_id, json.dumps({"id": str(row_id), "title": title, "author": author})),
+            )
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"DROP TABLE IF EXISTS {test_schema}.{VIEW} CASCADE")
+        await conn.commit()
+
+
+class TestSchemaQualifiedPagination:
+    """``paginate`` renders one view name; ``include_total`` renders the second."""
+
+    async def test_the_unqualified_name_does_not_resolve(
+        self, class_db_pool, test_schema, qualified_view
+    ) -> None:
+        """Without this, every test below could pass for the wrong reason."""
+        async with class_db_pool.connection() as conn:
+            paginator = CursorPaginator(conn)
+
+            with pytest.raises(psycopg.errors.UndefinedTable):
+                await paginator.paginate(VIEW, PaginationParams(first=2, order_by="title"))
+
+    async def test_paginate_resolves_the_qualified_view(
+        self, class_db_pool, test_schema, qualified_view
+    ) -> None:
+        """Both the page query and the ``include_total`` count query name the view."""
+        async with class_db_pool.connection() as conn:
+            paginator = CursorPaginator(conn)
+
+            result = await paginator.paginate(
+                f"{test_schema}.{VIEW}", PaginationParams(first=2, order_by="title")
+            )
+
+        assert [edge["node"]["title"] for edge in result["edges"]] == ["post-a", "post-b"]
+        assert result["page_info"]["has_next_page"] is True
+        # _get_total_count is the second Identifier site, and counts past the page.
+        assert result["total_count"] == len(ROWS)
+
+    async def test_get_total_count_resolves_the_qualified_view_with_filters(
+        self, class_db_pool, test_schema, qualified_view
+    ) -> None:
+        """The filtered count path renders the same name."""
+        async with class_db_pool.connection() as conn:
+            paginator = CursorPaginator(conn)
+
+            total = await paginator._get_total_count(
+                f"{test_schema}.{VIEW}", filters={"author": "alice"}
+            )
+
+        assert total == 2
+
+    async def test_unqualified_name_still_resolves_on_the_search_path(
+        self, class_db_pool, test_schema, qualified_view
+    ) -> None:
+        """The bare-name form must keep working — the helper must not split what has no dot."""
+        async with class_db_pool.connection() as conn:
+            await conn.execute(f"SET search_path TO {test_schema}, public")
+            paginator = CursorPaginator(conn)
+
+            result = await paginator.paginate(VIEW, PaginationParams(first=2, order_by="title"))
+
+        assert result["total_count"] == len(ROWS)


### PR DESCRIPTION
Closes #486.

`CursorPaginator.paginate` (`src/fraiseql/cqrs/pagination.py:105`) and `_get_total_count` (`:225`) passed the whole view name to a single-argument `Identifier`, so `"myschema.v_posts"` rendered as `"myschema.v_posts"` — one quoted relation name containing a dot — instead of `"myschema"."v_posts"`. PostgreSQL then failed the statement with `relation "myschema.v_posts" does not exist`.

Same defect as #472, in a different module. Reachable from any `@connection` query, which resolves a view name and hands it to `CQRSRepository.paginate` → `paginate_query` → `CursorPaginator`.

## Changes

- Reuse `_view_identifier()` from `fraiseql.db` at both sites rather than adding a fourth spelling of the split. The import direction is acyclic (`fraiseql.db` contains no reference to `fraiseql.cqrs`), and `cqrs/repository.py:9` already imports a private helper across modules the same way — so no move was needed.
- Add live-database coverage in `tests/integration/database/repository/test_schema_qualified_pagination.py`, following the pattern added in #485. A text assertion cannot tell `"myschema.v_posts"` from `"myschema"."v_posts"`, so tables are built in the class's own `test_schema` and `search_path` is never set. A guard test asserts the bare name raises `UndefinedTable`, so the rest cannot pass for the wrong reason, and a fourth test holds the unqualified-name form in place on the search path.

## Verification

Both new tests fail on the parent commit with the reported error:

```
E   psycopg.errors.UndefinedTable: relation "test_...60635d2c.v_486_posts" does not exist
E   LINE 1: SELECT id, data FROM "test_...
```

- ✅ 4 new tests pass with the fix
- ✅ `pytest tests/unit/ tests/integration/ -q` → 5970 passed (dev's known `test_nested_organization_without_tenant_id` failure is unchanged)
- ✅ `ruff check` + `ruff format --check` clean on the touched file
- ✅ `ty check` reports 538 diagnostics, unchanged from dev

## Note on the site count

Issue enumerations have been wrong before, so I grepped every `Identifier(` in `src/` rather than trusting the two sites listed. #486's enumeration is correct for the live path: the remaining whole-name candidates — `sql/sql_generator.py:523,578`, `mutations/sql_generator.py:117`, `integrations/langchain.py:174,290` — sit on functions with **no in-src caller** (the live query path uses the Rust `build_sql_query` from `fraiseql._fraiseql_rs`, not the Python one). They are public/legacy API surface and belong in their own issue, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N