### PR TITLE
feat(sql): apply default_string_collation to text fields, with the type plumbing it needed

### DIFF
--- a/docs/core/queries-and-mutations.md
+++ b/docs/core/queries-and-mutations.md
@@ -302,9 +302,12 @@ query {
 
 1. Per-field explicit value (highest priority)
 2. Explicit `null`
-3. PostgreSQL database default (lowest priority)
+3. `default_string_collation` from config, on text fields only
+4. PostgreSQL database default (lowest priority)
 
-`default_string_collation` is not part of this chain today -- see the warning above.
+Step 3 applies only where the sort key resolves to a string on the type
+registered for the view; anything else, including a field that cannot be
+resolved, falls straight through to step 4.
 
 **Common Collations**:
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -533,12 +533,11 @@ extensions; `"postgis"` is the most accurate but requires the PostGIS extension.
 PostgreSQL collation applied to text `ORDER BY` clauses, e.g. `"fr_FR.utf8"` or
 `"C"`.
 
-!!! warning "Not currently applied"
-    This setting has no effect yet. Applying it safely needs field *types* in the
-    ORDER BY builder, which does not distinguish a text field from a numeric one --
-    and collating a numeric field either sorts it lexicographically or fails
-    outright. Only a per-field collation reaches the SQL today. This has always
-    been its effective behaviour.
+Applied to text fields only. The ORDER BY builder resolves each sort key
+against the type registered for the view, and a field it cannot resolve to a
+string is left alone -- collating a numeric field would either sort it
+lexicographically (1, 10, 2) or fail outright. A per-field collation always
+wins over this default.
 
 ### `session_variables`
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -122,12 +122,13 @@ config = FraiseQLConfig(
 
 Applied to all text fields in ORDER BY unless overridden per-field in queries.
 
-!!! warning "Not currently applied"
-    This setting has no effect yet. Applying it safely needs field *types* in the
-    ORDER BY builder, which does not distinguish a text field from a numeric one --
-    and collating a numeric field either sorts it lexicographically or fails
-    outright. Only a per-field collation reaches the SQL today. This has always
-    been its effective behaviour.
+!!! note "Text fields only"
+    Each sort key is resolved against the type registered for the view, and the
+    default is applied only to fields that resolve to a string. A field that
+    resolves to anything else -- or that cannot be resolved at all, because the
+    view is unregistered or the field is not declared on its type -- is left
+    alone. Collating a numeric field would either sort it lexicographically
+    (1, 10, 2) or fail with *collations are not supported by type integer*.
 
 **Common Values**:
 

--- a/src/fraiseql/db.py
+++ b/src/fraiseql/db.py
@@ -1925,7 +1925,7 @@ class FraiseQLRepository:
             union_native_measures = kwargs.get("native_measures")
             union_native_dim_mapping = kwargs.get("native_dimension_mapping")
             union_jsonb_col = jsonb_column or "data"
-            union_order_by = self._resolve_order_by_set(kwargs.get("order_by"))
+            union_order_by = self._resolve_order_by_set(kwargs.get("order_by"), view_name)
 
             query = _build_partial_period_union_query(
                 coarse_view=view_name,
@@ -2946,7 +2946,7 @@ class FraiseQLRepository:
             f"Available views: {available_views}. Registry size: {len(_type_registry)}",
         )
 
-    def _resolve_order_by_set(self, order_by: Any) -> Any | None:
+    def _resolve_order_by_set(self, order_by: Any, view_name: str | None = None) -> Any | None:
         """Normalise any accepted ``order_by`` shape to an ``OrderBySet``.
 
         Three shapes reach the repository — an ``OrderBySet``, a GraphQL
@@ -2972,8 +2972,14 @@ class FraiseQLRepository:
                     _convert_order_by_input_to_sql,
                 )
 
+                # The dict and list shapes carry field names and nothing else,
+                # so the view's registered type is what tells the collation
+                # resolver which of them are text (#482). An unregistered view
+                # resolves to None, which leaves every collation alone.
                 order_set = _convert_order_by_input_to_sql(
-                    order_set, config=self.context.get("config")
+                    order_set,
+                    config=self.context.get("config"),
+                    source_type=_type_registry.get(view_name) if view_name else None,
                 )
             else:
                 # Raw SQL string, or something unrecognised — the caller handles it
@@ -2989,6 +2995,7 @@ class FraiseQLRepository:
         table_ref: str,
         native_columns: set[str] | None = None,
         column_mapping: dict[str, str] | None = None,
+        view_name: str | None = None,
     ) -> tuple[Any | None, bool]:
         """Resolve any accepted ``order_by`` shape to SQL, once, for every shape.
 
@@ -3002,7 +3009,7 @@ class FraiseQLRepository:
             the caller must ensure the FROM clause carries that alias; raw string
             ``order_by`` is passed through untouched and reports ``(None, False)``.
         """
-        order_set = self._resolve_order_by_set(order_by)
+        order_set = self._resolve_order_by_set(order_by, view_name)
         if order_set is None:
             return None, False
 
@@ -3084,6 +3091,7 @@ class FraiseQLRepository:
             table_ref,
             native_columns=native_dimensions or None,
             column_mapping=native_dimension_mapping,
+            view_name=view_name,
         )
 
         table_identifier = qualified_identifier(view_name)

--- a/src/fraiseql/fastapi/config.py
+++ b/src/fraiseql/fastapi/config.py
@@ -323,13 +323,12 @@ class FraiseQLConfig(BaseSettings):
     default_string_collation: str | None = None
     """Default PostgreSQL collation for string ORDER BY clauses.
 
-    .. warning::
-       Not currently applied. Honouring it needs field *types* plumbed into the
-       ORDER BY builder, because nothing there distinguishes a text field from a
-       numeric one -- and collating a numeric field either sorts it
-       lexicographically or fails outright. Until then only a per-field
-       collation reaches the SQL; see ``_apply_collation_default``. This has
-       always been its effective behaviour, so nothing changed in #476.
+    Applied to text fields only. Each sort key is resolved against the type
+    registered for the view, and anything that does not resolve to ``str`` is
+    left alone -- collating a numeric field either sorts it lexicographically
+    (1, 10, 2) or fails with "collations are not supported by type integer".
+    A per-field collation always wins over this default; see
+    ``_apply_collation_default``.
 
     Examples:
     - "en_US.utf8" - US English locale-aware sorting

--- a/src/fraiseql/sql/graphql_order_by_generator.py
+++ b/src/fraiseql/sql/graphql_order_by_generator.py
@@ -7,6 +7,7 @@ automatically converted to SQL ORDER BY clauses.
 
 import warnings
 from dataclasses import make_dataclass
+from functools import lru_cache
 from typing import Any, Optional, TypeVar, Union, get_args, get_origin, get_type_hints
 
 from fraiseql import fraise_input
@@ -124,59 +125,140 @@ def _normalize_order_direction(direction: Any) -> OrderDirection:
     return OrderDirection.ASC  # Default
 
 
+def _unwrap_annotation(annotation: Any, *, into_list: bool) -> Any:
+    """Strip ``| None`` to reach the annotation that carries a type.
+
+    ``into_list`` also steps inside ``list[X]``. That is right while *walking*
+    a dotted path — ``posts.title`` has to reach ``Post`` through
+    ``list[Post]`` — and wrong at the leaf, where ``list[str]`` is an array and
+    not a text field: sorting by one collates the serialized JSON array, which
+    is meaningless rather than merely useless.
+    """
+    import types as _types
+
+    origin = get_origin(annotation)
+    if origin is Union or (
+        hasattr(_types, "UnionType") and isinstance(annotation, _types.UnionType)
+    ):
+        non_none = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if not non_none:
+            return None
+        return _unwrap_annotation(non_none[0], into_list=into_list)
+
+    if into_list and origin is list:
+        args = get_args(annotation)
+        return _unwrap_annotation(args[0], into_list=into_list) if args else None
+
+    return annotation
+
+
+@lru_cache(maxsize=2048)
+def _resolve_field_type(source_type: Any, path: tuple[str, ...]) -> Any | None:
+    """Walk a dotted sort path through ``source_type``'s annotations.
+
+    Returns the annotation the leaf segment names, or ``None`` when any segment
+    cannot be resolved — an unregistered view, a container like the aggregation
+    ``dimensions`` prefix that is not a declared field, or a class whose hints
+    do not evaluate. ``None`` is the answer that leaves the collation alone, so
+    every unknown is conservative by construction.
+    """
+    current: Any = source_type
+    last = len(path) - 1
+    for index, segment in enumerate(path):
+        if current is None or not isinstance(current, type):
+            return None
+        try:
+            hints = get_type_hints(current)
+        except Exception:
+            return None
+        annotation = hints.get(segment)
+        if annotation is None:
+            return None
+        current = _unwrap_annotation(annotation, into_list=index < last)
+    return current
+
+
+def _is_text_field(source_type: Any, dotted_path: str) -> bool:
+    """Whether a sort key names a field the database will hold as text.
+
+    Only ``str`` counts. The global default exists to make text sort by locale,
+    and a collation on anything else is either a silent wrong answer (a numeric
+    JSONB field sorts 1, 10, 2) or an outright error ("collations are not
+    supported by type integer"). So the question is not "might this be text" but
+    "is this certainly text", and everything unresolved answers no (#482).
+    """
+    if source_type is None:
+        return False
+    return _resolve_field_type(source_type, tuple(dotted_path.split("."))) is str
+
+
+def _source_type_of(order_by_input: Any) -> Any | None:
+    """The type a generated order-by input was built for, if this is one."""
+    return getattr(type(order_by_input), "_target_class", None)
+
+
 def _apply_collation_default(
     field_collation: str | None,
     global_collation: str | None,
     was_explicitly_set: bool = False,
+    is_text_field: bool = False,
 ) -> str | None:
     """Resolve the collation for one sort key. The single place that decides.
 
     Precedence:
     1. Per-field explicit value, including an explicit None
-    2. Nothing -- the database default
+    2. ``default_string_collation`` from config, on text fields only
+    3. Nothing -- the database default
 
-    Why the global default is dropped
-    ---------------------------------
-    ``default_string_collation`` is documented as applying to "all *text* fields",
-    but nothing here tracks which fields are text: it was applied to every field,
-    numeric ones included. That was harmless only for as long as a collation
-    never reached the sort. Since #476 one does, and honouring a blanket default
-    would now
+    Why the default is restricted to text
+    -------------------------------------
+    ``default_string_collation`` is documented as applying to "all *text*
+    fields". Nothing in the order_by pipeline tracked which fields were text, so
+    it was applied to every field, numeric ones included. That was harmless only
+    while a collation never reached the sort; since #476 one does, and a blanket
+    default would
 
     * make a numeric JSONB sort lexicographic -- 1, 10, 2 -- silently, and
-    * make a numeric flat column fail outright with
-      "collations are not supported by type integer".
+    * make a numeric flat column fail with "collations are not supported by
+      type integer".
 
-    Dropping it leaves the setting exactly as effective as it has always been,
-    which is not at all, so this is a no-op for every existing deployment. The
-    parameter stays because making the setting work needs field *types* plumbed
-    down to here, and that is the change that will use it.
+    So #481 dropped the default rather than ship either, and #482 supplies what
+    was missing: ``is_text_field``, resolved from the view's registered type by
+    :func:`_is_text_field`. Anything that cannot be resolved to ``str`` answers
+    False, so an unknown field keeps the behaviour it has had all along.
 
     Args:
         field_collation: Collation from field/input
-        global_collation: Global default from config; deliberately not applied
+        global_collation: Global default from config
         was_explicitly_set: True if field_collation was explicitly set
                            (even if set to None)
+        is_text_field: True only when the sort key is known to name a text field
 
     Returns:
         Collation to use, or None for database default
 
     Examples:
-        # Explicit per-field value
-        _apply_collation_default("en_US.utf8", "fr_FR.utf8", True) -> "en_US.utf8"
+        # Explicit per-field value wins over the default
+        _apply_collation_default("en_US.utf8", "fr_FR.utf8", True, True) -> "en_US.utf8"
 
-        # Explicit None
-        _apply_collation_default(None, "fr_FR.utf8", True) -> None
+        # Explicit None wins too: it asks for the database default
+        _apply_collation_default(None, "fr_FR.utf8", True, True) -> None
 
-        # No field value: the global default is not applied
-        _apply_collation_default(None, "fr_FR.utf8", False) -> None
+        # No field value, text field: the global default applies
+        _apply_collation_default(None, "fr_FR.utf8", False, True) -> "fr_FR.utf8"
+
+        # No field value, not known to be text: left alone
+        _apply_collation_default(None, "fr_FR.utf8", False, False) -> None
 
         # No field value, no global default
-        _apply_collation_default(None, None, False) -> None
+        _apply_collation_default(None, None, False, True) -> None
     """
-    # Only a collation the caller asked for on this field reaches the SQL.
+    # A collation the caller asked for on this field always wins.
     if was_explicitly_set:
         return field_collation
+
+    if is_text_field:
+        return global_collation
 
     return None
 
@@ -211,6 +293,8 @@ def _collect_dict_order_by(
     obj_dict: dict[str, Any],
     instructions: list[OrderBy],
     prefix: str = "",
+    global_collation: str | None = None,
+    source_type: Any = None,
 ) -> None:
     """Walk a dict-shaped ``order_by``, appending one ``OrderBy`` per leaf.
 
@@ -234,14 +318,26 @@ def _collect_dict_order_by(
 
         # Nested object: recurse so the leaf carries the full dotted path.
         if isinstance(value, dict):
-            _collect_dict_order_by(value, instructions, field_path)
+            _collect_dict_order_by(value, instructions, field_path, global_collation, source_type)
         # A VectorOrderBy names the distance operator it wants.
         elif _is_vector_order_by(value):
             _append_vector_order_by(value, field_path, instructions)
         # A direction: a string, an OrderDirection, or any enum-like carrying one.
         elif isinstance(value, (OrderDirection, str)) or hasattr(value, "value"):
+            # A dict carries no per-field collation, so only the configured
+            # default can apply here, and only to a field known to be text.
+            collation = _apply_collation_default(
+                None,
+                global_collation,
+                False,
+                _is_text_field(source_type, field_path),
+            )
             instructions.append(
-                OrderBy(field=field_path, direction=_normalize_order_direction(value))
+                OrderBy(
+                    field=field_path,
+                    direction=_normalize_order_direction(value),
+                    collation=collation,
+                )
             )
         else:
             # Defaulting to ASC here would mean "sorted by something else
@@ -254,12 +350,21 @@ def _collect_dict_order_by(
             )
 
 
-def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> OrderBySet | None:
+def _convert_order_by_input_to_sql(
+    order_by_input: Any, config: Any = None, source_type: Any = None
+) -> OrderBySet | None:
     """Convert GraphQL order by input to SQL OrderBySet with optional collation.
 
     Args:
         order_by_input: GraphQL OrderBy input (various formats)
         config: Optional FraiseQLConfig with default_string_collation
+        source_type: The type the sort paths are rooted in, used to decide which
+            fields are text so ``default_string_collation`` can apply to those
+            and nothing else (#482). A generated order-by input names its own
+            source type, so this only has to be supplied for the dict and list
+            shapes, which carry field names and nothing more. Omitted, the
+            configured default simply does not apply -- the behaviour every
+            shape had before.
 
     Returns:
         OrderBySet with collation applied per precedence rules
@@ -267,6 +372,10 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
     if order_by_input is None:
         return None
 
+    if source_type is None:
+        source_type = _source_type_of(order_by_input)
+
+    global_collation = config.default_string_collation if config else None
     instructions = []
 
     # Handle single OrderByItem
@@ -276,8 +385,12 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
         # Apply collation with precedence
         field_collation = getattr(order_by_input, "collation", None)
         was_explicit = hasattr(order_by_input, "collation")
-        global_collation = config.default_string_collation if config else None
-        collation = _apply_collation_default(field_collation, global_collation, was_explicit)
+        collation = _apply_collation_default(
+            field_collation,
+            global_collation,
+            was_explicit,
+            _is_text_field(source_type, order_by_input.field),
+        )
 
         instructions.append(
             OrderBy(field=order_by_input.field, direction=direction, collation=collation)
@@ -294,9 +407,11 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
                 # Apply collation with precedence
                 field_collation = getattr(item, "collation", None)
                 was_explicit = hasattr(item, "collation")
-                global_collation = config.default_string_collation if config else None
                 collation = _apply_collation_default(
-                    field_collation, global_collation, was_explicit
+                    field_collation,
+                    global_collation,
+                    was_explicit,
+                    _is_text_field(source_type, item.field),
                 )
 
                 instructions.append(
@@ -306,7 +421,7 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
             # A dict carries no per-field collation, so none is set -- see
             # _apply_collation_default.
             elif isinstance(item, dict):
-                _collect_dict_order_by(item, instructions)
+                _collect_dict_order_by(item, instructions, "", global_collation, source_type)
         return OrderBySet(instructions=instructions) if instructions else None
 
     # Handle object with field-specific order directions
@@ -333,10 +448,15 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
                     elif isinstance(value, (OrderDirection, str)):
                         direction = _normalize_order_direction(value)
 
-                        # No per-field override in this format, so this
-                        # resolves to None -- see _apply_collation_default.
-                        global_collation = config.default_string_collation if config else None
-                        collation = _apply_collation_default(None, global_collation, False)
+                        # No per-field override in this format, so only the
+                        # configured default can apply -- see
+                        # _apply_collation_default.
+                        collation = _apply_collation_default(
+                            None,
+                            global_collation,
+                            False,
+                            _is_text_field(source_type, field_path),
+                        )
 
                         instructions.append(
                             OrderBy(field=field_path, direction=direction, collation=collation)
@@ -349,7 +469,7 @@ def _convert_order_by_input_to_sql(order_by_input: Any, config: Any = None) -> O
 
     # Handle plain dict (common from GraphQL frameworks)
     elif isinstance(order_by_input, dict):
-        _collect_dict_order_by(order_by_input, instructions)
+        _collect_dict_order_by(order_by_input, instructions, "", global_collation, source_type)
 
     return OrderBySet(instructions=instructions) if instructions else None
 

--- a/tests/integration/database/sql/test_order_by_collation_default_execution.py
+++ b/tests/integration/database/sql/test_order_by_collation_default_execution.py
@@ -1,0 +1,204 @@
+"""Issue #482: the configured collation default, executed against a live database.
+
+#481 made an *explicit* per-field collation work on every path and deliberately
+left ``default_string_collation`` inert, because nothing in the order_by
+pipeline tracked field types and a blanket default would have produced
+
+* a silently lexicographic sort for a numeric JSONB field -- 1, 10, 2 -- and
+* ``ERROR: collations are not supported by type integer`` for a numeric flat
+  column.
+
+Both of those are why this needs a live database rather than a text assertion.
+The first does not error, so only the returned order can tell; the second only
+errors at the server. So these tests run the whole repository path -- config,
+view registry, type resolution, SQL generation -- and look at what PostgreSQL
+gives back.
+"""
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from psycopg.sql import SQL
+
+from fraiseql.db import FraiseQLRepository, _table_metadata, _type_registry, register_type_for_view
+from fraiseql.types import fraise_type
+
+pytestmark = [pytest.mark.integration, pytest.mark.database]
+
+VIEW = "v_482_docs"
+
+# Byte order puts uppercase first; a linguistic collation orders
+# case-insensitively. Rows that disagree prove the collation reached the sort.
+NAMES = ["a", "B", "c"]
+BYTE_ORDER = ["B", "a", "c"]
+
+# Lexicographic text order would be 1, 10, 2.
+AMOUNTS = [2, 10, 1]
+
+
+@fraise_type
+class _Doc:
+    """The registered type: how the collation resolver learns which field is text."""
+
+    id: uuid.UUID
+    name: str
+    amount: int
+
+
+async def _linguistic_collation(pool: Any) -> str | None:
+    """A collation on this server that disagrees with ``"C"`` about case."""
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        for candidate in ("en-US-x-icu", "und-x-icu", "en_US.utf8", "en_US.UTF-8"):
+            await cursor.execute(
+                "SELECT 1 FROM pg_collation WHERE collname = %s LIMIT 1", (candidate,)
+            )
+            if await cursor.fetchone() is None:
+                continue
+            try:
+                await cursor.execute(
+                    SQL("SELECT v FROM unnest(%s::text[]) AS s(v) ORDER BY v COLLATE {}").format(
+                        SQL('"{}"'.format(candidate.replace('"', '""')))
+                    ),
+                    (NAMES,),
+                )
+            except Exception:
+                await conn.rollback()
+                continue
+            if [r[0] for r in await cursor.fetchall()] != BYTE_ORDER:
+                return candidate
+            await conn.rollback()
+    return None
+
+
+class _Config:
+    """Stand-in for the one FraiseQLConfig attribute this path reads."""
+
+    def __init__(self, collation: str | None) -> None:
+        self.default_string_collation = collation
+
+
+@pytest.fixture
+async def docs_table(class_db_pool, test_schema) -> AsyncIterator[None]:
+    """The same values as flat columns and inside JSONB, with the view registered."""
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {test_schema}")
+        await cursor.execute(
+            f"CREATE TABLE IF NOT EXISTS {VIEW} "
+            f"(id UUID PRIMARY KEY, name TEXT NOT NULL, amount INT NOT NULL, data JSONB NOT NULL)"
+        )
+        for name, amount in zip(NAMES, AMOUNTS, strict=True):
+            await cursor.execute(
+                f"INSERT INTO {VIEW} (id, name, amount, data) VALUES (%s, %s, %s, %s::jsonb)",
+                (uuid.uuid4(), name, amount, f'{{"name": "{name}", "amount": {amount}}}'),
+            )
+        await conn.commit()
+
+    register_type_for_view(VIEW, _Doc, table_columns={"id", "name", "amount", "data"})
+
+    yield
+
+    for registry in (_table_metadata, _type_registry):
+        registry.pop(VIEW, None)
+
+    async with class_db_pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {test_schema}")
+        await cursor.execute(f"DROP TABLE IF EXISTS {VIEW} CASCADE")
+        await conn.commit()
+
+
+async def _run(pool: Any, schema: str, order_by: Any, collation: str | None, **kwargs) -> list:
+    """Build the query the way the repository does, then execute it."""
+    repo = FraiseQLRepository(pool, context={"config": _Config(collation)})
+    query = repo._build_find_query(VIEW, order_by=order_by, jsonb_column="data", **kwargs)
+
+    async with pool.connection() as conn, conn.cursor() as cursor:
+        await cursor.execute(f"SET search_path TO {schema}")
+        await cursor.execute(query.statement, query.params)
+        return [row[0] for row in await cursor.fetchall()]
+
+
+# The repository always selects ``jsonb_column::text`` -- Rust does the field
+# projection, not PostgreSQL -- so each row arrives as a JSON string.
+def _names(rows: list) -> list[str]:
+    return [json.loads(row)["name"] for row in rows]
+
+
+def _amounts(rows: list) -> list[int]:
+    return [json.loads(row)["amount"] for row in rows]
+
+
+class TestDefaultReachesTextFields:
+    """The setting finally does what it has always documented."""
+
+    async def test_default_changes_the_order_of_a_text_field(
+        self, class_db_pool, test_schema, docs_table
+    ) -> None:
+        linguistic = await _linguistic_collation(class_db_pool)
+        if linguistic is None:
+            pytest.skip('no collation on this server disagrees with "C" about case')
+
+        byte = _names(await _run(class_db_pool, test_schema, {"name": "ASC"}, "C"))
+        ling = _names(await _run(class_db_pool, test_schema, {"name": "ASC"}, linguistic))
+
+        assert byte == BYTE_ORDER
+        assert ling != byte, f"the configured default {linguistic!r} did not reach the sort"
+
+    async def test_no_default_leaves_the_database_collation(
+        self, class_db_pool, test_schema, docs_table
+    ) -> None:
+        rows = _names(await _run(class_db_pool, test_schema, {"name": "ASC"}, None))
+
+        assert sorted(rows) == sorted(NAMES)
+
+
+class TestDefaultDoesNotReachNonTextFields:
+    """The two failures #481 refused to ship."""
+
+    async def test_numeric_jsonb_field_stays_numeric(
+        self, class_db_pool, test_schema, docs_table
+    ) -> None:
+        """A blanket default makes this 1, 10, 2 -- silently, with no error."""
+        amounts = _amounts(await _run(class_db_pool, test_schema, {"amount": "ASC"}, "C"))
+
+        assert amounts == [1, 2, 10]
+
+    async def test_numeric_flat_column_does_not_error(
+        self, class_db_pool, test_schema, docs_table
+    ) -> None:
+        """A blanket default fails outright: collations are not supported by type integer."""
+        amounts = _amounts(
+            await _run(
+                class_db_pool,
+                test_schema,
+                {"amount": "ASC"},
+                "C",
+                native_dimensions={"amount"},
+            )
+        )
+
+        assert amounts == [1, 2, 10]
+
+    async def test_text_flat_column_still_gets_the_default(
+        self, class_db_pool, test_schema, docs_table
+    ) -> None:
+        """The flat-column path must collate text even though it must not collate integers."""
+        linguistic = await _linguistic_collation(class_db_pool)
+        if linguistic is None:
+            pytest.skip('no collation on this server disagrees with "C" about case')
+
+        byte = _names(
+            await _run(
+                class_db_pool, test_schema, {"name": "ASC"}, "C", native_dimensions={"name"}
+            )
+        )
+        ling = _names(
+            await _run(
+                class_db_pool, test_schema, {"name": "ASC"}, linguistic, native_dimensions={"name"}
+            )
+        )
+
+        assert byte == BYTE_ORDER
+        assert ling != byte

--- a/tests/unit/sql/test_order_by_collation_default.py
+++ b/tests/unit/sql/test_order_by_collation_default.py
@@ -1,0 +1,182 @@
+"""Issue #482: default_string_collation applies, to text fields only.
+
+The setting is documented as applying to "all *text* fields in ORDER BY unless
+overridden per-field", was validated against SQL injection, and had never
+reached a query. #481 made an *explicit* per-field collation work on every path
+and deliberately left the global default inert, because nothing in the order_by
+pipeline tracked which fields were text and a blanket default would have given
+
+* a numeric JSONB field a silently lexicographic sort -- 1, 10, 2 -- and
+* a numeric flat column an outright "collations are not supported by type
+  integer".
+
+What was missing is field types. They now come from the view's registered type,
+so the default lands on ``str`` fields and nothing else. Anything that cannot be
+resolved to ``str`` -- an unregistered view, a container prefix, a field that is
+not declared -- answers no and keeps the behaviour it has always had.
+"""
+
+from uuid import UUID
+
+import pytest
+
+from fraiseql.sql.graphql_order_by_generator import (
+    OrderByItem,
+    _convert_order_by_input_to_sql,
+    create_graphql_order_by_input,
+)
+from fraiseql.sql.order_by_generator import OrderDirection
+from fraiseql.types import fraise_type
+
+pytestmark = pytest.mark.unit
+
+COLLATION = "fr_FR.utf8"
+
+
+class _Config:
+    """Stand-in for the one FraiseQLConfig attribute that matters here."""
+
+    def __init__(self, collation: str | None = COLLATION) -> None:
+        self.default_string_collation = collation
+
+
+@fraise_type
+class _Profile:
+    nickname: str
+    age: int
+
+
+@fraise_type
+class _Doc:
+    id: UUID
+    name: str
+    amount: int
+    tags: list[str] | None
+    profile: _Profile
+
+
+def _render(order_by, config=None, source_type=None) -> str:
+    order_set = _convert_order_by_input_to_sql(order_by, config=config, source_type=source_type)
+    assert order_set is not None
+    return order_set.to_sql().as_string(None)
+
+
+class TestDictShape:
+    """The shape that carries field names and nothing else."""
+
+    def test_text_field_gets_the_default(self) -> None:
+        sql = _render({"name": "ASC"}, _Config(), _Doc)
+
+        assert sql == 'ORDER BY (t ->> \'name\') COLLATE "fr_FR.utf8" ASC'
+
+    def test_numeric_field_is_left_alone(self) -> None:
+        """The silent wrong answer #481 refused to ship: 1, 10, 2."""
+        sql = _render({"amount": "ASC"}, _Config(), _Doc)
+
+        assert sql == "ORDER BY t -> 'amount' ASC"
+
+    def test_uuid_field_is_left_alone(self) -> None:
+        sql = _render({"id": "ASC"}, _Config(), _Doc)
+
+        assert sql == "ORDER BY t -> 'id' ASC"
+
+    def test_list_of_text_is_not_a_text_field(self) -> None:
+        """Collating a serialized JSON array is meaningless, not merely useless."""
+        sql = _render({"tags": "ASC"}, _Config(), _Doc)
+
+        assert sql == "ORDER BY t -> 'tags' ASC"
+
+    def test_nested_text_field_gets_the_default(self) -> None:
+        sql = _render({"profile": {"nickname": "ASC"}}, _Config(), _Doc)
+
+        assert 'COLLATE "fr_FR.utf8"' in sql
+        assert "profile" in sql
+
+    def test_nested_numeric_field_is_left_alone(self) -> None:
+        sql = _render({"profile": {"age": "ASC"}}, _Config(), _Doc)
+
+        assert "COLLATE" not in sql
+
+    def test_undeclared_field_is_left_alone(self) -> None:
+        """An unknown field answers 'not text', which is the safe answer."""
+        sql = _render({"whatever": "ASC"}, _Config(), _Doc)
+
+        assert "COLLATE" not in sql
+
+    def test_without_a_source_type_nothing_is_collated(self) -> None:
+        """No type to consult is the pre-#482 behaviour, unchanged."""
+        sql = _render({"name": "ASC"}, _Config(), None)
+
+        assert "COLLATE" not in sql
+
+    def test_without_a_config_nothing_is_collated(self) -> None:
+        sql = _render({"name": "ASC"}, None, _Doc)
+
+        assert "COLLATE" not in sql
+
+
+class TestListOfOrderByItems:
+    """The shape that can also carry an explicit per-field collation."""
+
+    def test_explicit_collation_beats_the_default(self) -> None:
+        item = OrderByItem(field="name", direction=OrderDirection.ASC, collation="en_US.utf8")
+
+        sql = _render([item], _Config(), _Doc)
+
+        assert 'COLLATE "en_US.utf8"' in sql
+        assert "fr_FR" not in sql
+
+    def test_explicit_none_beats_the_default(self) -> None:
+        """Setting it to None asks for the database default, and must win."""
+        item = OrderByItem(field="name", direction=OrderDirection.ASC, collation=None)
+
+        sql = _render([item], _Config(), _Doc)
+
+        assert "COLLATE" not in sql
+
+    def test_numeric_field_is_left_alone(self) -> None:
+        sql = _render([{"amount": "ASC"}], _Config(), _Doc)
+
+        assert "COLLATE" not in sql
+
+    def test_text_field_gets_the_default(self) -> None:
+        sql = _render([{"name": "ASC"}], _Config(), _Doc)
+
+        assert 'COLLATE "fr_FR.utf8"' in sql
+
+
+class TestGqlFieldsShape:
+    """The generated input names its own source type, so nothing is threaded in."""
+
+    def test_text_field_gets_the_default_without_an_explicit_source_type(self) -> None:
+        order_by_input = create_graphql_order_by_input(_Doc)
+
+        sql = _render(order_by_input(name=OrderDirection.ASC), _Config())
+
+        assert 'COLLATE "fr_FR.utf8"' in sql
+
+    def test_numeric_field_is_left_alone(self) -> None:
+        order_by_input = create_graphql_order_by_input(_Doc)
+
+        sql = _render(order_by_input(amount=OrderDirection.ASC), _Config())
+
+        assert "COLLATE" not in sql
+
+
+class TestAllShapesAgree:
+    """The same request written three ways must render the same collation."""
+
+    @pytest.mark.parametrize(
+        ("field", "collated"), [("name", True), ("amount", False)], ids=["text", "numeric"]
+    )
+    def test_shapes_agree(self, field: str, collated: bool) -> None:
+        order_by_input = create_graphql_order_by_input(_Doc)
+
+        rendered = {
+            "dict": _render({field: "ASC"}, _Config(), _Doc),
+            "list": _render([{field: "ASC"}], _Config(), _Doc),
+            "gql_fields": _render(order_by_input(**{field: OrderDirection.ASC}), _Config()),
+        }
+
+        for shape, sql in rendered.items():
+            assert ('COLLATE "fr_FR.utf8"' in sql) is collated, f"{shape}: {sql}"


### PR DESCRIPTION
Closes #482.

`default_string_collation` is documented as applying to "all text fields in ORDER BY unless overridden per-field", is validated against SQL injection, and had never reached a query. #481 made an *explicit* per-field collation work on every path and deliberately left the global default inert, because nothing tracked which fields were text and a blanket default would have produced:

| | with a blanket default |
|---|---|
| numeric JSONB field | `(t ->> 'amount') COLLATE "x"` → **1, 10, 2**, silently |
| numeric flat column | `t."amount" COLLATE "x"` → `ERROR: collations are not supported by type integer` |

This PR supplies what was missing.

## How the types get there

- **`_resolve_field_type`** walks a dotted sort path through the source type's annotations, stripping `| None`, and stepping into `list[X]` **while walking but not at the leaf**. `posts.title` has to reach `Post` through `list[Post]`; a `list[str]` leaf is an array, and collating a serialized JSON array is meaningless rather than merely useless.
- **`_is_text_field`** answers True only for `str`. Everything unresolved — an unregistered view, an aggregation container prefix, an undeclared field, a class whose hints do not evaluate — answers False. The question is not "might this be text" but "is this certainly text", so every unknown keeps the behaviour it has always had.
- **`_apply_collation_default`** gains `is_text_field` and applies the default only when it is True. Per-field precedence is unchanged, including an explicit `None` still meaning "use the database default".

## How the source type reaches the resolver

A generated order-by input already names its source class as `_target_class`, so the `__gql_fields__` shape needs nothing threaded in. The dict and list shapes carry field names and nothing else, so `view_name` is threaded from `_build_find_query` → `_build_order_by_sql` → `_resolve_order_by_set` and looked up in `_type_registry`.

The dict shape also **gained the collation decision it never had**: it built `OrderBy` with no collation at all, so even a working default could not have reached it. That is why the issue's "behaviour would depend on the input shape" worry is addressed rather than accepted — all three shapes now render the same collation for the same request, and a test asserts exactly that.

## Scope: only one path renders a collation

My initial estimate said `config` reached only 1 of 5 call sites of `_convert_order_by_input_to_sql` and all five would need threading. Checking each, that was pessimistic: `cqrs/repository.py`, `caching/cache_key.py` and `sql/sql_generator.py` all reduce instructions to `(field, direction)` tuples and **drop collation by construction**. Nothing is threaded to them, because nothing there could use it.

## Verification

The decisive test is not "does it pass now" but "does it fail for a naive implementation":

- **Against a blanket default** (`is_text_field` ignored): **11 tests fail**, exactly the non-text cases — numeric JSONB, numeric flat column, UUID, `list[str]`, nested numeric, undeclared field, and the cross-shape agreement test. The flat integer case fails at the server, which is the error #481 refused to ship.
- **Against `dev`**: the new tests cannot even be called — `_convert_order_by_input_to_sql` had no `source_type` parameter, and the default never applied on any path.
- **Live database**: the integration tests run the whole repository path (config → view registry → type resolution → SQL) and assert the *returned order*, because a mis-collated numeric JSONB sort does not error and only the rows can tell. They discover a linguistic collation on the server and skip if none disagrees with `"C"`, following the #476 pattern.
- `uv run pytest tests/unit/ tests/integration/ -q` — **6046 passed** (+22), only the pre-existing `test_nested_organization_without_tenant_id` failure.
- `uv run ty check` — 538 diagnostics, unchanged from `dev`.
- `ruff check` and `ruff format --check` clean.

## Docs

`docs/reference/config.md`, `docs/operations/configuration.md`, `docs/core/queries-and-mutations.md` and the `FraiseQLConfig` docstring all carried a "Not currently applied" warning added by #481. They now describe what it does, including that the default is step 3 in the precedence chain and that an unresolvable field falls straight through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N