### PR TITLE
docs(ci): record why the Trivy SARIF category must never change

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -153,6 +153,16 @@ jobs:
        if: always()
        with:
          sarif_file: 'trivy-${{ matrix.dockerfile.label }}-results.sarif'
+         # DO NOT CHANGE THIS CATEGORY, and do not change matrix.dockerfile.label,
+         # which composes it. GitHub closes an alert only when a later analysis
+         # for the same (analysis_key, category, ref) omits it, so every alert
+         # filed under a previous category is stranded open forever: nothing
+         # uploads to that category again, so nothing can ever mark it fixed.
+         # That already happened once. Introducing this input moved uploads from
+         # the derived category to 'container-Standard' and left 66 alerts pinned
+         # to the old one -- including the single HIGH the Security tab still
+         # shows, which today's scan already reports as fixed under the current
+         # category. See #479.
          category: 'container-${{ matrix.dockerfile.label }}'
 
      - name: Scan container with Trivy (JSON for detailed analysis)


### PR DESCRIPTION
Refs #479. The investigation is written up in full [on the issue](https://github.com/fraiseql/fraiseql-python/issues/479#issuecomment-5468995714); this PR is the one part that is safe to land as code.

## The finding

The count **does** reconcile — exactly — once open alerts on `dev` are split by category:

| category | count | severities |
|---|---:|---|
| `container-Standard` | **88** | 43 medium, 38 low, 7 unscored |
| `.github/workflows/security-compliance.yml:container-security` | **66** | 1 high, 2 medium, 62 low, 1 unscored |
| | **154** | |

The latest analysis reports `results=88` against 88 open alerts in that category, and CI's own scan of the image reports `Medium: 43, Low: 38` — the same 43 and the same 38, plus 7 CVEs GitHub could not assign a severity. 81 findings + 7 unscored = 88 alerts.

So Trivy's synthetic `library/fraiseql` location reconciles fine, contrary to the issue's second hypothesis. The first is the answer: **the category changed.** GitHub closes an alert only when a later analysis for the same `(analysis_key, category, ref)` omits it. The `analysis_key` is identical for both groups; only the category differs, because introducing the `category:` input moved uploads off the derived name. Nothing writes to the old category any more, so those 66 can never be marked fixed.

`CVE-2025-12818`, the single HIGH on display, proves it — it has both instances on `dev`:

```
cat=.github/workflows/…:container-security   state=open     (last touched 2026-01-26)
cat=container-Standard                       state=fixed
```

Today's scan already fixed it under the current category. The alert-level state is the union, so it still reads open.

## What this PR does

Adds a comment on the `category:` line saying it must never change, and why — because a future rename would strand the current 88 exactly as the last one stranded 66.

That is all it does. Clearing the 66 requires an irreversible API call against the Security tab (`DELETE /code-scanning/analyses/{id}`, or bulk dismissal) and is not something to fold into a PR.

## On the severity flags

The SARIF step scans `CRITICAL,HIGH,MEDIUM` and the JSON step adds `LOW`, so the issue is right that they were never directly comparable — but not in the direction it looks. The 38 GitHub-`low` alerts came from a scan that *excluded* LOW, because GitHub re-buckets by CVSS and many Trivy MEDIUMs land as GitHub `low` or `note`. Aligning the flags would not make the numbers comparable; comparing GitHub's buckets to GitHub's buckets, as above, already does. Left unchanged deliberately.

## Verification

- Alert and analysis counts read from the code-scanning API (`/code-scanning/alerts`, `/code-scanning/analyses`, `/alerts/64/instances`), not inferred.
- Workflow YAML still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N