### PR TITLE
fix(sql): render every VectorOrderBy operator, identically on both order_by shapes

### DIFF
--- a/src/fraiseql/sql/graphql_order_by_generator.py
+++ b/src/fraiseql/sql/graphql_order_by_generator.py
@@ -10,7 +10,12 @@ from dataclasses import make_dataclass
 from typing import Any, Optional, TypeVar, Union, get_args, get_origin, get_type_hints
 
 from fraiseql import fraise_input
-from fraiseql.sql.order_by_generator import OrderBy, OrderBySet, OrderDirection
+from fraiseql.sql.order_by_generator import (
+    VECTOR_DISTANCE_OPERATORS,
+    OrderBy,
+    OrderBySet,
+    OrderDirection,
+)
 from fraiseql.types.scalars.vector import HalfVectorField, QuantizedVectorField, SparseVectorField
 
 # Type variable for generic types
@@ -176,12 +181,30 @@ def _apply_collation_default(
     return None
 
 
-# Only the operators OrderBy.to_sql can actually render. jaccard_distance is
-# deliberately absent: it exists on VectorOrderBy and the __gql_fields__ branch
-# emits it, but to_sql has no case for it, so the instruction degrades into a
-# plain JSONB path sort and the query fails. Adding it here has to wait for
-# to_sql to support it -- see #483.
-_VECTOR_OPERATORS = ("cosine_distance", "l2_distance", "inner_product")
+def _is_vector_order_by(value: Any) -> bool:
+    """Recognise a ``VectorOrderBy`` without importing it into the check."""
+    return hasattr(value, "__gql_fields__") and hasattr(value, "cosine_distance")
+
+
+def _append_vector_order_by(value: Any, field_path: str, instructions: list[OrderBy]) -> None:
+    """Append the one distance instruction a ``VectorOrderBy`` asks for.
+
+    Both ``order_by`` shapes route through here. They had a copy each until
+    #483 and emitted different subsets of ``VECTOR_DISTANCE_OPERATORS``, so the
+    same request sorted differently -- or not at all -- depending on which shape
+    it arrived in.
+    """
+    for operator in VECTOR_DISTANCE_OPERATORS:
+        operand = getattr(value, operator, None)
+        if operand is not None:
+            instructions.append(
+                OrderBy(
+                    field=f"{field_path}.{operator}",
+                    direction=OrderDirection.ASC,  # ASC = nearest first
+                    value=operand,
+                )
+            )
+            return
 
 
 def _collect_dict_order_by(
@@ -213,18 +236,8 @@ def _collect_dict_order_by(
         if isinstance(value, dict):
             _collect_dict_order_by(value, instructions, field_path)
         # A VectorOrderBy names the distance operator it wants.
-        elif hasattr(value, "__gql_fields__") and hasattr(value, "cosine_distance"):
-            for operator in _VECTOR_OPERATORS:
-                operand = getattr(value, operator, None)
-                if operand is not None:
-                    instructions.append(
-                        OrderBy(
-                            field=f"{field_path}.{operator}",
-                            direction=OrderDirection.ASC,  # ASC for vectors
-                            value=operand,
-                        )
-                    )
-                    break
+        elif _is_vector_order_by(value):
+            _append_vector_order_by(value, field_path, instructions)
         # A direction: a string, an OrderDirection, or any enum-like carrying one.
         elif isinstance(value, (OrderDirection, str)) or hasattr(value, "value"):
             instructions.append(
@@ -305,59 +318,19 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
                 value = getattr(obj, field_name)
                 if value is not None:
                     field_path = f"{prefix}.{field_name}" if prefix else field_name
-                    # Check if this is a VectorOrderBy input
-                    if hasattr(value, "__gql_fields__") and hasattr(value, "cosine_distance"):
-                        # This is a VectorOrderBy - check which distance operator is set
-                        if value.cosine_distance is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.cosine_distance",
-                                    direction=OrderDirection.ASC,  # ASC for vectors
-                                    value=value.cosine_distance,
-                                )
-                            )
-                        elif value.l2_distance is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.l2_distance",
-                                    direction=OrderDirection.ASC,
-                                    value=value.l2_distance,
-                                )
-                            )
-                        elif value.l1_distance is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.l1_distance",
-                                    direction=OrderDirection.ASC,
-                                    value=value.l1_distance,
-                                )
-                            )
-                        elif value.inner_product is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.inner_product",
-                                    direction=OrderDirection.ASC,
-                                    value=value.inner_product,
-                                )
-                            )
-                        elif value.hamming_distance is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.hamming_distance",
-                                    direction=OrderDirection.ASC,
-                                    value=value.hamming_distance,
-                                )
-                            )
-                        elif value.jaccard_distance is not None:
-                            instructions.append(
-                                OrderBy(
-                                    field=f"{field_path}.jaccard_distance",
-                                    direction=OrderDirection.ASC,
-                                    value=value.jaccard_distance,
-                                )
-                            )
+                    # A VectorOrderBy names the distance operator it wants.
+                    #
+                    # This has to be chained with the direction/recursion cases
+                    # below rather than standing alone: a VectorOrderBy carries
+                    # __gql_fields__, so an unchained check fell through to the
+                    # nested-input recursion as well, which read the bit string
+                    # of hamming_distance / jaccard_distance as a direction --
+                    # any string that is not "ASC" normalises to DESC -- and
+                    # appended a contradictory second instruction (#483).
+                    if _is_vector_order_by(value):
+                        _append_vector_order_by(value, field_path, instructions)
                     # If it's an OrderDirection enum or string, use it
