### PR TITLE
test: stop DATABASE_URL leaking out of the example fixtures into unit tests

### DIFF
--- a/tests/fixtures/examples/conftest_examples.py
+++ b/tests/fixtures/examples/conftest_examples.py
@@ -221,7 +221,7 @@ async def blog_simple_context(blog_simple_repository) -> dict[str, Any]:
 
 
 @pytest_asyncio.fixture(scope="function", loop_scope="function")
-async def blog_simple_app(smart_dependencies, blog_simple_db_url) -> AsyncGenerator[Any, None]:
+async def blog_simple_app(smart_dependencies, blog_simple_db_url, monkeypatch) -> AsyncGenerator[Any, None]:
     """Create blog_simple app for testing with guaranteed dependencies."""
     import sys
     import importlib.util
@@ -235,13 +235,18 @@ async def blog_simple_app(smart_dependencies, blog_simple_db_url) -> AsyncGenera
 
     # Parse the test database URL and set individual env vars
     # The example uses DB_NAME, DB_USER, etc. not DATABASE_URL
+    # monkeypatch, not a bare assignment: these restore when the fixture ends.
+    # A bare os.environ[...] leaked DATABASE_URL into every later test in a full
+    # run, and `fraiseql query-stats` reads it as its --database-url default, so
+    # a unit test written to prove nothing was configured reached a real server
+    # instead (#470).
     parsed = urlparse(blog_simple_db_url)
-    os.environ["DATABASE_URL"] = blog_simple_db_url
-    os.environ["DB_NAME"] = parsed.path.lstrip("/")
-    os.environ["DB_USER"] = parsed.username or "fraiseql"
-    os.environ["DB_PASSWORD"] = parsed.password or "fraiseql"
-    os.environ["DB_HOST"] = parsed.hostname or "localhost"
-    os.environ["DB_PORT"] = str(parsed.port or 5432)
+    monkeypatch.setenv("DATABASE_URL", blog_simple_db_url)
+    monkeypatch.setenv("DB_NAME", parsed.path.lstrip("/"))
+    monkeypatch.setenv("DB_USER", parsed.username or "fraiseql")
+    monkeypatch.setenv("DB_PASSWORD", parsed.password or "fraiseql")
+    monkeypatch.setenv("DB_HOST", parsed.hostname or "localhost")
+    monkeypatch.setenv("DB_PORT", str(parsed.port or 5432))
 
     try:
         # Force fresh module load using importlib (bypass Python cache)
