### PR TITLE
fix(langchain): render the vector-store read path through psycopg.sql

### DIFF
--- a/src/fraiseql/integrations/langchain.py
+++ b/src/fraiseql/integrations/langchain.py
@@ -30,7 +30,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
 import psycopg_pool
-from psycopg.sql import SQL, Identifier
+from psycopg.sql import SQL, Composable, Identifier
 
 from fraiseql.sql.identifiers import qualified_identifier
 
@@ -188,8 +188,14 @@ class FraiseQLVectorStore(VectorStore if LANGCHAIN_AVAILABLE else object):  # ty
         metadatas = [doc.metadata for doc in documents]
         return await self.aadd_texts(texts, metadatas, **kwargs)
 
-    def _build_metadata_where_clause(self, filter_dict: Dict[str, Any]) -> Tuple[str, List[Any]]:
+    def _build_metadata_where_clause(
+        self, filter_dict: Dict[str, Any]
+    ) -> Tuple[Composable, List[Any]]:
         """Build WHERE clause for metadata filtering.
+
+        The filter keys and values are parameters, never text; the metadata
+        column is a constructor-supplied name, so it is rendered as an
+        identifier the same way the rest of the statement renders its names.
 
         Args:
             filter_dict: Dictionary of metadata filters
@@ -199,7 +205,7 @@ class FraiseQLVectorStore(VectorStore if LANGCHAIN_AVAILABLE else object):  # ty
             Tuple of (where_clause_sql, parameters)
         """
         if not filter_dict:
-            return "", []
+            return SQL(""), []
 
         conditions = []
         params = []
@@ -207,15 +213,10 @@ class FraiseQLVectorStore(VectorStore if LANGCHAIN_AVAILABLE else object):  # ty
         for key, value in filter_dict.items():
             # For now, support simple equality filtering
             # v1.8: Add support for complex operators (gt, lt, in, etc.)
-            conditions.append(f"{self.metadata_column} ->> %s = %s")
+            conditions.append(SQL("{} ->> %s = %s").format(Identifier(self.metadata_column)))
             params.extend([key, value])
 
-        if conditions:
-            where_sql = " AND " + " AND ".join(conditions)
-        else:
-            where_sql = ""
-
-        return where_sql, params
+        return SQL(" AND ") + SQL(" AND ").join(conditions), params
 
     async def asimilarity_search(
         self,
@@ -236,27 +237,35 @@ class FraiseQLVectorStore(VectorStore if LANGCHAIN_AVAILABLE else object):  # ty
             # Build the query for vector similarity search
             # Use different operators based on distance metric
             if self.distance_metric == "cosine":
-                distance_op = "<=>"
+                distance_op = SQL("<=>")
             elif self.distance_metric == "l2":
-                distance_op = "<->"
+                distance_op = SQL("<->")
             elif self.distance_metric == "inner_product":
-                distance_op = "<#>"
+                distance_op = SQL("<#>")
             else:
-                distance_op = "<=>"
+                distance_op = SQL("<=>")
 
-            query_str = f"""
-            SELECT {self.id_column}, {self.content_column}, {self.metadata_column}
-            FROM {self.table_name}
+            query = SQL("""
+            SELECT {id_column}, {content_column}, {metadata_column}
+            FROM {table}
             WHERE 1=1{metadata_where}
-            ORDER BY {self.embedding_column} {distance_op} %s::vector
+            ORDER BY {embedding_column} {distance_op} %s::vector
             LIMIT %s
-            """
+            """).format(
+                id_column=Identifier(self.id_column),
+                content_column=Identifier(self.content_column),
+                metadata_column=Identifier(self.metadata_column),
+                table=qualified_identifier(self.table_name),
+                metadata_where=metadata_where,
+                embedding_column=Identifier(self.embedding_column),
+                distance_op=distance_op,
+            )
 
             # Combine metadata params with vector params
             all_params = [*metadata_params, query_embedding, k]
 
             async with conn.cursor() as cursor:
-                await cursor.execute(query_str, all_params)  # type: ignore[arg-type]
+                await cursor.execute(query, all_params)  # type: ignore[arg-type]
                 rows = await cursor.fetchall()
 
         # Convert results to LangChain Documents