-                    if isinstance(value, (OrderDirection, str)):
+                    elif isinstance(value, (OrderDirection, str)):
                         direction = _normalize_order_direction(value)
 
                         # No per-field override in this format, so this

--- a/src/fraiseql/sql/order_by_generator.py
+++ b/src/fraiseql/sql/order_by_generator.py
@@ -29,6 +29,33 @@ from psycopg import sql
 
 from fraiseql import fraise_enum
 
+# The distance operators :meth:`OrderBy._build_vector_distance_sql` can render,
+# in the order ``VectorOrderBy`` declares them so that the first operand set on
+# one wins identically on every ``order_by`` shape. Both shapes read this tuple:
+# they emitted different subsets of it until #483, and the three the gate below
+# did not route -- ``l1_distance``, ``hamming_distance``, ``jaccard_distance`` --
+# degraded into a JSONB path sort against a vector column.
+VECTOR_DISTANCE_OPERATORS = (
+    "cosine_distance",
+    "l2_distance",
+    "l1_distance",
+    "inner_product",
+    "hamming_distance",
+    "jaccard_distance",
+)
+
+
+def _bit_cast(bit_string: str) -> sql.Composed:
+    """Cast a bit-string literal to a bit type of its own width.
+
+    A bare ``::bit`` is ``bit(1)``, so ``'1010...'::bit`` keeps the first bit and
+    pgvector's bit operators then reject the comparison with *different bit
+    lengths 64 and 1*. The width has to come from the literal (#483). A caller
+    whose string does not match the column width still gets the server's
+    length mismatch, which is the right error to surface.
+    """
+    return sql.SQL("::bit({})").format(sql.Literal(len(bit_string)))
+
 
 @fraise_enum
 class OrderDirection(Enum):
@@ -169,7 +196,7 @@ class OrderBy:
             parts = self.field.split(".")
             if len(parts) == 2:  # field.operator format
                 field_name, operator = parts
-                if operator in ("cosine_distance", "l2_distance", "inner_product"):
+                if operator in VECTOR_DISTANCE_OPERATORS:
                     return self._build_vector_distance_sql(
                         field_name, operator, self.value, table_ref
                     )