@@ -345,7 +350,7 @@ async def blog_enterprise_db_url(smart_dependencies) -> AsyncGenerator[str, None
 
 @pytest_asyncio.fixture(scope="function", loop_scope="function")
 async def blog_enterprise_app(
-    smart_dependencies, blog_enterprise_db_url
+    smart_dependencies, blog_enterprise_db_url, monkeypatch
 ) -> AsyncGenerator[Any, None]:
     """Create blog_enterprise app for testing with guaranteed dependencies."""
     import sys
@@ -360,13 +365,18 @@ async def blog_enterprise_app(
 
     # Parse the test database URL and set individual env vars
     # The example uses DB_NAME, DB_USER, etc. not DATABASE_URL
+    # monkeypatch, not a bare assignment: these restore when the fixture ends.
+    # A bare os.environ[...] leaked DATABASE_URL into every later test in a full
+    # run, and `fraiseql query-stats` reads it as its --database-url default, so
+    # a unit test written to prove nothing was configured reached a real server
+    # instead (#470).
     parsed = urlparse(blog_enterprise_db_url)
-    os.environ["DATABASE_URL"] = blog_enterprise_db_url
-    os.environ["DB_NAME"] = parsed.path.lstrip("/")
-    os.environ["DB_USER"] = parsed.username or "fraiseql"
-    os.environ["DB_PASSWORD"] = parsed.password or "fraiseql"
-    os.environ["DB_HOST"] = parsed.hostname or "localhost"
-    os.environ["DB_PORT"] = str(parsed.port or 5432)
+    monkeypatch.setenv("DATABASE_URL", blog_enterprise_db_url)
+    monkeypatch.setenv("DB_NAME", parsed.path.lstrip("/"))
+    monkeypatch.setenv("DB_USER", parsed.username or "fraiseql")
+    monkeypatch.setenv("DB_PASSWORD", parsed.password or "fraiseql")
+    monkeypatch.setenv("DB_HOST", parsed.hostname or "localhost")
+    monkeypatch.setenv("DB_PORT", str(parsed.port or 5432))
 
     try:
         # Force fresh module load using importlib (bypass Python cache)

--- a/tests/unit/cli/test_query_stats_command.py
+++ b/tests/unit/cli/test_query_stats_command.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from fraiseql.cli.commands.query_stats import query_stats
@@ -222,7 +223,13 @@ class TestQueryStatsReset:
 class TestQueryStatsRequiresUrl:
     """Test that --database-url is required."""
 
-    def test_fails_without_database_url(self) -> None:
+    def test_fails_without_database_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The option declares envvar="DATABASE_URL", so with one set in the
+        # environment the CLI connects instead of reporting the missing
+        # argument. Stated here as well as in tests/unit/conftest.py so the
+        # precondition travels with the test (#470).
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
         runner = CliRunner()
         result = runner.invoke(query_stats, [])
         assert result.exit_code != 0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,22 @@
+"""Unit-test isolation from the ambient environment (issue #470).
+
+A unit test must not be able to reach a database. ``fraiseql query-stats``
+declares ``envvar="DATABASE_URL"`` on its ``--database-url`` option, so with that
+variable set in the process environment the CLI does not stop at the missing
+argument — it connects to whatever server the URL names and fails further in.
+
+That is not hypothetical: the variable was leaking out of the example app
+fixtures, which set it with a bare ``os.environ[...] = ...`` and never restored
+it, so every later test in a full run inherited it. Those fixtures now use
+``monkeypatch.setenv``; this clears the variable for the whole unit suite as
+well, so a future writer anywhere cannot quietly give a unit test a live
+database again.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset ``DATABASE_URL`` for every unit test, however it got set."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)


### PR DESCRIPTION
Closes #470.

## Reproduction

```
DATABASE_URL=postgresql://… uv run pytest tests/unit/ -q
```

Before: `1 failed, 3540 passed`. After: `3541 passed`.

The failing test is `TestQueryStatsRequiresUrl::test_fails_without_database_url`, and the failure output shows what the issue describes — the CLI did not stop at the missing argument, it connected to a real server:

```
assert 'database-url' in "pg_stat_statements extension is not available. …"
```

`--database-url` declares `envvar="DATABASE_URL"` (`src/fraiseql/cli/commands/query_stats.py:170`), so an ambient value is silently accepted as the argument.

## The writers

`blog_simple_app` and `blog_enterprise_app` in `tests/fixtures/examples/conftest_examples.py`. Each sets **six** variables with a bare `os.environ[...] = ...` and never restores them — `DATABASE_URL`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`. Every later test in the run inherits all six; `DATABASE_URL` is just the one with a consumer loud enough to notice.

## Changes

- Both fixtures use `monkeypatch.setenv`, which restores on teardown. They are function-scoped, so the plain `monkeypatch` fixture is exactly right. All six variables.
- New `tests/unit/conftest.py` clears `DATABASE_URL` for every unit test. A unit test must not be able to reach a database, whoever set the variable and however it arrived — a future writer elsewhere, or the developer's own shell.
- The CLI test states the precondition itself as well, so it travels with the test if it ever moves out of `tests/unit/`.

Two mechanisms because they cover different things: the fixture fix stops the leak at the source, so `tests/system/` and `tests/integration/` benefit too; the conftest guard makes the unit suite immune regardless of what any future fixture does.

## Scope check

One unit test is exposed, not several. `query_stats` is the only option in `src/fraiseql/cli/` declaring `envvar="DATABASE_URL"` (grep), and running the whole unit suite with the variable set produces exactly that one failure.

## Verification

- `DATABASE_URL=… uv run pytest tests/unit/ -q` — 1 failed before the change, 3541 passed after.
- `uv run pytest tests/unit/ tests/integration/ -q` — 5988 passed, identical to `dev`, only the pre-existing `test_nested_organization_without_tenant_id` failure. This PR adds no tests; it removes a cross-test dependency, so an unchanged count is the expected result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N