### PR TITLE
fix: make vector WHERE operators boolean predicates

### DIFF
--- a/src/fraiseql/sql/where_generator.py
+++ b/src/fraiseql/sql/where_generator.py
@@ -75,6 +75,51 @@ def build_operator_composed(
     if detected_field_type is None:
         detected_field_type = detect_field_type("", val, field_type)
 
+    vector_distance_operators = {
+        "cosine_distance",
+        "l2_distance",
+        "l1_distance",
+        "inner_product",
+        "hamming_distance",
+        "jaccard_distance",
+    }
+
+    # Vector distance filters carry both the query vector and its threshold.
+    # The operator builders render the distance expression, so add the boolean
+    # comparison here before the expression is used as a WHERE condition.
+    if (
+        detected_field_type in (FieldType.VECTOR, FieldType.SPARSE_VECTOR)
+        and op in vector_distance_operators
+    ):
+        if isinstance(val, dict):
+            vector = val.get("vector")
+            threshold = val.get("threshold", 0.5)
+            comparison = val.get("comparison", "lt")
+        elif isinstance(val, (list, tuple)) and len(val) == 2:
+            vector, threshold = val
+            comparison = "lt"
+        else:
+            raise ValueError(
+                f"Vector operator requires dict or (vector, threshold) tuple, got {val!r}"
+            )
+
+        comparison_operator = {
+            "lt": "<",
+            "lte": "<=",
+            "gt": ">",
+            "gte": ">=",
+            "eq": "=",
+            "neq": "<>",
+        }.get(comparison)
+        if comparison_operator is None:
+            raise ValueError(f"Unsupported vector comparison '{comparison}'")
+
+        operator_func = get_operator_function(detected_field_type, op)
+        distance_sql = operator_func(path_sql, vector)
+        return Composed(
+            [SQL("("), distance_sql, SQL(f") {comparison_operator} "), Literal(threshold)]
+        )
+
     # Get the operator function
     operator_func = get_operator_function(detected_field_type, op)
 

--- a/tests/integration/database/sql/test_where_generator.py
+++ b/tests/integration/database/sql/test_where_generator.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 import pytest
 from psycopg.sql import SQL, Composed
 
+from fraiseql.sql.where.core.field_detection import FieldType
 from fraiseql.sql.where_generator import (
     DynamicType,
     build_operator_composed,
@@ -681,6 +682,31 @@ class TestBuildOperatorComposedExtended:
 
         with pytest.raises(ValueError, match="Unsupported operator"):
             build_operator_composed(path_sql, "unsupported_op", "value")
+
+    @pytest.mark.parametrize(
+        ("operator", "value", "distance_operator"),
+        [
+            ("cosine_distance", {"vector": [0.1, 0.2], "threshold": 0.5}, "<=>"),
+            ("l2_distance", ([0.1, 0.2], 1.0), "<->"),
+            ("l1_distance", {"vector": [0.1, 0.2], "threshold": 2.0}, "<+>"),
+            ("inner_product", {"vector": [0.1, 0.2], "threshold": -0.1}, "<#>"),
+            ("hamming_distance", {"vector": "1010", "threshold": 1}, "<~>"),
+            ("jaccard_distance", {"vector": "1010", "threshold": 0.5}, "<%>"),
+        ],
+    )
+    def test_vector_distance_operators_render_boolean_predicates(
+        self, operator: str, value: object, distance_operator: str
+    ) -> None:
+        """Distance operators must be valid WHERE predicates, not bare numbers."""
+        path_sql = SQL("data ->> 'embedding'")
+
+        result = build_operator_composed(
+            path_sql, operator, value, detected_field_type=FieldType.VECTOR
+        )
+        sql = result.as_string(None)
+
+        assert distance_operator in sql
+        assert ") < " in sql
 
 
 class TestSafeCreateWhereTypeExtended:


### PR DESCRIPTION
## Summary

Fixes #505.

The dynamic WHERE operator registry emitted a bare pgvector distance expression for vector distance filters. PostgreSQL therefore rejected the expression with `argument of WHERE must be type boolean`.

## Changes

- Unpack vector distance inputs in the registry path, including dictionary and tuple forms.
- Wrap all six distance expressions in the requested comparison predicate.
- Add regression coverage for cosine, L2, L1, inner-product, Hamming, and Jaccard distance operators.

The change is limited to WHERE predicate generation. Existing ordering and the parameterized `WhereClause` path are unchanged.

## Tests

- `uv run pytest tests/integration/database/sql/test_where_generator.py -q -m unit` (18 passed)
- `uv run ruff check src/` (passed)
- `uv run ruff format --check src/fraiseql/sql/where_generator.py tests/integration/database/sql/test_where_generator.py` (passed)
- `uv run ty check src/fraiseql/sql/where_generator.py` (passed)
- `git diff --check` (passed)
- `uv run pytest tests/integration/test_vector_e2e.py -q` (15 skipped: Docker daemon unavailable in the environment)

The full unit suite was not green before this change on Windows: collection fails in two existing CLI tests because the dependency imports Unix-only `fcntl`. The repository-wide type check also reports pre-existing diagnostics outside the changed files.

## Compatibility

The existing dictionary and tuple vector filter formats remain supported. The generated SQL now has boolean semantics required by PostgreSQL; no public API is removed.
