### PR TITLE
fix(sql): render Jaccard distance as a function call, not the <%> operator

### DIFF
--- a/src/fraiseql/sql/order_by_generator.py
+++ b/src/fraiseql/sql/order_by_generator.py
@@ -252,6 +252,10 @@ class OrderBy:
             SQL fragment for vector distance ordering
         """
         # Map operator names to PostgreSQL operators and data types
+        # Set to a function name by any operator that must render as a call rather
+        # than an infix operator; pg_operator_sql is None in exactly those cases.
+        pg_function_sql = None
+
         if isinstance(value, dict):
             # Sparse vector handling
             indices = value["indices"]
@@ -293,13 +297,22 @@ class OrderBy:
                 literal_value = str(value)  # value is already a string for binary operators
                 type_cast = _bit_cast(literal_value)
             elif operator == "jaccard_distance":
-                pg_operator_sql = sql.SQL("<%>")
+                # Rendered as jaccard_distance(col, lit), not as the <%> operator.
+                # psycopg scans a statement for placeholders whenever parameters
+                # accompany it, and rejects `%>` as one; escaping to `<%%>` only
+                # moves the failure to the no-parameter statements, which are sent
+                # verbatim and then have no such operator. The function form is the
+                # one spelling correct under both, at the cost of the
+                # bit_jaccard_ops index, which cannot match a function call (#495).
+                pg_operator_sql = None
+                pg_function_sql = sql.SQL("jaccard_distance")
                 literal_value = str(value)  # value is already a string for binary operators
                 type_cast = _bit_cast(literal_value)
             else:
                 raise ValueError(f"Unknown vector distance operator: {operator}")
 
         # Build SQL: ({table_ref}."field") <operator> 'literal'::type ASC
+        # or, where pg_operator_sql is None: func({table_ref}."field", 'literal'::type) ASC
 
         # Handle both OrderDirection enum and string directions
         if isinstance(self.direction, OrderDirection):
@@ -307,11 +320,26 @@ class OrderBy:
         else:
             direction_str = str(self.direction).upper()
         direction_sql = sql.SQL(direction_str)
+        column_sql = sql.Composed(
+            [sql.SQL(table_ref + "."), sql.Identifier(field_name)],
+        )
+        if pg_operator_sql is None:
+            return sql.Composed(
+                [
+                    pg_function_sql,
+                    sql.SQL("("),
+                    column_sql,
+                    sql.SQL(", "),
+                    sql.Literal(literal_value),
+                    type_cast,
+                    sql.SQL(") "),
+                    direction_sql,
+                ]
+            )
         return sql.Composed(
             [
                 sql.SQL("("),
-                sql.SQL(table_ref + "."),
-                sql.Identifier(field_name),
+                column_sql,
                 sql.SQL(")"),
                 sql.SQL(" "),
                 pg_operator_sql,

--- a/src/fraiseql/sql/where/operators/vectors.py
+++ b/src/fraiseql/sql/where/operators/vectors.py
@@ -94,17 +94,35 @@ def build_hamming_distance_sql(path_sql: SQL, value: str) -> Composed:
 
 
 def build_jaccard_distance_sql(path_sql: SQL, value: str) -> Composed:
-    """Build SQL for Jaccard distance using PostgreSQL <%> operator.
+    """Build SQL for Jaccard distance using pgvector's jaccard_distance function.
 
-    Generates: (column)::bit(6) <%> '111000'::bit(6)
+    Generates: jaccard_distance((column)::bit(6), '111000'::bit(6))
     Returns distance: 1 - (intersection / union) for bit sets
+
+    Rendered as a function call rather than with the ``<%>`` operator. psycopg
+    scans a statement for placeholders whenever parameters accompany it and
+    rejects ``%>`` as one, so an ``<%>`` term fails as soon as anything else in
+    the statement parameterises. Escaping to ``<%%>`` only moves the failure:
+    a statement sent without parameters is passed verbatim and PostgreSQL then
+    has no such operator. The function form is the one spelling correct under
+    both, at the cost of the bit_jaccard_ops index, which cannot match a
+    function call (#495).
 
     Note: Jaccard distance works on bit type vectors for set similarity.
     Useful for recommendation systems, tag similarity, feature matching.
     """
     bit_cast = _bit_cast(value)
     return Composed(
-        [SQL("("), path_sql, SQL(")"), bit_cast, SQL(" <%> "), Literal(value), bit_cast]
+        [
+            SQL("jaccard_distance(("),
+            path_sql,
+            SQL(")"),
+            bit_cast,
+            SQL(", "),
+            Literal(value),
+            bit_cast,
+            SQL(")"),
+        ]
     )
 
 

