### PR TITLE
fix: compile Rust benchmarks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
       # cargo test cannot run for PyO3 extension-module crates (linking issue).
       # Rust integration is tested via pytest in the integration-tests job.
       - name: Build (verify compilation)
-        run: cargo build --manifest-path fraiseql_rs/Cargo.toml --all-features
+        run: cargo build --manifest-path fraiseql_rs/Cargo.toml --all-features --all-targets
 
   ci-success:
     name: CI Success

--- a/fraiseql_rs/benches/mutation_benchmark.rs
+++ b/fraiseql_rs/benches/mutation_benchmark.rs
@@ -19,6 +19,7 @@ fn benchmark_simple_format(c: &mut Criterion) {
                 true,
                 None,
                 None,
+                None,
             )
         })
     });
@@ -48,6 +49,7 @@ fn benchmark_full_format_with_cascade(c: &mut Criterion) {
                 Some("User"),
                 None,
                 true,
+                None,
                 None,
                 None,
             )
@@ -80,6 +82,7 @@ fn benchmark_error_response(c: &mut Criterion) {
                 true,
                 None,
                 None,
+                None,
             )
         })
     });
@@ -103,6 +106,7 @@ fn benchmark_array_entities(c: &mut Criterion) {
                 Some("User"),
                 None,
                 true,
+                None,
                 None,
                 None,
             )

--- a/fraiseql_rs/benches/streaming.rs
+++ b/fraiseql_rs/benches/streaming.rs
@@ -4,6 +4,7 @@
 //! Real streaming benchmarks will be added in Phase 3.
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::time::Duration;
 
 /// Benchmark JSON field name transformation
 fn bench_field_transformation(c: &mut Criterion) {
@@ -16,8 +17,8 @@ fn bench_field_transformation(c: &mut Criterion) {
             |b, &field_count| {
                 b.iter(|| {
                     // Simulate transforming N field names from snake_case to camelCase
-                    let mut transformed = Vec::with_capacity(*field_count);
-                    for i in 0..*field_count {
+                    let mut transformed = Vec::with_capacity(field_count);
+                    for i in 0..field_count {
                         let snake = format!("field_name_{}", i);
                         // Simple simulation of transformation
                         let camel = snake.replace("_", "");
@@ -43,8 +44,8 @@ fn bench_response_serialization(c: &mut Criterion) {
             |b, &object_count| {
                 b.iter(|| {
                     // Simulate serializing N objects to JSON
-                    let mut json_strings = Vec::with_capacity(*object_count);
-                    for i in 0..*object_count {
+                    let mut json_strings = Vec::with_capacity(object_count);
+                    for i in 0..object_count {
                         let json = format!(r#"{{"id": {}, "name": "Item {}"}}"#, i, i);
                         json_strings.push(json);
                     }
@@ -68,7 +69,7 @@ fn bench_chunked_processing(c: &mut Criterion) {
             |b, &chunk_size| {
                 b.iter(|| {
                     // Simulate processing data in chunks
-                    let data = vec![42u8; *chunk_size];
+                    let data = vec![42u8; chunk_size];
                     let mut checksum = 0u64;
                     for &byte in &data {
                         checksum = checksum.wrapping_add(byte as u64);


### PR DESCRIPTION
## Description

Fix Rust benchmark compilation and ensure benchmark targets are covered by CI.

The benchmark code was not compiling due to outdated function arguments and invalid dereferences. The CI build also did not include all Rust targets, allowing these issues to go undetected.

This PR:
- Adds the missing argument to mutation benchmark calls.
- Fixes invalid dereferences in the streaming benchmark.
- Adds the missing `Duration` import.
- Updates the Rust CI build to include `--all-targets`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test update
- [x] Configuration/build update

## Validation

- `cargo check --all-targets --all-features`
- `cargo check --bench mutation_benchmark --all-features`
- `cargo check --bench streaming --all-features`
- `cargo clippy --all-features --bench mutation_benchmark --bench streaming`
- `git diff --check`

The full local `cargo build --all-targets --all-features` is affected by the existing PyO3 extension-module linker issue on macOS.