### PR TITLE
fix(sql): split schema-qualified names in the SQL, mutation and langchain generators

### DIFF
--- a/src/fraiseql/cqrs/pagination.py
+++ b/src/fraiseql/cqrs/pagination.py
@@ -10,7 +10,7 @@ from typing import Any, TypeVar
 from psycopg import AsyncConnection
 from psycopg.sql import SQL, Literal
 
-from fraiseql.db import _view_identifier
+from fraiseql.sql.identifiers import qualified_identifier
 
 from .repository import CQRSRepository
 
@@ -104,7 +104,7 @@ class CursorPaginator:
             Dictionary with edges, page_info, and optional total_count
         """
         # Build the main query
-        query_parts = [SQL("SELECT id, data FROM {}").format(_view_identifier(view_name))]
+        query_parts = [SQL("SELECT id, data FROM {}").format(qualified_identifier(view_name))]
         query_params = []
         where_clauses = []
 
@@ -224,7 +224,7 @@ class CursorPaginator:
         Returns:
             Total count of matching items
         """
-        query_parts = [SQL("SELECT COUNT(*) FROM {}").format(_view_identifier(view_name))]
+        query_parts = [SQL("SELECT COUNT(*) FROM {}").format(qualified_identifier(view_name))]
         query_params = []
 
         if filters:

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -8,7 +8,7 @@ from datetime import UTC
 from typing import Any, Optional, TypeVar, Union, get_args, get_origin
 
 from psycopg.rows import dict_row
-from psycopg.sql import SQL, Composed, Identifier
+from psycopg.sql import SQL, Composed
 from psycopg_pool import AsyncConnectionPool
 
 from fraiseql.audit import get_security_logger
@@ -16,6 +16,7 @@ from fraiseql.core.rust_pipeline import (
     RustResponseBytes,
     execute_via_rust_pipeline,
 )
+from fraiseql.sql.identifiers import qualified_identifier
 from fraiseql.sql.native_columns import resolve_native_column
 from fraiseql.utils.casing import to_snake_case
 from fraiseql.where_clause import WhereClause
