### PR TITLE
fix(rust): make the benches compile and run, and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,12 @@ jobs:
       - name: Build (verify compilation)
         run: cargo build --manifest-path fraiseql_rs/Cargo.toml --all-features
 
+      # Neither clippy nor build above compiles the bench targets, so the benches
+      # drifted past the API they call and nothing noticed (#471). This is the
+      # step that keeps them building.
+      - name: Check all targets (benches and test binaries)
+        run: cargo check --manifest-path fraiseql_rs/Cargo.toml --all-targets --all-features
+
   ci-success:
     name: CI Success
     needs: [lint, type-check, unit-tests, integration-tests, build-extension]

--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -24,6 +24,12 @@ name = "memory"
 harness = false
 name = "core_benchmark"
 
+[[bench]]
+# Without harness = false cargo builds this against the default libtest harness,
+# criterion_main! never runs, and the target reports "running 0 tests" (#471).
+harness = false
+name = "mutation_benchmark"
+
 [build-dependencies]
 # Detect CPU features at compile time
 target-features = "0.1"

--- a/fraiseql_rs/benches/mutation_benchmark.rs
+++ b/fraiseql_rs/benches/mutation_benchmark.rs
@@ -19,6 +19,7 @@ fn benchmark_simple_format(c: &mut Criterion) {
                 true,
                 None,
                 None,
+                None,
             )
         })
     });
@@ -48,6 +49,7 @@ fn benchmark_full_format_with_cascade(c: &mut Criterion) {
                 Some("User"),
                 None,
                 true,
+                None,
                 None,
                 None,
             )
@@ -80,6 +82,7 @@ fn benchmark_error_response(c: &mut Criterion) {
                 true,
                 None,
                 None,
+                None,
             )
         })
     });
@@ -103,6 +106,7 @@ fn benchmark_array_entities(c: &mut Criterion) {
                 Some("User"),
                 None,
                 true,
+                None,
                 None,
                 None,
             )

--- a/fraiseql_rs/benches/streaming.rs
+++ b/fraiseql_rs/benches/streaming.rs
@@ -4,6 +4,7 @@
 //! Real streaming benchmarks will be added in Phase 3.
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::time::Duration;
 
 /// Benchmark JSON field name transformation
 fn bench_field_transformation(c: &mut Criterion) {
@@ -16,8 +17,8 @@ fn bench_field_transformation(c: &mut Criterion) {
             |b, &field_count| {
                 b.iter(|| {
                     // Simulate transforming N field names from snake_case to camelCase
-                    let mut transformed = Vec::with_capacity(*field_count);
-                    for i in 0..*field_count {
+                    let mut transformed = Vec::with_capacity(field_count);
+                    for i in 0..field_count {
                         let snake = format!("field_name_{}", i);
                         // Simple simulation of transformation
                         let camel = snake.replace("_", "");
@@ -43,8 +44,8 @@ fn bench_response_serialization(c: &mut Criterion) {
             |b, &object_count| {
                 b.iter(|| {
                     // Simulate serializing N objects to JSON
-                    let mut json_strings = Vec::with_capacity(*object_count);
-                    for i in 0..*object_count {
+                    let mut json_strings = Vec::with_capacity(object_count);
+                    for i in 0..object_count {
                         let json = format!(r#"{{"id": {}, "name": "Item {}"}}"#, i, i);
                         json_strings.push(json);
                     }
@@ -68,7 +69,7 @@ fn bench_chunked_processing(c: &mut Criterion) {
             |b, &chunk_size| {
                 b.iter(|| {
                     // Simulate processing data in chunks
-                    let data = vec![42u8; *chunk_size];
+                    let data = vec![42u8; chunk_size];
                     let mut checksum = 0u64;
                     for &byte in &data {
                         checksum = checksum.wrapping_add(byte as u64);


### PR DESCRIPTION
Closes #471.

`cargo check --all-targets` was red on `dev` and nothing noticed: the Rust job runs `cargo clippy --all-features` and `cargo build --all-features`, and **neither builds bench targets**.

Reproduced exactly as reported — 4 errors in `mutation_benchmark`, 6 in `streaming`.

## The compile errors

- **`benches/mutation_benchmark.rs`** — four calls to `build_mutation_response` passed 10 of its 11 arguments. The function grew `entity_selections: Option<&str>` and the bench was never updated.
- **`benches/streaming.rs`** — `use std::time::Duration` was missing, and five in-closure dereferences were stale: criterion hands the parameter over by value through the `|b, &param|` pattern.

One thing worth flagging for review: the file has **seven** `*param` uses, not five. The two at lines 39 and 64 are correct — they sit in the `for x in [...].iter()` loop where the binding really *is* a reference. A blanket replace would have broken them; only the five inside the closures are changed.

## The bench that compiled and measured nothing

`mutation_benchmark` was the one bench file with no `[[bench]]` entry in `Cargo.toml`, so cargo built it against the default libtest harness, `criterion_main!` never ran, and the target reported:

```
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```

Fixing only the compile error would have left a benchmark that still measures nothing, so it is registered with `harness = false`. All four of its benchmarks now execute.

## The gate

New CI step: `cargo check --manifest-path fraiseql_rs/Cargo.toml --all-targets --all-features`.

**Why `check` and not `clippy --all-targets`.** `cargo clippy --all-targets --all-features -- -D warnings` is red on `dev` with roughly 104 errors across the lib-test target, six benches and two integration test binaries — `expect_used` ×16, `panic` ×9, `field_reassign_with_default` ×5, `approx_constant` ×4 and so on. That is lint debt in test and bench code and a much larger separate change; proposing it here would put a permanently red check into CI, which is the thing the issue warns against. `cargo check --all-targets` catches the defect this issue is about and is green.

## Verification

- `cargo check --all-targets --all-features` — 10 errors across two bench targets before, clean after.
- `cargo bench --bench mutation_benchmark -- --test` — 4 benchmarks run and pass (`simple_format`, `full_format_cascade`, `error_response`, `array_entities`). This is what proves the 11th argument is *correct*, not merely present.
- `cargo bench --bench streaming -- --test` — all benchmarks run and pass.
- `cargo fmt --check` and `cargo clippy --all-features -- -D warnings` still clean.

## Found while verifying, filed separately

`fraiseql_rs/tests/{common,integration,unit,e2e}/` contain only a `mod.rs` each and no top-level test file declares them, so **cargo builds none of them** — `cargo metadata` lists seven test targets and none is from those directories. The dead `TestDatabase` scaffolding the issue mentions lives there. The new `--all-targets` gate will not cover that tree, because it is not targets. Issue to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N