### PR TITLE
fix(db): normalize aggregation measure keys at registration

### DIFF
--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -892,20 +892,41 @@ def _normalize_mapping_keys(mapping: dict[str, str]) -> dict[str, str]:
     }
 
 
+# The aggregation entries keyed by dotted field paths. Every one of them is
+# matched against paths built with ``transform_path=to_snake_case``, so every one
+# of them needs its keys normalized or the entry silently never fires.
+_PATH_KEYED_AGGREGATION_ENTRIES = ("native_dimension_mapping", "measures", "native_measures")
+
+
 def _normalize_aggregation_mapping_keys(aggregation: dict[str, Any]) -> dict[str, Any]:
-    """Return ``aggregation`` with ``native_dimension_mapping`` keys in one spelling.
+    """Return ``aggregation`` with its path-keyed entries in one spelling.
+
+    ``native_dimension_mapping`` maps dimension paths to columns (#467),
+    ``measures`` maps measure paths to aggregate functions, and
+    ``native_measures`` maps those same measure paths to columns.
+
+    The two measure dicts have to move together (#477). A camelCase ``measures``
+    key derives no aggregation at all in :func:`_derive_auto_aggregation`, so
+    normalizing ``native_measures`` alone would leave a correct mapping with
+    nothing to attach to — the same invisible no-op, minus the obvious
+    explanation.
 
     The caller's dict is never mutated: a new dict is returned when anything
     changed, and the original is returned untouched otherwise.
     """
-    mapping: dict[str, str] = aggregation.get("native_dimension_mapping") or {}
-    if not mapping:
-        return aggregation
+    normalized_entries: dict[str, dict[str, str]] = {}
 
-    normalized = _normalize_mapping_keys(mapping)
-    if normalized == mapping:
+    for entry in _PATH_KEYED_AGGREGATION_ENTRIES:
+        mapping: dict[str, str] = aggregation.get(entry) or {}
+        if not mapping:
+            continue
+        normalized = _normalize_mapping_keys(mapping)
+        if normalized != mapping:
+            normalized_entries[entry] = normalized
+
+    if not normalized_entries:
         return aggregation
-    return {**aggregation, "native_dimension_mapping": normalized}
+    return {**aggregation, **normalized_entries}
 
 
 def _aggregation_mapping_error(

--- a/tests/unit/test_measures_key_casing.py
+++ b/tests/unit/test_measures_key_casing.py
@@ -1,0 +1,130 @@
+"""Issue #477: ``measures`` and ``native_measures`` keys have #467's casing trap.
+
+#467 normalised ``native_dimension_mapping`` keys segment-wise at registration,
+because field paths are built with ``transform_path=to_snake_case`` and a key in
+GraphQL spelling could never match one. ``aggregation["measures"]`` and
+``aggregation["native_measures"]`` are matched against the same snake_case
+dot-paths and were deliberately left out of that change.
+
+The two have to move together. A camelCase ``measures`` key fails to derive the
+aggregation at all in ``_derive_auto_aggregation``, so normalising
+``native_measures`` alone would produce a mapping that is correct and still
+dead — with the obvious explanation eliminated.
+"""
+
+import pytest
+
+from fraiseql.db import (
+    _derive_auto_aggregation,
+    _table_metadata,
+    _type_registry,
+    register_type_for_view,
+)
+
+pytestmark = pytest.mark.unit
+
+CAMEL = "measures.totalCost"
+SNAKE = "measures.total_cost"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Keep the module-level registries clean between tests."""
+    yield
+    for registry in (_table_metadata, _type_registry):
+        for view in [v for v in registry if v.startswith("v_measure_casing")]:
+            del registry[view]
+
+
+def _register(view_name: str, key: str) -> dict:
+    register_type_for_view(
+        view_name,
+        type("Stats", (), {}),
+        table_columns={"id", "data", "period_date", "total_cost"},
+        aggregation={
+            "dimensions": "dimensions",
+            "measures": {key: "SUM"},
+            "native_measures": {key: "total_cost"},
+            "native_dimensions": ["period_date"],
+        },
+    )
+    return _table_metadata[view_name]["aggregation"]
+
+
+class TestMeasureKeyCasing:
+    """Both measure dicts accept either spelling and store one."""
+
+    def test_camel_case_measures_key_is_normalized_at_registration(self) -> None:
+        agg = _register("v_measure_casing_measures", CAMEL)
+
+        assert agg["measures"] == {SNAKE: "SUM"}
+
+    def test_camel_case_native_measures_key_is_normalized_at_registration(self) -> None:
+        agg = _register("v_measure_casing_native", CAMEL)
+
+        assert agg["native_measures"] == {SNAKE: "total_cost"}
+
+    def test_both_spellings_register_identically(self) -> None:
+        camel = _register("v_measure_casing_camel_eq", CAMEL)
+        snake = _register("v_measure_casing_snake_eq", SNAKE)
+
+        assert camel["measures"] == snake["measures"]
+        assert camel["native_measures"] == snake["native_measures"]
+
+    def test_registration_does_not_mutate_the_caller_dict(self) -> None:
+        measures = {CAMEL: "SUM"}
+        native_measures = {CAMEL: "total_cost"}
+        aggregation = {
+            "dimensions": "dimensions",
+            "measures": measures,
+            "native_measures": native_measures,
+            "native_dimensions": ["period_date"],
+        }
+
+        register_type_for_view(
+            "v_measure_casing_no_mutation",
+            type("Stats", (), {}),
+            table_columns={"id", "data", "period_date", "total_cost"},
+            aggregation=aggregation,
+        )
+
+        assert measures == {CAMEL: "SUM"}
+        assert native_measures == {CAMEL: "total_cost"}
+        assert aggregation["measures"] is measures
+        assert aggregation["native_measures"] is native_measures
+
+
+class TestMeasureKeyCasingEndToEnd:
+    """The two dicts are useless apart: the measure has to derive *and* map."""
+
+    def test_camel_case_measure_derives_and_its_native_counterpart_resolves(self) -> None:
+        """One test, two reasons to fail today (#477)."""
+        agg = _register("v_measure_casing_e2e", CAMEL)
+        field_paths = [["dimensions", "date"], ["measures", "total_cost"]]
+
+        derived = _derive_auto_aggregation(field_paths, agg)
+
+        assert derived is not None
+        _group_by, aggregations, _native_dims, _native_dim_mapping = derived
+        # Reason one: a camelCase measures key derives no aggregation at all.
+        assert aggregations == {SNAKE: f"SUM({SNAKE})"}
+        # Reason two: with no aggregation derived there is nothing for the
+        # native_measures entry to attach to, whatever spelling it carries.
+        assert agg["native_measures"][SNAKE] == "total_cost"
+
+
+class TestNativeMeasureColumnValidation:
+    """The value half, already covered for native_dimension_mapping (#467)."""
+
+    def test_unknown_native_measure_column_raises_in_strict_mode(self) -> None:
+        with pytest.raises(ValueError, match="native_measures"):
+            register_type_for_view(
+                "v_measure_casing_bad_column",
+                type("Stats", (), {}),
+                table_columns={"id", "data", "period_date"},
+                aggregation={
+                    "dimensions": "dimensions",
+                    "measures": {CAMEL: "SUM"},
+                    "native_measures": {CAMEL: "no_such_column"},
+                },
+            )


### PR DESCRIPTION
Closes #477.

`aggregation["measures"]` and `aggregation["native_measures"]` carried the same casing trap #467 fixed for `native_dimension_mapping`, and were deliberately left out of that change.

Both are matched against the dotted field paths field extraction produces, and both call sites build those with `transform_path=to_snake_case` (`src/fraiseql/db.py:1764`, `src/fraiseql/db.py:2029`). A key written in GraphQL spelling — `measures.totalCost` — matched nothing, with no error and no warning.

## Changes

- `_normalize_aggregation_mapping_keys` normalizes every path-keyed entry now, not one: `native_dimension_mapping`, `measures` and `native_measures`, listed in `_PATH_KEYED_AGGREGATION_ENTRIES`. A fourth would be one line.
- The no-mutation contract is unchanged — a new dict comes back only when something actually changed, and the caller's nested dicts are never touched. A test pins that.

## Why the two measure dicts had to move together

Normalizing `native_measures` alone achieves nothing: a camelCase `measures` key derives no aggregation at all in `_derive_auto_aggregation`, so there would be no aggregation for the normalized `native_measures` entry to attach to. The end-to-end test is written to fail today for both reasons at once, as the issue asks.

## On the validation half

The issue also asks for registration-time validation of `native_measures` **values**. That is already in place — `_validate_aggregation_mapping` has included `native_measures` in its declarations since #467, raising under `validate_fk_strict=True` and warning otherwise. Rather than assume it, this PR pins it with a test; it is one of the two new tests that pass before the fix.

## Verification

- 4 of the 6 new tests fail on unpatched `src`. The two that pass are the no-mutation contract and the already-working value validation — which is what distinguishes what this change does from what was already true.
- The existing #467 casing tests (`tests/unit/test_group_by_native_dimension_mapping.py`) and validation tests (`tests/unit/test_aggregation_registration_validation.py`) pass unchanged, so the generalized helper still does exactly what it did for `native_dimension_mapping`.
- `uv run pytest tests/unit/ tests/integration/ -q` — 6017 passed, only the pre-existing `test_nested_organization_without_tenant_id` failure.
- `uv run ty check` — 538 diagnostics, unchanged from `dev`.
- `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N