### PR TITLE
fix(sql): give both operands of a bit distance the literal's width

### DIFF
--- a/src/fraiseql/sql/where/operators/vectors.py
+++ b/src/fraiseql/sql/where/operators/vectors.py
@@ -14,6 +14,22 @@ from typing import Any
 from psycopg.sql import SQL, Composed, Literal
 
 
+def _bit_cast(bit_string: str) -> Composed:
+    """Cast a bit-string operand to a bit type of its own width.
+
+    A bare ``::bit`` is ``bit(1)``, so ``'1010...'::bit`` keeps only the first
+    bit. Applied to *both* operands -- as it was here until #494 -- the lengths
+    still agree, no error is raised, and the distance is computed over a single
+    bit: every row reports 0 and a threshold filter matches everything.
+
+    The width has to come from the literal. The column side needs the cast too,
+    because this path renders a JSONB extraction (``data ->> 'field'``) that
+    arrives as text, not as a ``bit(n)`` column. Mirrors ``_bit_cast`` in
+    :mod:`fraiseql.sql.order_by_generator`, which fixed the ORDER BY half (#483).
+    """
+    return SQL("::bit({})").format(Literal(len(bit_string)))
+
+
 def build_cosine_distance_sql(path_sql: SQL, value: list[float]) -> Composed:
     """Build SQL for cosine distance using PostgreSQL <=> operator.
 
@@ -65,25 +81,31 @@ def build_l1_distance_sql(path_sql: SQL, value: list[float]) -> Composed:
 def build_hamming_distance_sql(path_sql: SQL, value: str) -> Composed:
     """Build SQL for Hamming distance using PostgreSQL <~> operator.
 
-    Generates: column <~> '101010'::bit
+    Generates: (column)::bit(6) <~> '101010'::bit(6)
     Returns distance: number of differing bits
 
     Note: Hamming distance works on bit type vectors, not float vectors.
     Use for categorical features, fingerprints, or binary similarity.
     """
-    return Composed([SQL("("), path_sql, SQL(")::bit <~> "), Literal(value), SQL("::bit")])
+    bit_cast = _bit_cast(value)
+    return Composed(
+        [SQL("("), path_sql, SQL(")"), bit_cast, SQL(" <~> "), Literal(value), bit_cast]
+    )
 
 
 def build_jaccard_distance_sql(path_sql: SQL, value: str) -> Composed:
     """Build SQL for Jaccard distance using PostgreSQL <%> operator.
 
