### PR TITLE
chore(deps): drop aiosqlite, a core dependency with no importer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ dependencies = [
   "python-dotenv>=1.2.2",
   "structlog>=25.5.0",
   "passlib[argon2]>=1.7.4",
-  "aiosqlite>=0.22.1",
   "typer>=0.24.0",
   "rich>=14.0.0",
   "pyyaml>=6.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -715,7 +715,6 @@ wheels = [
 
 [[package]]
 dependencies = [
-  {name = "aiosqlite"},
   {name = "click"},
   {name = "cryptography"},
   {name = "fastapi"},
@@ -781,7 +780,6 @@ requires-dist = [
   {name = "aioboto3", marker = "extra == 'kms-all'", specifier = ">=15.5.0"},
   {name = "aioboto3", marker = "extra == 'kms-aws'", specifier = ">=15.5.0"},
   {name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.14.3"},
-  {name = "aiosqlite", specifier = ">=0.22.1"},
   {name = "banks", marker = "extra == 'llamaindex'", specifier = ">=2.4.2"},
   {name = "black", marker = "extra == 'dev'", specifier = ">=26.5.1"},
   {name = "boto3", marker = "extra == 'all'", specifier = ">=1.38.0"},


### PR DESCRIPTION
Closes #474.

`aiosqlite>=0.22.1` was declared in `[project.dependencies]` — a **core** dependency, installed by every `pip install fraiseql` and present in every container image — and nothing imports it.

## The check the issue asks for

Across the whole repository, the string `aiosqlite` appeared **exactly once**: the declaration itself. Not in `src/`, `tests/`, `examples/` or `scripts/`, and no optional extra referenced it. Almost certainly vestigial from the multi-database ambition v1 dropped; v1 is PostgreSQL-only.

## Changes

- Removed the declaration from `[project.dependencies]`.
- Removed the two corresponding lines from `uv.lock` — the entry in fraiseql's `dependencies` list and in its `requires-dist` metadata.

The `[[package]] aiosqlite` block itself stays, because `llama-index-core` depends on it, so the `llamaindex` extra still resolves. That is the point of the change: aiosqlite may legitimately arrive as somebody else's transitive dependency, but it should not be part of fraiseql's own declared surface.

## A note on the lock file

`uv sync` rewrote 4870 lines of `uv.lock` as format churn (uv 0.9.18 expands what an older uv wrote compactly), which would have made the real change unreviewable. The lock is edited by hand to the three lines that actually change, and `uv lock --check` confirms it still resolves cleanly against `pyproject.toml`.

## Verification

- `uv lock --check` — resolved 258 packages, no drift.
- `uv pip install -e ".[dev,all,langchain,llamaindex]"` (what CI does, plus the integration extras) then `uv run pytest tests/unit/ tests/integration/ -q` — **5988 passed, 2 skipped**, identical to `dev`, only the pre-existing `test_nested_organization_without_tenant_id` failure. In particular the LlamaIndex and LangChain integration tests still run rather than skipping, so the extras still resolve.

## Related

#473 — `src/fraiseql/security/startup_checks.py` documents a SQLite mitigation and is never called. It is the other half of "why is SQLite a live question here at all".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N