@@ -217,7 +244,7 @@ class OrderBy:
 
         Args:
             field_name: The vector field name (e.g., 'embedding')
-            operator: The distance operator ('cosine_distance', 'l2_distance', 'inner_product')
+            operator: One of :data:`VECTOR_DISTANCE_OPERATORS`
             value: The vector to compare against
             table_ref: Table alias or column name to use for field access
 
@@ -238,9 +265,13 @@ class OrderBy:
                 pg_operator_sql = sql.SQL("<=>")
             elif operator == "l2_distance":
                 pg_operator_sql = sql.SQL("<->")
+            elif operator == "l1_distance":
+                pg_operator_sql = sql.SQL("<+>")
             elif operator == "inner_product":
                 pg_operator_sql = sql.SQL("<#>")
             else:
+                # hamming_distance and jaccard_distance are bit-string operators;
+                # pgvector has no sparsevec form of either.
                 raise ValueError(f"Unsupported sparse vector operator: {operator}")
         else:
             # Dense vector handling
@@ -259,12 +290,12 @@ class OrderBy:
                 type_cast = sql.SQL("::vector")
             elif operator == "hamming_distance":
                 pg_operator_sql = sql.SQL("<~>")
-                type_cast = sql.SQL("::bit")
                 literal_value = str(value)  # value is already a string for binary operators
+                type_cast = _bit_cast(literal_value)
             elif operator == "jaccard_distance":
                 pg_operator_sql = sql.SQL("<%>")
-                type_cast = sql.SQL("::bit")
                 literal_value = str(value)  # value is already a string for binary operators
+                type_cast = _bit_cast(literal_value)
             else:
                 raise ValueError(f"Unknown vector distance operator: {operator}")
 