-    Generates: column <%> '111000'::bit
+    Generates: (column)::bit(6) <%> '111000'::bit(6)
     Returns distance: 1 - (intersection / union) for bit sets
 
     Note: Jaccard distance works on bit type vectors for set similarity.
     Useful for recommendation systems, tag similarity, feature matching.
     """
-    return Composed([SQL("("), path_sql, SQL(")::bit <%> "), Literal(value), SQL("::bit")])
+    bit_cast = _bit_cast(value)
+    return Composed(
+        [SQL("("), path_sql, SQL(")"), bit_cast, SQL(" <%> "), Literal(value), bit_cast]
+    )
 
 
 def build_sparse_cosine_distance_sql(path_sql: SQL, value: dict[str, Any]) -> Composed:

--- a/tests/integration/test_vector_e2e.py
+++ b/tests/integration/test_vector_e2e.py
@@ -333,8 +333,10 @@ async def test_binary_vector_hamming_distance_filter(
     )
 
     results = extract_graphql_data(result, "test_fingerprints")
-    assert len(results) > 0
-    # Results should be filtered by Hamming distance
+    # Item A *is* the query fingerprint (distance 0); B and C each differ in 32
+    # of the 64 bits, so a threshold of 10 must exclude both. Asserting only
+    # len(results) > 0 held just as well when the filter matched everything (#494).
+    assert [row["name"] for row in results] == ["Item A"]
 
 
 @pytest.mark.asyncio
@@ -354,8 +356,51 @@ async def test_binary_vector_jaccard_distance_filter(
     )
 
     results = extract_graphql_data(result, "test_fingerprints")
-    assert len(results) > 0
-    # Results should be filtered by Jaccard distance
+    # Distances are 0.0 / 0.667 / 0.667 to Items A / B / C, so 0.3 keeps only A.
+    # See the Hamming test above for why counting rows was not enough (#494).
+    assert [row["name"] for row in results] == ["Item A"]
+
+
+@pytest.mark.asyncio
+async def test_binary_vector_where_builders_compute_over_every_bit(
+    class_db_pool, test_schema, binary_vector_test_setup
+) -> None:
+    """The WHERE-side bit builders must span the whole literal, not one bit (#494).
+
+    Drives the real operator-registry builders -- the path a filter with no
+    resolved type hint takes -- and checks the distances PostgreSQL actually
+    computes. Under the old bare ``::bit`` both operands were truncated to
+    ``bit(1)`` and every row came back 0.0.
+    """
+    from psycopg.sql import SQL, Composed
+
+    from fraiseql.sql.where.operators.vectors import (
+        build_hamming_distance_sql,
+        build_jaccard_distance_sql,
+    )
+
+    query_fingerprint = "1111000011110000111100001111000011110000111100001111000011110000"
+    expected = [
+        (build_hamming_distance_sql, [("Item A", 0.0), ("Item B", 32.0), ("Item C", 32.0)]),
+        (build_jaccard_distance_sql, [("Item A", 0.0), ("Item B", 0.667), ("Item C", 0.667)]),
+    ]
+
+    async with class_db_pool.connection() as conn:
+        await conn.execute(f"SET search_path TO {test_schema}, public")
+        for builder, want in expected:
+            # The registry renders a JSONB text extraction, so feed the builder a
+            # text-typed path rather than the bit(64) column itself.
+            distance = builder(SQL("fingerprint::text"), query_fingerprint)
+            cur = await conn.execute(
+                Composed(
+                    [
+                        SQL("SELECT name, round(("),
+                        distance,
+                        SQL(")::numeric, 3) FROM test_fingerprints ORDER BY name"),
+                    ]
+                )
+            )
+            assert [(name, float(d)) for name, d in await cur.fetchall()] == want
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sql/where/operators/test_vectors.py
+++ b/tests/unit/sql/where/operators/test_vectors.py
@@ -6,6 +6,7 @@ These tests focus on SQL generation for pgvector's three native distance operato
 - <#> : negative inner product
 """
 
+import pytest
 from psycopg.sql import SQL, Composed
 
 from fraiseql.sql.where.core.field_detection import FieldType
@@ -398,3 +399,47 @@ class TestCustomVectorDistanceOperators:
         result = build_custom_distance_sql(path_sql, config)
         sql_str = result.as_string(None)
         assert "my_distance_func(" in sql_str
+
+
+class TestBinaryVectorBitWidth:
+    """Both operands of a bit distance must carry the literal's width (#494).
+
+    A bare ``::bit`` is ``bit(1)``. Casting *both* sides that way keeps the
+    lengths in agreement, so PostgreSQL raises nothing and computes the distance
+    over a single bit -- every row comes back 0. The existing assertions in
+    ``TestBinaryVectorDistanceOperators`` only check ``"::bit" in sql_str``,
+    which a ``bit(1)`` rendering satisfies, so they cannot see this.
+    """
+
+    QUERY_BITS = "1111000011110000111100001111000011110000111100001111000011110000"
+
+    def test_hamming_casts_both_operands_to_the_literal_width(self) -> None:
+        result = build_hamming_distance_sql(SQL('(data ->> \'fingerprint\')'), self.QUERY_BITS)
+        assert result.as_string(None) == (
+            "((data ->> 'fingerprint'))::bit(64) <~> "
+            f"'{self.QUERY_BITS}'::bit(64)"
+        )
+
+    def test_jaccard_casts_both_operands_to_the_literal_width(self) -> None:
+        result = build_jaccard_distance_sql(SQL('(data ->> \'fingerprint\')'), self.QUERY_BITS)
+        assert result.as_string(None) == (
+            "((data ->> 'fingerprint'))::bit(64) <%> "
+            f"'{self.QUERY_BITS}'::bit(64)"
+        )
+
+    @pytest.mark.parametrize("builder", [build_hamming_distance_sql, build_jaccard_distance_sql])
+    @pytest.mark.parametrize("width", [1, 6, 8, 64, 128])
+    def test_width_tracks_the_literal_not_a_fixed_size(self, builder, width) -> None:
+        bits = "10" * (width // 2) + "1" * (width % 2)
+        assert len(bits) == width
+        sql_str = builder(SQL("fingerprint"), bits).as_string(None)
+        assert sql_str.count(f"::bit({width})") == 2
+        # A bare ``::bit`` anywhere means an operand was left at bit(1).
+        assert "::bit " not in sql_str
+        assert not sql_str.endswith("::bit")
+
+    @pytest.mark.parametrize("builder", [build_hamming_distance_sql, build_jaccard_distance_sql])
+    def test_column_side_is_cast_too(self, builder) -> None:
+        """The path is a JSONB text extraction, so it needs the cast as well."""
+        sql_str = builder(SQL('(data ->> \'fp\')'), "101010").as_string(None)
+        assert sql_str.startswith("((data ->> 'fp'))::bit(6)")


### PR DESCRIPTION
Closes #494.

`build_hamming_distance_sql` and `build_jaccard_distance_sql` cast both sides with a bare `::bit`, which is `bit(1)`. Because *both* operands are truncated the lengths still agree, PostgreSQL raises nothing, and the distance is computed over a single bit. Measured against the `test_fingerprints` fixture, every row reports `0.0`:

```
                                 | before | after (true)
 Item A (== query fingerprint)   |    0.0 |          0.0
 Item B                          |    0.0 |         32.0
 Item C                          |    0.0 |         32.0
```

Same root cause #493 fixed on the ORDER BY side (#483). `_bit_cast` here mirrors the helper added there. The column side needs the cast too, because this path renders a JSONB extraction that arrives as text rather than a `bit(n)` column.

## Scope correction

The issue describes this as a live silent wrong answer for threshold filters. It is narrower than that, and worth recording:

- `repo.find(where={...})` normalises through `where_clause.py`, **not** this registry. That path emits `("fingerprint" <~> %s) < %s` with the bit string as a parameter and no cast at all, and it is **correct** today — verified live, the hamming/jaccard filter tests return only `Item A`.
- The registry in `sql/where/operators/vectors.py` is reached when the field resolves to `FieldType.VECTOR`, which needs a vector-ish field name *and* no resolved type hint (an explicit `str` hint detects as `STRING` and the operator is skipped).

So the wrong distance is real and worth fixing, but it does not currently reach a `repo.find` threshold filter. What it does reach is anything that consumes the rendered distance expression.

## Parked finding

Every distance builder in this registry — all six, dense and binary alike — returns a bare distance expression, not a boolean. Used directly as a WHERE predicate PostgreSQL rejects it with `argument of WHERE must be type boolean, not type double precision`. That is systemic and pre-existing, unrelated to bit width, and is filed separately rather than folded in here.

Note also that a genuine width mismatch does **not** surface as the server's "different bit lengths" error, contrary to the issue's expectation: `(bit64col)::bit(8)` truncates silently. Taking the width from the literal is still the only source available, and it matches #493.

## Changes

- Add `_bit_cast` to `sql/where/operators/vectors.py` and apply it to both operands of `<~>` and `<%>`
- Add `TestBinaryVectorBitWidth` — exact-rendering assertions for both operators, width parametrisation over 1/6/8/64/128 bits, and a column-side check. The pre-existing tests assert only `"::bit" in sql_str`, which a `bit(1)` rendering satisfies, so they could not see this
- Add `test_binary_vector_where_builders_compute_over_every_bit` — drives the real builders against PostgreSQL and asserts the distances it actually computes
- Replace the `len(results) > 0` assertions in the two binary-vector filter tests with the rows expected, closing the same vacuity #483 closed on the ORDER BY tests. These two exercise the already-correct `where_clause.py` path, so they pass either way — they are a vacuity fix, not proof of this one

## Verification

- 14 new unit tests and the new integration test all fail against unpatched src (every row `0.0`); the 31 pre-existing tests in the file still pass
- `uv run pytest tests/unit/ tests/integration/ -q` — 6061 passed, only the pre-existing `test_nested_organization_without_tenant_id` failure
- `ruff check` + `format` clean; `ty check` 538, unchanged from dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N