### PR TITLE
chore(ci): count UNKNOWN CVEs so the scan summary matches the Security tab

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -144,6 +144,13 @@ jobs:
          scan-ref: ${{ matrix.dockerfile.tag }}
          format: 'sarif'
          output: 'trivy-${{ matrix.dockerfile.label }}-results.sarif'
+         # INERT, and deliberately left in place as documentation of intent.
+         # trivy-action runs `unset TRIVY_SEVERITY` whenever the format is sarif
+         # and limit-severities-for-sarif is not 'true', logging "Building SARIF
+         # report with all severities". So the Security tab receives EVERY
+         # severity regardless of this line -- 43 medium + 38 low + 7 unknown.
+         # Tightening it changes nothing; setting limit-severities-for-sarif
+         # would, and would close the 38 low and 7 unknown alerts. See #479.
          severity: 'CRITICAL,HIGH,MEDIUM'  # Government standard: include MEDIUM
          exit-code: 0  # Report only, don't fail
          trivyignores: '.trivyignore'
@@ -172,7 +179,11 @@ jobs:
          scan-ref: ${{ matrix.dockerfile.tag }}
          format: 'json'
          output: 'trivy-${{ matrix.dockerfile.label }}-detailed.json'
-         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+         # UNKNOWN is included so this scan covers exactly what the SARIF upload
+         # puts in the Security tab, which is unfiltered (see the step above).
+         # Without it the two disagree by the CVEs Trivy rates UNKNOWN -- the
+         # whole of the 88-vs-81 gap investigated in #479.
+         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
          trivyignores: '.trivyignore'
 
      - name: Generate compliance report
@@ -189,12 +200,19 @@ jobs:
          HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' trivy-${{ matrix.dockerfile.label }}-detailed.json)
          MEDIUM=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="MEDIUM")] | length' trivy-${{ matrix.dockerfile.label }}-detailed.json)
          LOW=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="LOW")] | length' trivy-${{ matrix.dockerfile.label }}-detailed.json)
+         # Trivy rates a CVE UNKNOWN when no vendor has scored it. Counted and
+         # shown because it is not zero, and because leaving it out is what made
+         # this summary disagree with the Security tab (#479).
+         UNKNOWN=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="UNKNOWN")] | length' trivy-${{ matrix.dockerfile.label }}-detailed.json)
+         TOTAL=$((CRITICAL + HIGH + MEDIUM + LOW + UNKNOWN))
 
          echo "## Vulnerability Summary" >> security-report.md
          echo "- 🔴 Critical: $CRITICAL" >> security-report.md
          echo "- 🟠 High: $HIGH" >> security-report.md
          echo "- 🟡 Medium: $MEDIUM" >> security-report.md
          echo "- 🔵 Low: $LOW" >> security-report.md
+         echo "- ⚪ Unknown (unscored by any vendor): $UNKNOWN" >> security-report.md
+         echo "- **Total: $TOTAL** (should equal the open alert count for \`container-${{ matrix.dockerfile.label }}\`)" >> security-report.md
          echo "" >> security-report.md
 
          # Patch availability.


### PR DESCRIPTION
Addresses the last open item on #479 — which figure is authoritative, and whether the two Trivy severity flags should be aligned.

## The mechanism, which was the thing to establish

`severity: 'CRITICAL,HIGH,MEDIUM'` on the SARIF step has never done anything. From `trivy-action`'s `entrypoint.sh`:

```bash
if [ "${TRIVY_FORMAT:-}" = "sarif" ]; then
  if [ "${INPUT_LIMIT_SEVERITIES_FOR_SARIF:-false,,}" != "true" ]; then
    echo "Building SARIF report with all severities"
    unset TRIVY_SEVERITY
  fi
fi
```

The action **discards the severity filter** for SARIF output unless `limit-severities-for-sarif: true`, on the reasoning that the Security tab should receive everything and filtering happens in GitHub's UI. Our own job log prints `Building SARIF report with all severities` on the line immediately before the scan, so this is not inference.

That is why the two steps behave differently with the same input mechanism: the JSON step (`format: json`) filters normally and dropped UNKNOWN; the SARIF step did not filter at all.

## Two corrections to #479

Verified by fetching back the SARIF GitHub actually stored (`Accept: application/sarif+json`) and the JSON artifact from the same run:

1. **There is no CVSS re-bucketing.** The earlier comment explains the 38 GitHub-`low` alerts as re-bucketed Trivy MEDIUMs, making the 43/38 correspondence coincidental. Cross-tabulating Trivy severity against GitHub's bucket over all 88 alerts gives a clean 1:1 — 43 MEDIUM→medium, 38 LOW→low, 7 UNKNOWN→unscored. The correspondence is real, not coincidence.
2. **The 7 are not "alerts GitHub could not score".** They are five CVEs Trivy itself rates `UNKNOWN` — CVE-2026-18374, CVE-2026-80489, CVE-2026-39113, CVE-2026-15534, CVE-2026-19487 — all base-OS packages (`libc6`, `perl-base`, `libsqlite3-0`) with no upstream fix. They were missing from the CI summary only because `UNKNOWN` was absent from that step's severity list.

The reconciliation `88 = 81 + 7` still holds; the reason is simply different, and knowing the real one is what makes the numbers predictable.

## Changes

- Add `UNKNOWN` to the JSON step's severity list, so it covers exactly what the SARIF upload puts in the tab
- Count `UNKNOWN` and report it, plus a `TOTAL` line stating the invariant that it should equal the open alert count for `container-Standard`
- Comment the SARIF step's `severity` input as inert, recording the mechanism — so nobody tightens it expecting the tab to shrink, and so the alternative (`limit-severities-for-sarif`, which *would* close the 38 low and 7 unknown alerts) is a deliberate choice rather than a discovery

## Effect

| | before | after |
|---|---|---|
| Security tab | 88 | 88 (unchanged) |
| CI scan summary | 81 | 88 |

The gate is untouched — it fails only on `CRITICAL` and language-package `HIGH`, and all five UNKNOWN CVEs are unpatched base-OS findings, so `FIXABLE` stays 0.

## Verification

- Uploaded SARIF re-fetched from the code-scanning API: 88 results, 43 MEDIUM / 38 LOW / 7 UNKNOWN — matching the 88 open alerts exactly
- Downloaded JSON artifact from the same run: 43 MEDIUM + 38 LOW, 0 UNKNOWN — confirming the filter applies there and not on the SARIF step
- Report block replayed against the real artifact: jq expressions and arithmetic correct, `FIXABLE` = 0
- YAML parses; gate logic unchanged

I'll confirm the summary prints `Total: 88` once this job runs on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N