@@ -83,23 +84,6 @@ def _make_mandatory_conditions(
         parts.append(Composed([Identifier(col), SQL(" = "), SQL("%s")]))
         params.append(val)
     return parts, params
-
-
-def _view_identifier(view_name: str) -> Identifier:
-    """Render a registered view name as the identifier PostgreSQL resolves.
-
-    A schema-qualified name has to become two identifiers — ``"myschema"."v_stats"``.
-    Passed whole to a single-argument ``Identifier`` it renders as
-    ``"myschema.v_stats"``, one quoted relation name containing a dot, and the
-    statement fails with ``relation "myschema.v_stats" does not exist`` (#472).
-
-    Every path that names a view goes through here, so the two renderings cannot
-    drift apart again.
-    """
-    if "." in view_name:
-        schema_name, table_name = view_name.split(".", 1)
-        return Identifier(schema_name, table_name)
-    return Identifier(view_name)
 
 
 def _is_rust_response_null(response: RustResponseBytes) -> bool:
@@ -463,7 +447,7 @@ def _build_fine_grain_branch(
     """
     from psycopg.sql import SQL, Composed, Identifier, Literal
 
-    table_id = _view_identifier(fine_grain_view)
+    table_id = qualified_identifier(fine_grain_view)
     col_id = Identifier(time_grain_column)
 
     def build_field(fp: str) -> SQL | Composed:
@@ -557,7 +541,7 @@ def _build_coarse_branch(
     """
     from psycopg.sql import SQL, Composed, Identifier, Literal
 
-    table_id = _view_identifier(coarse_view)
+    table_id = qualified_identifier(coarse_view)
     col_id = Identifier(time_grain_column)
 
     def build_field(fp: str) -> SQL | Composed:
@@ -2155,7 +2139,7 @@ class FraiseQLRepository:
         # Build WHERE clause (extracted to helper method for reuse)
         where_parts, params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build COUNT(*) query
         query_parts = [SQL("SELECT COUNT(*) FROM "), table_identifier]
@@ -2222,7 +2206,7 @@ class FraiseQLRepository:
         # Build WHERE clause using existing helper
         where_parts, params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build EXISTS query
         query_parts = [SQL("SELECT EXISTS(SELECT 1 FROM "), table_identifier]
@@ -2286,7 +2270,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build SUM query
         query_parts = [
@@ -2345,7 +2329,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build AVG query
         query_parts = [
@@ -2400,7 +2384,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build MIN query
         query_parts = [SQL("SELECT MIN("), Identifier(field), SQL(") FROM "), table_identifier]
@@ -2450,7 +2434,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build MAX query
         query_parts = [SQL("SELECT MAX("), Identifier(field), SQL(") FROM "), table_identifier]
@@ -2504,7 +2488,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build DISTINCT query
         query_parts = [SQL("SELECT DISTINCT "), Identifier(field), SQL(" FROM "), table_identifier]
@@ -2570,7 +2554,7 @@ class FraiseQLRepository:
 
         where_parts, _params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         query_parts = [SQL("SELECT "), Identifier(field), SQL(" FROM "), table_identifier]
 
@@ -2642,7 +2626,7 @@ class FraiseQLRepository:
 
         where_parts, params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build SELECT clause with all aggregations
         agg_clauses = [SQL(f"{expr} AS {name}") for name, expr in aggregations.items()]
@@ -2711,7 +2695,7 @@ class FraiseQLRepository:
 
         where_parts, where_params = self._build_where_clause(view_name, **kwargs)
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build query to select existing IDs
         query_parts = [SQL("SELECT "), Identifier(field), SQL(" FROM "), table_identifier]
@@ -3081,7 +3065,7 @@ class FraiseQLRepository:
             column_mapping=native_dimension_mapping,
         )
 
-        table_identifier = _view_identifier(view_name)
+        table_identifier = qualified_identifier(view_name)
 
         # Build SELECT clause — different when GROUP BY + aggregations are used
         if group_by:

--- a/src/fraiseql/integrations/langchain.py
+++ b/src/fraiseql/integrations/langchain.py
@@ -32,6 +32,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import psycopg_pool
 from psycopg.sql import SQL, Identifier
 
+from fraiseql.sql.identifiers import qualified_identifier
+
 # Optional imports for LangChain
 try:
     from langchain_core.documents import Document  # type: ignore[import]
@@ -171,7 +173,7 @@ class FraiseQLVectorStore(VectorStore if LANGCHAIN_AVAILABLE else object):  # ty
                 INSERT INTO {} ({})
                 VALUES ({})
                 """).format(
-                    Identifier(self.table_name),
+                    qualified_identifier(self.table_name),
                     SQL(", ").join(Identifier(col) for col in columns),
                     SQL(", ").join(SQL("%s") for _ in values),
                 )
@@ -287,7 +289,7 @@ class FraiseQLVectorStore(VectorStore if LANGCHAIN_AVAILABLE else object):  # ty
         async with self.db_pool.connection() as conn:
             for doc_id in ids:
                 query = SQL("DELETE FROM {} WHERE {} = %s").format(
-                    Identifier(self.table_name),
+                    qualified_identifier(self.table_name),
                     Identifier(self.id_column),
                 )
                 await conn.execute(query, [doc_id])

--- a/src/fraiseql/mutations/sql_generator.py
+++ b/src/fraiseql/mutations/sql_generator.py
@@ -20,6 +20,7 @@ from psycopg import sql
 from psycopg.types.json import Jsonb
 
 from fraiseql.db import DatabaseQuery
+from fraiseql.sql.identifiers import qualified_identifier
 from fraiseql.types.definitions import UNSET
 from fraiseql.utils.casing import to_snake_case
 
@@ -114,7 +115,7 @@ def generate_insert_json_call(
     placeholders.append(sql.Placeholder("input_json"))
 
     statement = sql.SQL("SELECT * FROM {}({})").format(
-        sql.Identifier(sql_function_name),
+        qualified_identifier(sql_function_name),
         sql.SQL(", ").join(placeholders),
     )
 

--- a/src/fraiseql/sql/identifiers.py
+++ b/src/fraiseql/sql/identifiers.py
@@ -1,0 +1,35 @@
+"""Render database object names as the identifiers PostgreSQL resolves.
+
+A schema-qualified name has to become two identifiers — ``"myschema"."v_stats"``.
+Passed whole to a single-argument :class:`~psycopg.sql.Identifier` it renders as
+``"myschema.v_stats"``, one quoted relation name that happens to contain a dot,
+and the statement fails with ``relation "myschema.v_stats" does not exist``.
+
+This module holds no FraiseQL imports so that every layer can reach it: the
+repository (:mod:`fraiseql.db`) imports both :mod:`fraiseql.sql` and
+:mod:`fraiseql.mutations`, so those two cannot import the helper back from
+there.
+"""
+
+from psycopg.sql import Identifier
+
+__all__ = ["qualified_identifier"]
+
+
+def qualified_identifier(name: str) -> Identifier:
+    """Split a possibly schema-qualified name into the identifiers it names.
+
+    Applies to any qualified database object — a view, a table, or a function.
+    Unqualified names are returned as a single identifier, unchanged.
+
+    Args:
+        name: A relation or function name, optionally ``schema.``-qualified.
+
+    Returns:
+        ``Identifier(schema, object)`` for a qualified name, ``Identifier(name)``
+        otherwise.
+    """
+    if "." in name:
+        schema_name, object_name = name.split(".", 1)
+        return Identifier(schema_name, object_name)
+    return Identifier(name)

--- a/src/fraiseql/sql/sql_generator.py
+++ b/src/fraiseql/sql/sql_generator.py
@@ -12,6 +12,7 @@ from psycopg import sql
 from psycopg.sql import SQL, Composed, Identifier
 
 from fraiseql.core.ast_parser import FieldPath
+from fraiseql.sql.identifiers import qualified_identifier
 
 
 def _get_graphql_field_type(typename: str | None, field_alias: str) -> type | None:
@@ -520,7 +521,7 @@ def build_sql_query(
         else:
             select_clause = SQL("data")
 
-        base = SQL("SELECT {} FROM {}").format(select_clause, Identifier(table))
+        base = SQL("SELECT {} FROM {}").format(select_clause, qualified_identifier(table))
 
         # Build query with clauses in correct SQL order
         query_parts = [base]
@@ -575,7 +576,7 @@ def build_sql_query(
         ]
         select_clause = SQL(", ").join(select_items)
 
-    base = SQL("SELECT {} FROM {}").format(select_clause, Identifier(table))
+    base = SQL("SELECT {} FROM {}").format(select_clause, qualified_identifier(table))
 
     # Build query with clauses in correct SQL order
     query_parts = [base]

--- a/tests/integration/database/sql/test_schema_qualified_identifiers.py
+++ b/tests/integration/database/sql/test_schema_qualified_identifiers.py
@@ -1,0 +1,307 @@
+"""Issue #488: schema-qualified names in the SQL, mutation and langchain generators.
+
+The same defect as #472 and #486, in the three modules those fixes did not
+touch. ``build_sql_query`` (both branches), ``generate_insert_json_call`` and
+``FraiseQLVectorStore``'s two write paths handed the whole dotted name to a
+single-argument ``Identifier``, so ``"myschema.v_posts"`` rendered as one quoted
+relation name containing a dot instead of ``"myschema"."v_posts"``.
+
+The two renderings differ by a single quote character and both read as plausible
+in a diff, so a text assertion cannot tell them apart; only the server can. Each
+class below therefore builds inside its own ``test_schema`` and leaves it *off*
+the search path, so a mis-quoted or unqualified name has nothing to resolve
+against, and opens with a guard test proving exactly that.
+
+The three generators are off the live request path — the served query and
+mutation paths go through Rust — but they are maintained, importable API that
+eight test files exercise. The mutation site is the sharpest: mutation function
+names are schema-qualified by construction in ``mutation_decorator``.
+"""
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+import pytest
+
+from fraiseql.core.ast_parser import FieldPath
+from fraiseql.integrations.langchain import FraiseQLVectorStore
+from fraiseql.mutations.sql_generator import generate_insert_json_call
+from fraiseql.sql.sql_generator import build_sql_query
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+VIEW = "v_488_posts"
+FUNCTION = "create_488_user"
+DOCS = "tb_488_documents"
+
+# (title, author)
+ROWS = [
+    ("post-a", "alice"),
+    ("post-b", "bob"),
+    ("post-c", "alice"),
+]
+
+ROW_IDS = [uuid.UUID(int=i) for i in range(1, len(ROWS) + 1)]
+
+FIELD_PATHS = [
+    FieldPath(alias="title", path=["title"]),
+    FieldPath(alias="author", path=["author"]),
+]
+
+
+async def _fetch(pool: Any, statement: Any, params: Any = None) -> list[tuple]:
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(statement, params)
+        return await cursor.fetchall()
+
+
+@pytest.fixture
+async def qualified_view(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """Build the posts table inside ``test_schema``, off the search path."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"""
+            CREATE TABLE IF NOT EXISTS {test_schema}.{VIEW} (
+                id UUID PRIMARY KEY,
+                data JSONB NOT NULL
+            )
+        """)
+        for row_id, (title, author) in zip(ROW_IDS, ROWS, strict=True):
+            await cursor.execute(
+                f"INSERT INTO {test_schema}.{VIEW} (id, data) VALUES (%s, %s::jsonb)",
+                (row_id, json.dumps({"id": str(row_id), "title": title, "author": author})),
+            )
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"DROP TABLE IF EXISTS {test_schema}.{VIEW} CASCADE")
+        await conn.commit()
+
+
+class TestBuildSqlQuery:
+    """``sql/sql_generator.build_sql_query`` renders one view name on each branch."""
+
+    async def test_the_unqualified_name_does_not_resolve(
+        self, class_db_pool, test_schema, qualified_view
+    ) -> None:
+        """Without this, every test below could pass for the wrong reason."""
+        query = build_sql_query(VIEW, FIELD_PATHS, json_output=True)
+
+        with pytest.raises(psycopg.errors.UndefinedTable):
+            await _fetch(class_db_pool, query)
+
+    async def test_projection_branch_resolves_the_qualified_view(
+        self, class_db_pool, test_schema, qualified_view
+    ) -> None:
+        """The jsonb_build_object branch — the one most callers reach."""
+        query = build_sql_query(f"{test_schema}.{VIEW}", FIELD_PATHS, json_output=True)
+
+        rows = [row[0] for row in await _fetch(class_db_pool, query)]
+
+        assert sorted((r["title"], r["author"]) for r in rows) == sorted(ROWS)
+
+    async def test_field_limit_threshold_branch_resolves_the_qualified_view(
+        self, class_db_pool, test_schema, qualified_view
+    ) -> None:
+        """The second, easily-missed branch: exceeding the threshold selects ``data`` whole."""
+        query = build_sql_query(
+            f"{test_schema}.{VIEW}",
+            FIELD_PATHS,
+            json_output=True,
+            field_limit_threshold=1,
+        )
+
+        rows = [row[0] for row in await _fetch(class_db_pool, query)]
+
+        assert sorted((r["title"], r["author"]) for r in rows) == sorted(ROWS)
+
+    async def test_unqualified_name_still_resolves_on_the_search_path(
+        self, class_db_pool, test_schema, qualified_view
+    ) -> None:
+        """The bare-name form must keep working — the helper must not split what has no dot."""
+        query = build_sql_query(VIEW, FIELD_PATHS, json_output=True)
+
+        async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+            await conn.execute(f"SET search_path TO {test_schema}, public")
+            await cursor.execute(query)
+            rows = [row[0] for row in await cursor.fetchall()]
+
+        assert len(rows) == len(ROWS)
+
+
+@dataclass
+class CreateUserInput:
+    """Minimal mutation input — ``generate_insert_json_call`` needs a dataclass."""
+
+    name: str
+
+
+@pytest.fixture
+async def qualified_function(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """Build the mutation function inside ``test_schema``, off the search path."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"""
+            CREATE OR REPLACE FUNCTION {test_schema}.{FUNCTION}(input_json JSONB)
+            RETURNS JSONB AS $$
+                SELECT jsonb_build_object('status', 'created', 'name', input_json->>'name')
+            $$ LANGUAGE sql
+        """)
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"DROP FUNCTION IF EXISTS {test_schema}.{FUNCTION}(JSONB)")
+        await conn.commit()
+
+
+class TestGenerateInsertJsonCall:
+    """``mutations/sql_generator`` names a function, which is qualified by construction."""
+
+    async def test_the_unqualified_name_does_not_resolve(
+        self, class_db_pool, test_schema, qualified_function
+    ) -> None:
+        """Without this, the test below could pass for the wrong reason."""
+        query = generate_insert_json_call(
+            input_object=CreateUserInput(name="alice"),
+            context={},
+            sql_function_name=FUNCTION,
+        )
+
+        with pytest.raises(psycopg.errors.UndefinedFunction):
+            await _fetch(class_db_pool, query.statement, query.params)
+
+    async def test_qualified_function_name_resolves(
+        self, class_db_pool, test_schema, qualified_function
+    ) -> None:
+        """``mutation_decorator`` builds ``f"{schema}.{function_name}"``; this is that shape."""
+        query = generate_insert_json_call(
+            input_object=CreateUserInput(name="alice"),
+            context={},
+            sql_function_name=f"{test_schema}.{FUNCTION}",
+        )
+
+        rows = await _fetch(class_db_pool, query.statement, query.params)
+
+        assert rows == [({"name": "alice", "status": "created"},)]
+
+    async def test_unqualified_name_still_resolves_on_the_search_path(
+        self, class_db_pool, test_schema, qualified_function
+    ) -> None:
+        """The bare-name form must keep working."""
+        query = generate_insert_json_call(
+            input_object=CreateUserInput(name="alice"),
+            context={},
+            sql_function_name=FUNCTION,
+        )
+
+        async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+            await conn.execute(f"SET search_path TO {test_schema}, public")
+            await cursor.execute(query.statement, query.params)
+            rows = await cursor.fetchall()
+
+        assert rows == [({"name": "alice", "status": "created"},)]
+
+
+class _StubEmbeddings:
+    """Deterministic stand-in — the vector maths is irrelevant to identifier rendering."""
+
+    def embed_query(self, text: str) -> list[float]:
+        return [float(len(text)), 0.0, 1.0]
+
+
+class _SearchPathPool:
+    """Hands out the class pool's connections with ``test_schema`` on the search path.
+
+    ``FraiseQLVectorStore`` opens its own connection, so the bare-name case has
+    to be set up inside ``connection()`` rather than on a connection the test holds.
+    """
+
+    def __init__(self, pool: Any, schema: str) -> None:
+        self._pool = pool
+        self._schema = schema
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator[Any]:
+        async with self._pool.connection() as conn:
+            await conn.execute(f"SET search_path TO {self._schema}, public")
+            yield conn
+
+
+@pytest.fixture
+async def qualified_documents(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """Build the documents table inside ``test_schema``, off the search path."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"""
+            CREATE TABLE IF NOT EXISTS {test_schema}.{DOCS} (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                embedding DOUBLE PRECISION[] NOT NULL
+            )
+        """)
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"DROP TABLE IF EXISTS {test_schema}.{DOCS} CASCADE")
+        await conn.commit()
+
+
+class TestLangchainVectorStore:
+    """``integrations/langchain`` renders its table name on the insert and delete paths."""
+
+    @staticmethod
+    def _store(pool, table_name: str) -> FraiseQLVectorStore:
+        return FraiseQLVectorStore(
+            db_pool=pool,
+            table_name=table_name,
+            embedding_function=_StubEmbeddings(),
+        )
+
+    async def test_the_unqualified_name_does_not_resolve(
+        self, class_db_pool, test_schema, qualified_documents
+    ) -> None:
+        """Without this, every test below could pass for the wrong reason."""
+        store = self._store(class_db_pool, DOCS)
+
+        with pytest.raises(psycopg.errors.UndefinedTable):
+            await store.aadd_texts(["hello"])
+
+    async def test_aadd_texts_resolves_the_qualified_table(
+        self, class_db_pool, test_schema, qualified_documents
+    ) -> None:
+        store = self._store(class_db_pool, f"{test_schema}.{DOCS}")
+
+        ids = await store.aadd_texts(["hello", "world"])
+
+        rows = await _fetch(class_db_pool, f"SELECT id, content FROM {test_schema}.{DOCS}")
+        assert sorted(rows) == sorted(zip(ids, ["hello", "world"], strict=True))
+
+    async def test_adelete_resolves_the_qualified_table(
+        self, class_db_pool, test_schema, qualified_documents
+    ) -> None:
+        store = self._store(class_db_pool, f"{test_schema}.{DOCS}")
+        ids = await store.aadd_texts(["hello", "world"])
+
+        await store.adelete([ids[0]])
+
+        rows = await _fetch(class_db_pool, f"SELECT id FROM {test_schema}.{DOCS}")
+        assert rows == [(ids[1],)]
+
+    async def test_unqualified_name_still_resolves_on_the_search_path(
+        self, class_db_pool, test_schema, qualified_documents
+    ) -> None:
+        """The bare-name form must keep working — the helper must not split what has no dot."""
+        store = self._store(_SearchPathPool(class_db_pool, test_schema), DOCS)
+
+        ids = await store.aadd_texts(["hello"])
+
+        rows = await _fetch(class_db_pool, f"SELECT id FROM {test_schema}.{DOCS}")
+        assert rows == [(ids[0],)]


### PR DESCRIPTION
Closes #488.

Five sites handed a whole dotted name to a single-argument `Identifier`, so `myschema.v_posts` rendered as `"myschema.v_posts"` — one quoted relation name containing a dot — instead of `"myschema"."v_posts"`. Same defect as #472 and #486, in the modules those fixes did not touch.

## Changes

- Move the splitting helper out of `db.py` into `sql/identifiers.py`, a leaf module with no FraiseQL imports, and rename it `qualified_identifier`: it now names functions as well as views, and `fraiseql.db` imports both `sql/` and `mutations/`, so those two cannot import it back from there (unlike the `cqrs` case in #486, which was acyclic). Updated the 13 `db.py` call sites and the two in `cqrs/pagination.py`.
- `sql/sql_generator.build_sql_query`: both branches — the projection one at `:578` and the `field_limit_threshold` one at `:523`.
- `mutations/sql_generator.generate_insert_json_call`.
- `integrations/langchain`: `aadd_texts` and `adelete`.
- `db.py` drops `Identifier` from its module-level import; the helper was its only module-scope use and every remaining use already has a function-local import. Without this, removing the helper makes ruff flag all 12 locals as F811.

## Scope

None of these are on the live request path — the served query and mutation paths go through Rust — so nothing user-visible changes today. They are maintained, importable API that eight test files exercise, and mutation function names are schema-qualified by construction in `mutation_decorator.py:728`, so a direct caller of `run_fraiseql_mutation` hits the mutation site immediately.

## Verification

Renderings taken from psycopg, driving the real module code (the langchain pair through `FraiseQLVectorStore` itself, not a hand-copied `SQL(...)`):

```
build_sql_query          : ... FROM "myschema"."v_posts"
build_sql_query (thresh) : ... FROM "myschema"."v_posts"
generate_insert_json_call: SELECT * FROM "graphql"."create_user"(%(input_json)s)
langchain aadd_texts     : INSERT INTO "myschema"."documents" ("id", "content", "embedding") VALUES (%s, %s, %s)
langchain adelete        : DELETE FROM "myschema"."documents" WHERE "id" = %s
```

11 new live-database tests in `tests/integration/database/sql/test_schema_qualified_identifiers.py`, each class building in its own `test_schema` left off the search path — a text assertion cannot tell `"a.b"` from `"a"."b"`, only the server can.

Reverting the source change fails exactly five of them, one per site, each reporting the mis-quoted name:

```
psycopg.errors.UndefinedTable: relation "test_..._7a71f000.tb_488_documents" does not exist
```

The three guard tests (bare name raises `UndefinedTable`/`UndefinedFunction`) and the three bare-name-on-search-path tests keep passing without the fix, so the rest cannot pass for the wrong reason.

- ✅ 5981 passed (`tests/unit/ tests/integration/`, +11); the one failure is `test_nested_organization_without_tenant_id`, already failing on `dev`
- ✅ `ruff check` + `ruff format` clean
- ✅ `ty check` 538 diagnostics — unchanged from `dev`

## Not addressed

`integrations/langchain.py:247` raw-interpolates `self.table_name` and four column names into an f-string. Left alone deliberately — parked as a separate injection question on #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N