--- a/tests/integration/database/sql/test_langchain_read_path_identifiers.py
+++ b/tests/integration/database/sql/test_langchain_read_path_identifiers.py
@@ -1,0 +1,152 @@
+"""Issue #490: the langchain read path interpolates its five identifiers raw.
+
+``FraiseQLVectorStore``'s two write paths (``aadd_texts``, ``adelete``) render
+their names through ``psycopg.sql``, so they are quoted. ``asimilarity_search``
+built its statement as an f-string, dropping five constructor-supplied names —
+the table and the id, content, metadata and embedding columns — into the text
+unquoted.
+
+The inversion versus #488 is the point. Raw interpolation means
+``FROM myschema.documents`` is valid SQL, so the read path has always resolved
+both the bare and the schema-qualified spelling; ``UndefinedTable`` cannot prove
+anything here. What raw interpolation *cannot* survive is a name that needs
+quoting, so each case below gives exactly one of the five identifiers a
+mixed-case spelling and leaves the other four alone. PostgreSQL folds an
+unquoted ``"DocId"`` to ``docid`` and the statement fails on that one name, which
+is what makes the parametrisation fail once per site rather than once overall.
+
+The write paths were already quoted, so ``aadd_texts`` populating these tables is
+itself the control: it accepts the mixed-case names the read path rejected.
+"""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from fraiseql.integrations.langchain import FraiseQLVectorStore
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+# Each site names the one identifier spelled in mixed case; the rest stay plain.
+# (site, table, id_column, content_column, metadata_column, embedding_column)
+SITES = [
+    ("table", "Tb490Documents", "id", "content", "metadata", "embedding"),
+    ("id_column", "tb490_id", "DocId", "content", "metadata", "embedding"),
+    ("content_column", "tb490_content", "id", "DocContent", "metadata", "embedding"),
+    ("metadata_column", "tb490_metadata", "id", "content", "DocMetadata", "embedding"),
+    ("embedding_column", "tb490_embedding", "id", "content", "metadata", "DocEmbedding"),
+]
+
+PLAIN = ("tb490_plain", "id", "content", "metadata", "embedding")
+
+DIMENSION = 3
+
+
+class _StubEmbeddings:
+    """Deterministic stand-in — the vector maths is irrelevant to identifier rendering."""
+
+    def embed_query(self, text: str) -> list[float]:
+        return [float(len(text)), 0.0, 1.0]
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return self.embed_query(text)
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self.embed_query(text) for text in texts]
+
+
+def _store(pool: Any, table_name: str, columns: tuple[str, str, str, str]) -> FraiseQLVectorStore:
+    id_column, content_column, metadata_column, embedding_column = columns
+    return FraiseQLVectorStore(
+        db_pool=pool,
+        table_name=table_name,
+        embedding_function=_StubEmbeddings(),
+        id_column=id_column,
+        content_column=content_column,
+        metadata_column=metadata_column,
+        embedding_column=embedding_column,
+    )
+
+
+@pytest.fixture
+async def documents_tables(class_db_pool, test_schema, pgvector_available) -> AsyncIterator[None]:
+    """One table per site, plus an all-plain table, inside ``test_schema``."""
+    if not pgvector_available:
+        pytest.skip("pgvector extension not available")
+
+    tables = [row[1:] for row in SITES] + [PLAIN]
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        for table, id_column, content_column, metadata_column, embedding_column in tables:
+            await cursor.execute(f"""
+                CREATE TABLE IF NOT EXISTS {test_schema}."{table}" (
+                    "{id_column}" TEXT PRIMARY KEY,
+                    "{content_column}" TEXT NOT NULL,
+                    "{metadata_column}" JSONB,
+                    "{embedding_column}" vector({DIMENSION})
+                )
+            """)
+        await conn.commit()
+
+    yield
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        for table, *_ in tables:
+            await cursor.execute(f'DROP TABLE IF EXISTS {test_schema}."{table}" CASCADE')
+        await conn.commit()
+
+
+class TestLangchainReadPathIdentifiers:
+    """``asimilarity_search`` renders every name it interpolates."""
+
+    @pytest.mark.parametrize(
+        ("site", "table", "id_column", "content_column", "metadata_column", "embedding_column"),
+        SITES,
+        ids=[row[0] for row in SITES],
+    )
+    async def test_mixed_case_identifier_resolves(
+        self,
+        class_db_pool,
+        test_schema,
+        documents_tables,
+        site: str,
+        table: str,
+        id_column: str,
+        content_column: str,
+        metadata_column: str,
+        embedding_column: str,
+    ) -> None:
+        """One mixed-case name per case, so a raw-interpolated site fails on its own."""
+        columns = (id_column, content_column, metadata_column, embedding_column)
+        store = _store(class_db_pool, f"{test_schema}.{table}", columns)
+        await store.aadd_texts(["hello"], [{"kind": "greeting"}])
+
+        results = await store.asimilarity_search("hello", k=1)
+
+        assert [document.page_content for document in results] == ["hello"]
+        assert results[0].metadata == {"kind": "greeting"}
+
+    async def test_mixed_case_metadata_column_resolves_in_the_filter(
+        self, class_db_pool, test_schema, documents_tables
+    ) -> None:
+        """``_build_metadata_where_clause`` interpolates the same name a second time."""
+        _site, table, *columns = next(row for row in SITES if row[0] == "metadata_column")
+        store = _store(class_db_pool, f"{test_schema}.{table}", tuple(columns))
+        await store.aadd_texts(["hello", "world"], [{"kind": "greeting"}, {"kind": "noun"}])
+
+        results = await store.asimilarity_search("hello", k=5, filter={"kind": "greeting"})
+
+        assert [document.page_content for document in results] == ["hello"]
+
+    async def test_plain_names_still_resolve(
+        self, class_db_pool, test_schema, documents_tables
+    ) -> None:
+        """The regression guard: quoting must not break the names that already worked."""
+        table, *columns = PLAIN
+        store = _store(class_db_pool, f"{test_schema}.{table}", tuple(columns))
+        await store.aadd_texts(["hello"], [{"kind": "greeting"}])
+
+        results = await store.asimilarity_search("hello", k=1, filter={"kind": "greeting"})
+
+        assert [document.page_content for document in results] == ["hello"]