--- a/tests/integration/test_vector_e2e.py
+++ b/tests/integration/test_vector_e2e.py
@@ -448,6 +448,45 @@ async def test_binary_vector_jaccard_distance_order_by(
 
 
 @pytest.mark.asyncio
+async def test_jaccard_order_by_survives_a_parameterised_where(
+    class_db_pool, test_schema, binary_vector_test_setup
+) -> None:
+    """A Jaccard ordering must work alongside a filter that carries params (#495).
+
+    psycopg scans a statement for placeholders whenever parameters accompany it
+    and rejects ``%>`` as one, so the ``<%>`` operator this used to render made
+    every such query fail with ``only '%s', '%b', '%t' are allowed as
+    placeholders``. Escaping to ``<%%>`` would only move the failure to the
+    no-parameter case below, which is why both halves are asserted here.
+    """
+    repo = FraiseQLRepository(class_db_pool)
+    from fraiseql.sql.graphql_order_by_generator import VectorOrderBy
+
+    # Distances 0.595 / 0.689 / 0.717 to Items C / A / B.
+    query_fingerprint = "0000000000100010100000100111001111100101001010111011101110100100"
+
+    # With parameters: the WHERE renders %s placeholders alongside the ordering.
+    result = await repo.find(
+        "test_fingerprints",
+        where={"category": {"in": ["books", "clothing"]}},
+        order_by={"fingerprint": VectorOrderBy(jaccard_distance=query_fingerprint)},
+        limit=5,
+    )
+    results = extract_graphql_data(result, "test_fingerprints")
+    assert [row["name"] for row in results] == ["Item C", "Item B"]
+
+    # Without parameters: the statement is sent verbatim, so a `%%` escape would
+    # reach PostgreSQL as a literal `%%` and there is no such operator.
+    result = await repo.find(
+        "test_fingerprints",
+        order_by={"fingerprint": VectorOrderBy(jaccard_distance=query_fingerprint)},
+        limit=3,
+    )
+    results = extract_graphql_data(result, "test_fingerprints")
+    assert [row["name"] for row in results] == ["Item C", "Item A", "Item B"]
+
+
+@pytest.mark.asyncio
 async def test_vector_limit_results(class_db_pool, test_schema, vector_test_setup) -> None:
     """Test pagination with vector similarity search."""
     # This test will fail until vector filtering is implemented

--- a/tests/unit/sql/test_order_by_vector_operator_parity.py
+++ b/tests/unit/sql/test_order_by_vector_operator_parity.py
@@ -48,7 +48,10 @@ OPERATORS = {
     # ``::bit`` alone is ``bit(1)``: the literal has to carry its own width or
     # pgvector rejects the comparison with "different bit lengths 64 and 1".
     "hamming_distance": (BITS, "(t.\"embedding\") <~> '111000'::bit(6) ASC"),
-    "jaccard_distance": (BITS, "(t.\"embedding\") <%> '111000'::bit(6) ASC"),
+    # Jaccard renders as a function call, not the ``<%>`` operator: psycopg
+    # rejects ``%>`` as a placeholder whenever the statement carries parameters,
+    # and ``<%%>`` fails on the statements that carry none (#495).
+    "jaccard_distance": (BITS, "jaccard_distance(t.\"embedding\", '111000'::bit(6)) ASC"),
 }
 
 
@@ -107,3 +110,19 @@ def test_both_shapes_render_identically(operator: str) -> None:
     assert from_dict is not None
     assert from_gql_fields is not None
     assert from_dict.to_sql().as_string(None) == from_gql_fields.to_sql().as_string(None)
+
+
+@pytest.mark.parametrize("operator", list(OPERATORS))
+def test_no_rendered_operator_contains_a_percent_sign(operator: str) -> None:
+    """No ORDER BY term may contain ``%``, in any spelling (#495).
+
+    psycopg scans a statement for placeholders whenever parameters accompany it,
+    so a bare ``<%>`` breaks every parameterised query. Escaping to ``<%%>``
+    only relocates the failure onto the statements sent without parameters,
+    which are passed through verbatim -- this assertion rejects both.
+    """
+    operand, _expected = OPERATORS[operator]
+    order_by_set = _convert_order_by_input_to_sql(_dict_shape(operator, operand))
+
+    assert order_by_set is not None
+    assert "%" not in order_by_set.to_sql().as_string(None)

--- a/tests/unit/sql/where/operators/test_vectors.py
+++ b/tests/unit/sql/where/operators/test_vectors.py
@@ -113,17 +113,17 @@ class TestVectorOperators:
         assert "::bit" in sql_str
 
     def test_jaccard_distance_sql(self) -> None:
-        """Should generate Jaccard distance SQL using <%> operator for bit vectors."""
+        """Should generate Jaccard distance SQL via the function form (#495)."""
         # Red cycle - this will fail initially
         path_sql = SQL("features")
         value = "111000"  # 6-bit binary string
 
         result = build_jaccard_distance_sql(path_sql, value)
 
-        # Should generate: (features)::bit <%> '111000'::bit
+        # Should generate: jaccard_distance((features)::bit(6), '111000'::bit(6))
         assert isinstance(result, Composed)
         sql_str = str(result)
-        assert "<%>" in sql_str
+        assert "jaccard_distance(" in sql_str
         assert "'111000'" in sql_str
         assert "::bit" in sql_str
 
@@ -259,7 +259,7 @@ class TestBinaryVectorDistanceOperators:
         bit_string = "111000"
         result = build_jaccard_distance_sql(path_sql, bit_string)
         sql_str = result.as_string(None)
-        assert "<%>" in sql_str
+        assert "jaccard_distance(" in sql_str
         assert "::bit" in sql_str
         assert "111000" in sql_str
 
@@ -423,8 +423,8 @@ class TestBinaryVectorBitWidth:
     def test_jaccard_casts_both_operands_to_the_literal_width(self) -> None:
         result = build_jaccard_distance_sql(SQL('(data ->> \'fingerprint\')'), self.QUERY_BITS)
         assert result.as_string(None) == (
-            "((data ->> 'fingerprint'))::bit(64) <%> "
-            f"'{self.QUERY_BITS}'::bit(64)"
+            "jaccard_distance(((data ->> 'fingerprint'))::bit(64), "
+            f"'{self.QUERY_BITS}'::bit(64))"
         )
 
     @pytest.mark.parametrize("builder", [build_hamming_distance_sql, build_jaccard_distance_sql])
@@ -438,8 +438,45 @@ class TestBinaryVectorBitWidth:
         assert "::bit " not in sql_str
         assert not sql_str.endswith("::bit")
 
-    @pytest.mark.parametrize("builder", [build_hamming_distance_sql, build_jaccard_distance_sql])
-    def test_column_side_is_cast_too(self, builder) -> None:
+    @pytest.mark.parametrize(
+        ("builder", "prefix"),
+        [
+            (build_hamming_distance_sql, "((data ->> 'fp'))::bit(6)"),
+            # Jaccard renders as a function call rather than an operator (#495).
+            (build_jaccard_distance_sql, "jaccard_distance(((data ->> 'fp'))::bit(6)"),
+        ],
+    )
+    def test_column_side_is_cast_too(self, builder, prefix) -> None:
         """The path is a JSONB text extraction, so it needs the cast as well."""
         sql_str = builder(SQL('(data ->> \'fp\')'), "101010").as_string(None)
-        assert sql_str.startswith("((data ->> 'fp'))::bit(6)")
+        assert sql_str.startswith(prefix)
+
+
+class TestJaccardRendersWithoutAPercentSign:
+    """The Jaccard term must never contain ``%``, in any spelling (#495).
+
+    psycopg scans a statement for placeholders whenever parameters accompany it
+    and rejects ``%>`` as one, so an ``<%>`` term breaks the moment anything
+    else in the statement parameterises. Escaping to ``<%%>`` only relocates the
+    failure onto statements sent without parameters, which go through verbatim
+    and leave PostgreSQL with no such operator. Only the function form is
+    correct under both.
+    """
+
+    BITS = "111000"
+
+    def test_jaccard_uses_the_function_form(self) -> None:
+        result = build_jaccard_distance_sql(SQL('(data ->> \'fp\')'), self.BITS)
+        assert result.as_string(None) == (
+            "jaccard_distance(((data ->> 'fp'))::bit(6), '111000'::bit(6))"
+        )
+
+    def test_jaccard_rendering_has_no_percent_sign(self) -> None:
+        """Rejects both `<%>` and the `<%%>` escape that merely moves the bug."""
+        assert "%" not in build_jaccard_distance_sql(SQL("fp"), self.BITS).as_string(None)
+
+    def test_hamming_keeps_the_operator_form(self) -> None:
+        """`<~>` carries no `%`, so it is unaffected and keeps index compatibility."""
+        sql_str = build_hamming_distance_sql(SQL("fp"), "101010").as_string(None)
+        assert "<~>" in sql_str
+        assert "%" not in sql_str


### PR DESCRIPTION
Closes #495.

## This is live, not latent

The issue records it as "not a live failure today". It is one. On `dev`:

```python
await repo.find(
    "test_fingerprints",
    where={"category": {"in": ["books", "clothing"]}},
    order_by={"fingerprint": VectorOrderBy(jaccard_distance=qf)},
)
# psycopg.ProgrammingError: only '%s', '%b', '%t' are allowed as placeholders, got '%>'
```

The identical query with `hamming_distance` passes, so it is the operator and nothing else. Any query that combines a Jaccard term with a filter carrying parameters fails — which is most filtered vector searches. `%s` placeholders are what the dict-WHERE path renders, so the two collide as soon as they appear together.

## Why not escape it

`<%%>` is the obvious fix and it does not work — it relocates the failure onto the statements that carry no parameters, which psycopg sends verbatim. Measured against pgvector:

| rendering | no params | with params |
|---|---|---|
| `<%>` (before) | works | `ProgrammingError: got '%>'` |
| `<%%>` (naive escape) | `UndefinedFunction: operator does not exist: bit <%%> bit` | works |
| `jaccard_distance(a, b)` | works | works |

The function form is the only spelling correct under both branches of the execute path in `core/rust_pipeline.py`.

**Cost:** `jaccard_distance(col, lit)` cannot match the `bit_jaccard_ops` index, so a Jaccard `ORDER BY` will not get index acceleration. No such index is created anywhere in `src/`, `tests/` or `docs/`, so nothing in the project regresses; a user who built one by hand would fall back to a sequential scan rather than an error. Flagging it explicitly since it is a silent performance change, and it is recorded in a comment at the render site.

Hamming keeps the `<~>` operator — it carries no `%`, is unaffected, and keeps its index compatibility.

## Changes

- `order_by_generator.py` — render `jaccard_distance(col, lit)` through a `pg_function_sql` branch for operators that must render as a call rather than infix
- `sql/where/operators/vectors.py` — same for `build_jaccard_distance_sql`
- `test_jaccard_order_by_survives_a_parameterised_where` — asserts **both** halves: with parameters (the reported failure) and without (the half `<%%>` breaks). One without the other passes against a naive fix
- Percent-sign assertions at both render sites, rejecting `<%>` and `<%%>` alike
- Updated the four existing tests that pinned the operator spelling

## Verification

- The new tests fail against `dev` (`ProgrammingError`) **and** against the naive `<%%>` fix (`UndefinedFunction`) — 9 unit + 1 integration failing in each case, confirmed by patching src both ways
- `uv run pytest tests/unit/ tests/integration/ -q` — 6071 passed, only the pre-existing `test_nested_organization_without_tenant_id` failure
- `ruff check` + `format` clean; `ty check` 538, unchanged from dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N