--- a/tests/integration/test_vector_e2e.py
+++ b/tests/integration/test_vector_e2e.py
@@ -274,7 +274,9 @@ async def test_vector_l1_distance_filter(class_db_pool, test_schema, vector_test
 async def test_vector_l1_distance_order_by(class_db_pool, test_schema, vector_test_setup) -> None:
     """Test ordering documents by L1/Manhattan distance."""
     repo = FraiseQLRepository(class_db_pool)
-    query_embedding = [0.1, 0.2, 0.3] + [0.0] * 381
+    # Nearest the last-inserted row, so the expected order is the reverse of the
+    # physical one and cannot be satisfied by an unordered scan (#483).
+    query_embedding = [0.3, 0.4, 0.5] + [0.0] * 381
 
     # Use proper GraphQL input object (not plain dict)
     from fraiseql.sql.graphql_order_by_generator import VectorOrderBy
@@ -286,15 +288,18 @@ async def test_vector_l1_distance_order_by(class_db_pool, test_schema, vector_te
     )
 
     results = extract_graphql_data(result, "test_documents")
-    assert len(results) == 3
-    # Results should be ordered by L1 distance
+    assert [row["title"] for row in results] == [
+        "Data Science",
+        "Machine Learning",
+        "Python Programming",
+    ]
 
 
 @pytest.mark.asyncio
 async def test_vector_l1_distance_combined(class_db_pool, test_schema, vector_test_setup) -> None:
     """Test L1 distance for both WHERE and ORDER BY combined."""
     repo = FraiseQLRepository(class_db_pool)
-    query_embedding = [0.1, 0.2, 0.3] + [0.0] * 381
+    query_embedding = [0.3, 0.4, 0.5] + [0.0] * 381
 
     from fraiseql.sql.graphql_order_by_generator import VectorOrderBy
 
@@ -306,8 +311,11 @@ async def test_vector_l1_distance_combined(class_db_pool, test_schema, vector_te
     )
 
     results = extract_graphql_data(result, "test_documents")
-    assert len(results) == 3
-    # Results should be filtered and ordered by L1 distance
+    assert [row["title"] for row in results] == [
+        "Data Science",
+        "Machine Learning",
+        "Python Programming",
+    ]
 
 
 @pytest.mark.asyncio
@@ -356,7 +364,9 @@ async def test_binary_vector_hamming_distance_order_by(
 ) -> None:
     """Test ordering binary vectors by Hamming distance."""
     repo = FraiseQLRepository(class_db_pool)
-    query_fingerprint = "1111000011110000111100001111000011110000111100001111000011110000"
+    # Distances 25 / 31 / 33 to items C / A / B -- distinct, and in an order the
+    # physical A, B, C cannot produce, so an omitted ORDER BY fails here (#483).
+    query_fingerprint = "0000000000100010100000100111001111100101001010111011101110100100"
 
     from fraiseql.sql.graphql_order_by_generator import VectorOrderBy
 
@@ -367,8 +377,7 @@ async def test_binary_vector_hamming_distance_order_by(
     )
 
     results = extract_graphql_data(result, "test_fingerprints")
-    assert len(results) == 3
-    # Results should be ordered by Hamming distance
+    assert [row["name"] for row in results] == ["Item C", "Item A", "Item B"]
 
 
 @pytest.mark.asyncio
@@ -377,7 +386,9 @@ async def test_binary_vector_jaccard_distance_order_by(
 ) -> None:
     """Test ordering binary vectors by Jaccard distance."""
     repo = FraiseQLRepository(class_db_pool)
-    query_fingerprint = "1111000011110000111100001111000011110000111100001111000011110000"
+    # Distances 0.595 / 0.689 / 0.717 to items C / A / B -- see the Hamming test
+    # above for why the expected order has to differ from the physical one.
+    query_fingerprint = "0000000000100010100000100111001111100101001010111011101110100100"
 
     from fraiseql.sql.graphql_order_by_generator import VectorOrderBy
 
@@ -388,8 +399,7 @@ async def test_binary_vector_jaccard_distance_order_by(
     )
 
     results = extract_graphql_data(result, "test_fingerprints")
-    assert len(results) == 3
-    # Results should be ordered by Jaccard distance
+    assert [row["name"] for row in results] == ["Item C", "Item A", "Item B"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sql/test_order_by_vector_operator_parity.py
+++ b/tests/unit/sql/test_order_by_vector_operator_parity.py
@@ -1,0 +1,109 @@
+"""Issue #483: every ``VectorOrderBy`` operator must render, on both order_by shapes.
+
+``VectorOrderBy`` accepts six distance operators. ``OrderBy.to_sql`` gated its
+vector branch on three of them, and the two ``order_by`` shapes disagreed about
+which ones to emit at all:
+
+* the dict shape emitted only the three the gate accepted, so ``l1_distance``,
+  ``hamming_distance`` and ``jaccard_distance`` produced **no instruction** —
+  the query ran with no ``ORDER BY`` and returned rows in whatever order the
+  scan produced;
+* the ``__gql_fields__`` shape emitted all six, so those same three fell past
+  the gate into plain JSONB extraction — ``t -> 'fingerprint' -> 'jaccard_distance'``
+  against a ``bit`` column, which the server rejects outright.
+
+The ``__gql_fields__`` shape had a second defect on top: a ``VectorOrderBy`` was
+handled and then *also* recursed into as if it were a nested order-by input, so
+the two bit-string operators emitted a **second** instruction. Their operand is
+a ``str``, and ``_normalize_order_direction`` reads any string that is not
+``"ASC"`` as ``DESC``, so ``jaccard_distance="111000"`` appended a contradictory
+``... DESC`` term after the real one.
+
+Both shapes now read one operator tuple and append through one helper, so a
+seventh operator cannot reach one shape and not the other.
+"""
+
+from uuid import UUID
+
+import pytest
+
+from fraiseql.sql.graphql_order_by_generator import (
+    VectorOrderBy,
+    _convert_order_by_input_to_sql,
+    create_graphql_order_by_input,
+)
+from fraiseql.types import fraise_type
+
+pytestmark = pytest.mark.unit
+
+DENSE = [0.1, 0.2, 0.3]
+BITS = "111000"
+
+# operator -> (operand, rendered SQL fragment)
+OPERATORS = {
+    "cosine_distance": (DENSE, "(t.\"embedding\") <=> '[0.1,0.2,0.3]'::vector ASC"),
+    "l2_distance": (DENSE, "(t.\"embedding\") <-> '[0.1,0.2,0.3]'::vector ASC"),
+    "l1_distance": (DENSE, "(t.\"embedding\") <+> '[0.1,0.2,0.3]'::vector ASC"),
+    "inner_product": (DENSE, "(t.\"embedding\") <#> '[0.1,0.2,0.3]'::vector ASC"),
+    # ``::bit`` alone is ``bit(1)``: the literal has to carry its own width or
+    # pgvector rejects the comparison with "different bit lengths 64 and 1".
+    "hamming_distance": (BITS, "(t.\"embedding\") <~> '111000'::bit(6) ASC"),
+    "jaccard_distance": (BITS, "(t.\"embedding\") <%> '111000'::bit(6) ASC"),
+}
+
+
+@fraise_type
+class _Document:
+    """The vector field is detected by name, so ``embedding`` gets a VectorOrderBy."""
+
+    id: UUID
+    title: str
+    embedding: list[float]
+
+
+def _dict_shape(operator: str, operand: object) -> dict:
+    return {"embedding": VectorOrderBy(**{operator: operand})}
+
+
+def _gql_fields_shape(operator: str, operand: object):
+    order_by_input = create_graphql_order_by_input(_Document)
+    return order_by_input(embedding=VectorOrderBy(**{operator: operand}))
+
+
+@pytest.mark.parametrize("operator", list(OPERATORS))
+@pytest.mark.parametrize("shape", [_dict_shape, _gql_fields_shape], ids=["dict", "gql_fields"])
+def test_operator_renders_its_distance_expression(shape, operator: str) -> None:
+    """Every operator ``VectorOrderBy`` accepts reaches the vector branch of to_sql."""
+    operand, expected = OPERATORS[operator]
+
+    order_by_set = _convert_order_by_input_to_sql(shape(operator, operand))
+
+    assert order_by_set is not None, f"{operator} emitted no instruction"
+    assert order_by_set.to_sql().as_string(None) == f"ORDER BY {expected}"
+
+
+@pytest.mark.parametrize("operator", list(OPERATORS))
+@pytest.mark.parametrize("shape", [_dict_shape, _gql_fields_shape], ids=["dict", "gql_fields"])
+def test_operator_emits_exactly_one_instruction(shape, operator: str) -> None:
+    """A bit-string operand must not also be read as a sort direction."""
+    operand, _expected = OPERATORS[operator]
+
+    order_by_set = _convert_order_by_input_to_sql(shape(operator, operand))
+
+    assert order_by_set is not None
+    assert [instruction.field for instruction in order_by_set.instructions] == [
+        f"embedding.{operator}"
+    ]
+
+
+@pytest.mark.parametrize("operator", list(OPERATORS))
+def test_both_shapes_render_identically(operator: str) -> None:
+    """The two shapes are the same request written two ways."""
+    operand, _expected = OPERATORS[operator]
+
+    from_dict = _convert_order_by_input_to_sql(_dict_shape(operator, operand))
+    from_gql_fields = _convert_order_by_input_to_sql(_gql_fields_shape(operator, operand))
+
+    assert from_dict is not None
+    assert from_gql_fields is not None
+    assert from_dict.to_sql().as_string(None) == from_gql_fields.to_sql().as_string(None)


### PR DESCRIPTION
Closes #483.

The issue reports one unrenderable operator. Rendering all six through the real code first, it is **three**, and the `__gql_fields__` shape has a second, independent defect on top.

## Measured on `dev`, per operator, per shape

| operator | dict shape | `__gql_fields__` shape |
|---|---|---|
| `cosine_distance` | `(t."x") <=> '[…]'::vector ASC` | same |
| `l2_distance` | `(t."x") <-> '[…]'::vector ASC` | same |
| `l1_distance` | **no instruction** | `t -> 'x' -> 'l1_distance' ASC` |
| `inner_product` | `(t."x") <#> '[…]'::vector ASC` | same |
| `hamming_distance` | **no instruction** | `t -> 'x' -> 'hamming_distance' ASC, t -> 'x' -> 'hamming_distance' DESC` |
| `jaccard_distance` | **no instruction** | `t -> 'x' -> 'jaccard_distance' ASC, t -> 'x' -> 'jaccard_distance' DESC` |

The dict shape emitted nothing at all, so the query ran with **no** `ORDER BY` and returned rows in scan order — silent, and the reason the four e2e tests passed. The `__gql_fields__` shape emitted a JSONB path sort against a vector column, which the server rejects.

The doubled instruction is a separate defect: a `VectorOrderBy` was handled and then *also* recursed into as if it were a nested order-by input. Its `hamming_distance` / `jaccard_distance` operand is a `str`, and `_normalize_order_direction` reads any string that is not `"ASC"` as `DESC`, so the bit string was appended a second time as a contradictory sort direction.

`_build_vector_distance_sql` already knew all six operators. Only the gate in front of it did not.

## Changes

- `VECTOR_DISTANCE_OPERATORS` is the single tuple the gate and both shapes read, in `VectorOrderBy` declaration order so the first operand set wins identically everywhere.
- Both shapes append through one `_append_vector_order_by` helper. The `__gql_fields__` branch's six-case chain is replaced by it, and its vector case is now chained with the direction and recursion cases so a `VectorOrderBy` is not also walked as a nested input.
- **Bit-string literals cast to their own width.** A bare `::bit` is `bit(1)`, so `'1010…'::bit` kept one bit and pgvector rejected the comparison with `different bit lengths 64 and 1`. This only appeared once the statement actually reached the server — the rendering looked right.
- `l1_distance` added to the sparse branch (pgvector renders `<+>` for `sparsevec`). hamming/jaccard stay unsupported there and raise, as both are bit-only.
- The four e2e tests asserted row counts only, each with a trailing comment naming the ordering it did not check. They now assert the returned order, against distances computed from the fixture data and chosen so the expected order differs from the physical one — an omitted `ORDER BY` cannot satisfy them.

## Verification

- 18 tests fail on unpatched `src`: all three operators on both shapes, plus all four e2e tests — confirming those four were passing vacuously.
- Both shapes rendered for all six operators after the fix: identical strings, exactly one instruction each.
- `uv run pytest tests/unit/ tests/integration/ -q` — 6011 passed (was 5981), only the pre-existing `test_nested_organization_without_tenant_id` failure.
- `uv run ty check` — 538 diagnostics, unchanged from `dev`.
- `ruff check` and `ruff format --check` clean.

## Found while verifying, filed separately

Two things this PR deliberately does not change; issues follow.

1. **The WHERE path has the same `::bit` truncation, and it is a silent wrong answer rather than an error.** `build_hamming_distance_sql` renders `(col)::bit <~> 'value'::bit`, casting *both* sides to `bit(1)`. Against the e2e fixture data the generated form returns Hamming distance `0` for all three rows where the true distances are `0, 32, 32`, so a `threshold` filter matches everything. The existing filter tests assert `len(results) > 0` and cannot see it.
2. **`<%>` collides with psycopg's placeholder scanning.** A composed statement containing `<%>` raises `ProgrammingError: only '%s', '%b', '%t' are allowed as placeholders, got '%>'` when executed *with* parameters. FraiseQL inlines values as `Literal`s on the paths exercised here, so nothing breaks today, and `<%>` already reaches the WHERE path on `dev` independently of this change — but the collision is structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N