### PR DESCRIPTION
Closes #490.

`FraiseQLVectorStore.asimilarity_search` built its statement as an f-string, interpolating five constructor-supplied names — the table and the id, content, metadata and embedding columns — as bare text. The two write paths (`aadd_texts`, `adelete`) render the same names through `psycopg.sql`, so the same constructor arguments were accepted by one half of the class and rejected by the other.

## Severity, stated precisely

The request-controlled values were already safe. `_build_metadata_where_clause` parameterizes both the filter key and its value (`{metadata} ->> %s = %s`), and `query_embedding` and `k` are parameters too. The five interpolated names are constructor config, and `distance_op` is a literal chosen by an if/elif. So this is config-trust, not injection-by-request.

The live defect is the non-security half: an unquoted name is folded to lower case, so any name needing quotes — mixed case, a reserved word, a hyphen — resolved on write and failed on read, from the same constructor arguments.

## Changes

- `asimilarity_search` composes with `SQL(...).format(...)`: `qualified_identifier` for the relation, `Identifier` for the four columns, the distance operator as a `SQL` literal.
- `_build_metadata_where_clause` returns a `Composable` and renders the metadata column as an `Identifier`; the filter key and value stay parameters.
- New live-database coverage in `tests/integration/database/sql/test_langchain_read_path_identifiers.py`.

## Why the guard inverts versus #488

Raw interpolation means `FROM myschema.documents` is valid SQL, so the read path has always resolved both the bare and the schema-qualified spelling — `UndefinedTable` cannot prove anything here. Each case therefore gives exactly one of the five identifiers a mixed-case spelling and leaves the other four plain, so the parametrisation fails once per site rather than once overall. The write paths, already quoted, populate those same tables, which is itself the control. A plain-name case guards the new quoting against regression.

## Verification

- 6 of the 7 new tests fail on unpatched `src`, one per interpolated site, each error naming its own identifier (`column "docid" does not exist`, `column "docembedding" does not exist`, …); the plain-name guard passes before and after.
- Rendered statement inspected by driving the real method: `FROM "MySchema"."Tb490Documents"`, all five names quoted, `WHERE 1=1 AND "DocMetadata" ->> %s = %s` still parameterized, and `WHERE 1=1` with nothing appended in the no-filter case.
- `uv run pytest tests/unit/ tests/integration/ -q` — 5988 passed (was 5981), only the pre-existing `test_nested_organization_without_tenant_id` failure.
- `uv run ty check` — 538 diagnostics, unchanged from `dev`.
- `ruff check` and `ruff format --check` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N