### PR TITLE
fix(sql): reject the four vector operators that are not WHERE predicates

### DIFF
--- a/src/fraiseql/sql/graphql_order_by_generator.py
+++ b/src/fraiseql/sql/graphql_order_by_generator.py
@@ -59,10 +59,6 @@ class VectorOrderBy:
     l2_distance: list[float] | dict[str, Any] | None = None
     l1_distance: list[float] | dict[str, Any] | None = None
     inner_product: list[float] | dict[str, Any] | None = None
-    custom_distance: dict[str, Any] | None = (
-        None  # {function: "my_distance_func", parameters: [...]}
-    )
-    vector_norm: Any | None = None  # For norm calculations
     hamming_distance: str | None = None  # bit string like "101010"
     jaccard_distance: str | None = None  # bit string like "111000"
 

--- a/src/fraiseql/sql/where/operators/vectors.py
+++ b/src/fraiseql/sql/where/operators/vectors.py
@@ -9,7 +9,7 @@ FraiseQL exposes these operators transparently without abstraction.
 Distance values are returned raw from PostgreSQL (no conversion to similarity).
 """
 
-from typing import Any
+from typing import Any, NoReturn
 
 from psycopg.sql import SQL, Composed, Literal
 
@@ -27,6 +27,38 @@ VECTOR_DISTANCE_OPERATORS = frozenset(
         "jaccard_distance",
     }
 )
+
+#: Vector operators that render an expression rather than a boolean and can
+#: therefore never serve as a WHERE predicate (#510), mapped to the two halves
+#: of the error each one raises: what it used to render, and what to do instead.
+#:
+#: These stay registered in ``OPERATOR_MAP`` deliberately. Deleting the entries
+#: would make ``get_operator_function`` raise ``ValueError``, which
+#: ``_make_filter_field_composed`` swallows with ``except ValueError: continue``
+#: -- the filter would vanish while its sibling scoping filters survived, and
+#: the query would succeed against a wider set of rows than was asked for.
+#: A registered builder that raises ``WhereClauseError`` fails loudly instead.
+NON_PREDICATE_OPERATORS: dict[str, tuple[str, str]] = {
+    "custom_distance": (
+        "a call to a caller-supplied function",
+        "FraiseQL cannot validate an arbitrary function name or its parameters. "
+        "Expose the distance as a column in your view and filter on that column, "
+        "or use one of the supported distance operators.",
+    ),
+    "vector_norm": (
+        "a bare norm expression",
+        "A norm is a number. Expose it as a column in your view and filter on that column.",
+    ),
+    "quantized_distance": (
+        "a call to a quantized_<type>_distance function that FraiseQL does not define",
+        "Reconstruct the vector in your view and filter with one of the "
+        "supported distance operators.",
+    ),
+    "reconstruct": (
+        "a call to a reconstruct_quantized_vector function that FraiseQL does not define",
+        "Reconstruct the vector in your view and filter on the reconstructed column.",
+    ),
+}
 
 #: Comparison keyword -> SQL operator, mirroring ``where_clause.py``.
 VECTOR_COMPARISON_SQL = {
@@ -53,6 +85,20 @@ def _reject(message: str, operator: str, value: object) -> WhereClauseError:
     """
     return WhereClauseError(
         f"{message} (operator {operator!r}, got {value!r})",
+        operator=operator,
+        supported_operators=sorted(VECTOR_DISTANCE_OPERATORS),
+    )
+
+
+def _reject_non_predicate(operator: str) -> WhereClauseError:
+    """Build the error raised for a vector operator that is not a predicate.
+
+    Like :func:`_reject`, deliberately not a :class:`ValueError`: the caller
+    swallows those and drops the filter rather than failing the query.
+    """
+    renders, remedy = NON_PREDICATE_OPERATORS[operator]
+    return WhereClauseError(
+        f"{operator!r} is not a WHERE predicate: it renders {renders}, not a boolean. {remedy}",
         operator=operator,
         supported_operators=sorted(VECTOR_DISTANCE_OPERATORS),
     )
@@ -373,88 +419,65 @@ def build_half_vector_avg_aggregation(path_sql: SQL) -> Composed:
     return Composed([SQL("AVG("), path_sql, SQL(")::halfvec")])
 
 
-def build_custom_distance_sql(path_sql: SQL, value: dict[str, Any]) -> Composed:
-    """Build SQL for custom distance function.
+def build_custom_distance_sql(path_sql: SQL, value: dict[str, Any]) -> NoReturn:
+    """Reject ``custom_distance`` in a WHERE clause (#510).
 
-    Allows calling user-defined distance functions with custom parameters.
+    The operator rendered ``<function>(<column>, <param>, ...)`` -- a bare
+    function call whose type is whatever the function returns, never a boolean.
 
-    Args:
-        path_sql: SQL for the vector column path
-        value: Dict with 'function' key and optional 'parameters' key
+    It also concatenated two caller-supplied strings straight into the
+    statement. ``psycopg.sql.SQL()`` is the raw-fragment constructor and
+    performs no escaping, so both the ``function`` name and every entry of
+    ``parameters`` were interpolated verbatim::
 
-    Generates: custom_distance_function(column, param1, param2, ...)
+        {"function": "true OR 1=1 --"}                    -> WHERE true OR 1=1 --(...)
+        {"function": "strpos", "parameters": ["'x') > -1 OR true --"]}
+
+    Both forms parse and return every row. FraiseQL has no registry of
+    user-defined distance functions to validate a name against, so there is
+    nothing to allow-list and no safe way to build the call from a filter dict.
     """
-    if not isinstance(value, dict) or "function" not in value:
-        raise ValueError("Custom distance requires 'function' key")
-
-    function_name = value["function"]
-    parameters = value.get("parameters", [])
-
-    # Build function call: function_name(column, param1, param2, ...)
-    sql_parts = [SQL(function_name), SQL("("), path_sql]
-
-    for param in parameters:
-        sql_parts.extend([SQL(", "), SQL(str(param))])
-
-    sql_parts.append(SQL(")"))
-
-    return Composed(sql_parts)
+    raise _reject_non_predicate("custom_distance")
 
 
-def build_vector_norm_sql(path_sql: SQL, value: Any) -> Composed:
-    """Build SQL for vector norm calculation.
+def build_vector_norm_sql(path_sql: SQL, value: Any) -> NoReturn:
+    """Reject ``vector_norm`` in a WHERE clause (#510).
 
-    Generates: vector_norm(column, 'p_norm') or similar
-    Useful for L1, L2, etc. norms
+    The operator rendered ``vector_norm(<column>, 'l2')``, ignoring ``value``
+    entirely. pgvector declares ``vector_norm(vector)`` -- one argument -- so
+    that call does not exist at any arity and PostgreSQL rejected it with
+    ``function vector_norm(text, unknown) does not exist`` on every execution.
+    The column side was never cast to ``vector`` either, and the sparse
+    registration was wrong twice over: pgvector names that one ``l2_norm``.
+
+    A norm is a number, so even spelled correctly it is not a predicate.
     """
-    # For now, implement as a simple wrapper around vector_norm function
-    # This could be extended to support different norm types
-    return Composed([SQL("vector_norm("), path_sql, SQL(", 'l2')")])
+    raise _reject_non_predicate("vector_norm")
 
 
-def build_quantized_distance_sql(path_sql: SQL, value: dict[str, Any]) -> Composed:
-    """Build SQL for quantized vector distance calculation.
+def build_quantized_distance_sql(path_sql: SQL, value: dict[str, Any]) -> NoReturn:
+    """Reject ``quantized_distance`` in a WHERE clause (#510).
 
-    This requires reconstructing the vector from the quantized representation
-    and then performing distance calculation.
+    The operator rendered ``quantized_<distance_type>_distance(<column>,
+    <vector>::vector)``. FraiseQL defines no such function, the vector literal
+    was emitted unquoted so the fragment did not even parse, and the result
+    would have been a number rather than a boolean.
 
-    Args:
-        path_sql: SQL for the quantized vector column path
-        value: Dict with quantization parameters and target vector
+    It carried the same two raw-interpolation channels as ``custom_distance``:
+    ``distance_type`` was substituted into the function name, and every element
+    of ``target_vector`` was rendered with ``SQL(str(v))``.
 
-    Generates: custom function call for quantized distance
+    Unlike ``FieldType.VECTOR``, this one is reachable from a plain type hint:
+    ``QuantizedVectorField`` is mapped in ``FieldType.from_python_type``.
     """
-    if not isinstance(value, dict) or "target_vector" not in value:
-        raise ValueError("Quantized distance requires 'target_vector' key")
-
-    target_vector = value["target_vector"]
-    distance_type = value.get("distance_type", "cosine")
-
-    # This would require custom PostgreSQL functions for quantization
-    # For now, implement as a placeholder that calls a custom function
-    function_name = f"quantized_{distance_type}_distance"
-
-    if isinstance(target_vector, list):
-        # Dense target vector
-        vector_literal = "[" + ",".join(str(v) for v in target_vector) + "]"
-        return Composed(
-            [
-                SQL(function_name),
-                SQL("("),
-                path_sql,
-                SQL(", "),
-                SQL(vector_literal),
-                SQL("::vector)"),
-            ]
-        )
-    # Could support sparse target vectors too
-    raise ValueError("Quantized distance currently only supports dense target vectors")
+    raise _reject_non_predicate("quantized_distance")
 
 
-def build_quantization_reconstruct_sql(path_sql: SQL, value: Any) -> Composed:
-    """Build SQL for reconstructing a vector from quantized representation.
+def build_quantization_reconstruct_sql(path_sql: SQL, value: Any) -> NoReturn:
+    """Reject ``reconstruct`` in a WHERE clause (#510).
 
-    Generates: reconstruct_quantized_vector(column)
-    Returns the reconstructed full vector
+    The operator rendered ``reconstruct_quantized_vector(<column>)``, a
+    function FraiseQL does not define, which would return a vector rather than
+    a boolean even if it existed.
     """
-    return Composed([SQL("reconstruct_quantized_vector("), path_sql, SQL(")")])
+    raise _reject_non_predicate("reconstruct")

--- a/tests/integration/test_vector_where_predicates_e2e.py
+++ b/tests/integration/test_vector_where_predicates_e2e.py
@@ -173,3 +173,131 @@ class TestVectorFilterRejectsBadInput:
                 {"tenant": {"eq": "acme"}, "embedding": {"cosine_distance": {"bad": 1}}},
             ]
             where.to_sql()
+
+
+@pytest_asyncio.fixture(scope="class", loop_scope="class")
+async def scoped_docs(class_db_pool, test_schema, pgvector_available) -> None:
+    """Rows carrying a scoping key, to show what a dropped vector filter leaves."""
+    if not pgvector_available:
+        pytest.skip("pgvector extension not available")
+
+    async with class_db_pool.connection() as conn:
+        await conn.execute(f"SET search_path TO {test_schema}, public")
+        await conn.execute("CREATE TABLE vec_docs (id int PRIMARY KEY, data jsonb NOT NULL)")
+        await conn.execute(
+            """INSERT INTO vec_docs (id, data) VALUES
+                (1, '{"kind": "doc", "embedding": "[1,0]"}'),
+                (2, '{"kind": "doc", "embedding": "[0,1]"}')"""
+        )
+        await conn.commit()
+
+
+@pytest.mark.usefixtures("scoped_docs")
+class TestNonPredicateOperatorsNeverReachTheDatabase:
+    """Four registry entries rendered an expression, not a predicate (#510).
+
+    ``custom_distance``, ``vector_norm``, ``quantized_distance`` and
+    ``reconstruct`` are refused in a WHERE clause. Each test here first
+    *executes* the outcome being prevented, so the assertion that the fix
+    raises is anchored to a demonstrated result set rather than to a string.
+    """
+
+    @staticmethod
+    async def run_sql(pool, schema, statement: str) -> list[int]:
+        """Execute a raw statement and return the matching ids, sorted."""
+        async with pool.connection() as conn:
+            await conn.execute(f"SET search_path TO {schema}, public")
+            cur = await conn.execute(statement)
+            return sorted([row[0] async for row in cur])
+
+    @staticmethod
+    async def run(pool, schema, condition: Composed) -> list[int]:
+        """Execute a rendered condition and return the matching ids."""
+        stmt = Composed([SQL("SELECT id FROM vec_docs WHERE "), condition, SQL(" ORDER BY id")])
+        async with pool.connection() as conn:
+            await conn.execute(f"SET search_path TO {schema}, public")
+            cur = await conn.execute(stmt)
+            return [row[0] async for row in cur]
+
+    async def test_injected_function_name_executes_and_returns_every_row(
+        self, class_db_pool, test_schema
+    ) -> None:
+        """The statement ``{"function": "true OR 1=1 --"}`` used to build, run.
+
+        ``build_custom_distance_sql`` concatenated the function name with
+        ``psycopg.sql.SQL()``, the raw-fragment constructor, so this parsed as
+        written. Establishes that the channel was live before asserting it is
+        closed.
+        """
+        injected = "SELECT id FROM vec_docs WHERE true OR 1=1 --((data ->> 'embedding'))"
+        assert await self.run_sql(class_db_pool, test_schema, injected) == [1, 2]
+
+        with pytest.raises(WhereClauseError):
+            render("embedding", "custom_distance", {"function": "true OR 1=1 --"})
+
+    async def test_injected_parameter_executes_and_returns_every_row(
+        self, class_db_pool, test_schema
+    ) -> None:
+        """``parameters`` was a second raw channel: ``SQL(str(param))`` per entry."""
+        injected = (
+            "SELECT id FROM vec_docs WHERE strpos((data ->> 'embedding'), 'x') > -1 OR true --)"
+        )
+        assert await self.run_sql(class_db_pool, test_schema, injected) == [1, 2]
+
+        with pytest.raises(WhereClauseError):
+            render(
+                "embedding",
+                "custom_distance",
+                {"function": "strpos", "parameters": ["'x') > -1 OR true --"]},
+            )
+
+    async def test_vector_norm_rendering_never_existed_in_pgvector(
+        self, class_db_pool, test_schema
+    ) -> None:
+        """``vector_norm(col, 'l2')`` is not a function at any arity.
+
+        pgvector declares ``vector_norm(vector)``. The two-argument form the
+        operator emitted -- against an uncast ``text`` column, and registered
+        for sparse fields where pgvector names the function ``l2_norm`` --
+        failed on every execution, so no caller can be relying on it.
+        """
+        import psycopg
+
+        with pytest.raises(psycopg.errors.UndefinedFunction):
+            await self.run_sql(
+                class_db_pool,
+                test_schema,
+                "SELECT id FROM vec_docs WHERE vector_norm((data ->> 'embedding'), 'l2')",
+            )
+
+        with pytest.raises(WhereClauseError):
+            render("embedding", "vector_norm", "l2")
+
+    async def test_a_dropped_vector_filter_would_widen_the_result_set(
+        self, class_db_pool, test_schema
+    ) -> None:
+        """Unregistering the operators instead is the worse fix.
+
+        ``get_operator_function`` raises ``ValueError`` for an unknown
+        operator and ``_make_filter_field_composed`` swallows it, so the scope
+        filter would render and execute alone -- the query succeeding over
+        every row rather than the similar ones. The first half of this test is
+        that surviving filter, rendered by the real renderer and executed.
+        """
+        scope_only = render("kind", "eq", "doc")
+        assert scope_only is not None
+        assert await self.run(class_db_pool, test_schema, scope_only) == [1, 2]
+
+        where = WhereType()
+        where.OR = [
+            {"kind": {"eq": "doc"}, "embedding": {"custom_distance": {"function": "my_dist"}}}
+        ]
+        with pytest.raises(WhereClauseError):
+            where.to_sql()
+
+    async def test_supported_operators_are_unaffected(self, class_db_pool, test_schema) -> None:
+        """The six real distance operators must still narrow the result set."""
+        value = {"vector": [1.0, 0.0], "threshold": 0.75}
+        condition = render("embedding", "cosine_distance", value)
+        assert condition is not None
+        assert await self.run(class_db_pool, test_schema, condition) == [1]

--- a/tests/unit/sql/test_order_by_vector_operator_parity.py
+++ b/tests/unit/sql/test_order_by_vector_operator_parity.py
@@ -126,3 +126,25 @@ def test_no_rendered_operator_contains_a_percent_sign(operator: str) -> None:
 
     assert order_by_set is not None
     assert "%" not in order_by_set.to_sql().as_string(None)
+
+
+class TestVectorOrderByDeclaresOnlyWhatItReads:
+    """A GraphQL input field nothing reads advertises sorting that never happens (#510).
+
+    ``VectorOrderBy`` declared ``custom_distance`` and ``vector_norm`` as
+    ``@fraise_input`` fields, so both reached the published schema. Nothing
+    consumed them: ``_append_vector_order_by`` iterates
+    ``VECTOR_DISTANCE_OPERATORS``, which names the six real operators. A client
+    sending either got no ``ORDER BY`` term and no error.
+    """
+
+    def test_declared_fields_match_the_operators_that_are_read(self) -> None:
+        """Pins both directions of drift, not just the two fields removed."""
+        from fraiseql.sql.order_by_generator import VECTOR_DISTANCE_OPERATORS
+
+        assert set(VectorOrderBy.__gql_fields__) == set(VECTOR_DISTANCE_OPERATORS)
+
+    @pytest.mark.parametrize("dead_field", ["custom_distance", "vector_norm"])
+    def test_dead_field_is_no_longer_declared(self, dead_field) -> None:
+        """Removed rather than wired up: neither is a usable ORDER BY operand."""
+        assert dead_field not in VectorOrderBy.__gql_fields__

--- a/tests/unit/sql/where/operators/test_vector_non_predicate_operators.py
+++ b/tests/unit/sql/where/operators/test_vector_non_predicate_operators.py
@@ -1,0 +1,238 @@
+"""Vector operators that cannot be WHERE predicates must be rejected loudly (#510).
+
+Four entries in the vector operator registry render an *expression*, not a
+boolean, so they can never serve as a WHERE predicate:
+
+``custom_distance``     a bare call to a user-supplied function
+``vector_norm``         ``vector_norm(col, 'l2')`` -- pgvector's is
+                        ``vector_norm(vector)``, one argument, so this does not
+                        exist at any arity and errors on every execution
+``quantized_distance``  a call to ``quantized_<type>_distance``, which FraiseQL
+                        does not define
+``reconstruct``         a call to ``reconstruct_quantized_vector``, which
+                        FraiseQL does not define, returning a vector
+
+``custom_distance`` and ``quantized_distance`` additionally concatenated
+caller-supplied strings into the statement through ``psycopg.sql.SQL()``, the
+raw-fragment constructor, which performs no escaping.
+
+The rejection must raise :class:`WhereClauseError`. Dropping the four from
+``OPERATOR_MAP`` instead is the tempting fix and is *worse*: an unregistered
+operator makes ``get_operator_function`` raise ``ValueError``, which
+``_make_filter_field_composed`` swallows with ``except ValueError: continue``.
+The filter would vanish while its sibling scoping filters survived, so the
+query would succeed and return rows the vector filter was meant to exclude.
+Several tests below pin that distinction.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+from psycopg.sql import SQL, Composed
+
+from fraiseql.errors.exceptions import WhereClauseError
+from fraiseql.sql.where.operators.vectors import (
+    NON_PREDICATE_OPERATORS,
+    build_custom_distance_sql,
+    build_quantization_reconstruct_sql,
+    build_quantized_distance_sql,
+    build_vector_norm_sql,
+)
+from fraiseql.sql.where_generator import safe_create_where_type
+from fraiseql.types.scalars.vector import QuantizedVectorField, SparseVectorField
+
+
+class _Doc:
+    """Bare marker class; filter fields arrive through the OR plain-dict path.
+
+    ``FieldType.from_python_type`` has no ``VECTOR`` mapping, so ``VECTOR`` is
+    reached only by field-name detection with no resolved type hint.
+    """
+
+    __annotations__ = {}
+
+
+WhereType = safe_create_where_type(_Doc)
+
+
+def render_dense(op: str, value: object) -> Composed | None:
+    """Render one filter on a vector-ish field name through the registry path."""
+    where = WhereType()
+    where.OR = [{"embedding": {op: value}}]
+    return where.to_sql()
+
+
+@dataclass
+class _SparseDoc:
+    sparse_emb: SparseVectorField
+
+
+@dataclass
+class _QuantizedDoc:
+    quantized_emb: QuantizedVectorField
+
+
+class TestNonPredicateOperatorsAreRejected:
+    """Every non-boolean vector operator must raise, on every field type."""
+
+    @pytest.mark.parametrize(
+        ("operator", "value"),
+        [
+            ("custom_distance", {"function": "my_dist", "parameters": [1.0, 2.0]}),
+            ("custom_distance", {"function": "my_dist"}),
+            ("vector_norm", "l2"),
+            ("vector_norm", {"threshold": 2.0}),
+        ],
+    )
+    def test_dense_vector_operator_raises(self, operator, value) -> None:
+        """Reached by field-name detection with no type hint."""
+        with pytest.raises(WhereClauseError):
+            render_dense(operator, value)
+
+    def test_null_operator_value_is_still_treated_as_unset(self) -> None:
+        """``{"vector_norm": None}`` must keep meaning "not supplied", not "reject".
+
+        ``_make_filter_field_composed`` skips a ``None`` operator value before
+        resolving the operator at all, so the rejection is never reached. That
+        is the framework-wide convention for every operator -- an unset GraphQL
+        input field -- and #510 does not change it. Pinned so the rejection is
+        not later widened into a behaviour change for null inputs.
+        """
+        assert render_dense("vector_norm", None) is None
+
+    @pytest.mark.parametrize(
+        ("operator", "value"),
+        [
+            ("custom_distance", {"function": "my_dist", "parameters": [1.0]}),
+            ("vector_norm", "l2"),
+        ],
+    )
+    def test_sparse_vector_operator_raises(self, operator, value) -> None:
+        """``SparseVectorField`` *is* mapped in ``from_python_type``."""
+        where = safe_create_where_type(_SparseDoc)()
+        where.sparse_emb = {operator: value}
+        with pytest.raises(WhereClauseError):
+            where.to_sql()
+
+    @pytest.mark.parametrize(
+        ("operator", "value"),
+        [
+            ("quantized_distance", {"target_vector": [0.1, 0.2], "distance_type": "cosine"}),
+            ("reconstruct", True),
+        ],
+    )
+    def test_quantized_vector_operator_raises(self, operator, value) -> None:
+        """``QuantizedVectorField`` is mapped too, so a plain type hint reaches these."""
+        where = safe_create_where_type(_QuantizedDoc)()
+        where.quantized_emb = {operator: value}
+        with pytest.raises(WhereClauseError):
+            where.to_sql()
+
+    def test_error_names_the_operator(self) -> None:
+        """The message must say which operator was refused, not just that one was."""
+        with pytest.raises(WhereClauseError, match="custom_distance"):
+            render_dense("custom_distance", {"function": "my_dist"})
+
+
+class TestRejectionIsLoudNotSilent:
+    """Unregistering the operators would drop the filter and widen the result set."""
+
+    def test_sibling_filter_does_not_survive_alone(self) -> None:
+        """A surviving scope filter with the vector filter gone is the danger (#505).
+
+        Under the tempting fix -- deleting the four ``OPERATOR_MAP`` entries --
+        this renders ``(data ->> 'tenant') = 'acme'`` on its own and executes,
+        silently ignoring the vector filter.
+        """
+        where = WhereType()
+        where.OR = [
+            {"tenant": {"eq": "acme"}, "embedding": {"custom_distance": {"function": "my_dist"}}}
+        ]
+        with pytest.raises(WhereClauseError):
+            where.to_sql()
+
+    def test_rejection_is_not_a_value_error(self) -> None:
+        """``_make_filter_field_composed`` swallows ``ValueError`` and continues."""
+        with pytest.raises(WhereClauseError) as excinfo:
+            render_dense("vector_norm", "l2")
+        assert not isinstance(excinfo.value, ValueError)
+
+    def test_operators_stay_registered(self) -> None:
+        """Kept in the registry on purpose, so the reject reaches the caller."""
+        from fraiseql.sql.where.core.field_detection import FieldType
+        from fraiseql.sql.where.operators import OPERATOR_MAP
+
+        assert (FieldType.VECTOR, "custom_distance") in OPERATOR_MAP
+        assert (FieldType.VECTOR, "vector_norm") in OPERATOR_MAP
+        assert (FieldType.SPARSE_VECTOR, "custom_distance") in OPERATOR_MAP
+        assert (FieldType.SPARSE_VECTOR, "vector_norm") in OPERATOR_MAP
+        assert (FieldType.QUANTIZED_VECTOR, "quantized_distance") in OPERATOR_MAP
+        assert (FieldType.QUANTIZED_VECTOR, "reconstruct") in OPERATOR_MAP
+
+    def test_registry_names_every_rejected_operator(self) -> None:
+        """The rejection table and the registry must not drift apart."""
+        assert set(NON_PREDICATE_OPERATORS) == {
+            "custom_distance",
+            "vector_norm",
+            "quantized_distance",
+            "reconstruct",
+        }
+
+    def test_every_rejected_operator_has_a_remedy(self) -> None:
+        """Each entry carries the two message halves ``_reject_non_predicate`` reads."""
+        for operator, (renders, remedy) in NON_PREDICATE_OPERATORS.items():
+            assert renders, operator
+            assert remedy, operator
+
+
+class TestNoCallerStringReachesTheStatement:
+    """The raw-interpolation channels must not render, whatever the payload."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            # The function name was concatenated verbatim via SQL().
+            {"function": "x) OR true --"},
+            {"function": "true OR 1=1 --"},
+            # 'parameters' was a second, unreported channel: SQL(str(param)).
+            {"function": "strpos", "parameters": ["'x') > -1 OR true --"]},
+            {"function": "my_dist", "parameters": ["0) OR true --"]},
+        ],
+    )
+    def test_custom_distance_payload_never_renders(self, payload) -> None:
+        """Both channels executed as injected SQL against live pgvector."""
+        with pytest.raises(WhereClauseError):
+            render_dense("custom_distance", payload)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            # 'distance_type' was interpolated into the function name.
+            {"target_vector": [0.1], "distance_type": "x(1) OR true --"},
+            # Each target_vector element was rendered with SQL(str(v)).
+            {"target_vector": ["0.1]'::vector) OR true --"]},
+        ],
+    )
+    def test_quantized_distance_payload_never_renders(self, payload) -> None:
+        """``quantized_distance`` carried the same two channels, unreported."""
+        where = safe_create_where_type(_QuantizedDoc)()
+        where.quantized_emb = {"quantized_distance": payload}
+        with pytest.raises(WhereClauseError):
+            where.to_sql()
+
+
+class TestBuildersRejectDirectly:
+    """The builders are public; calling one directly must not yield SQL either."""
+
+    @pytest.mark.parametrize(
+        ("builder", "value"),
+        [
+            (build_custom_distance_sql, {"function": "my_dist"}),
+            (build_vector_norm_sql, "l2"),
+            (build_quantized_distance_sql, {"target_vector": [0.1]}),
+            (build_quantization_reconstruct_sql, None),
+        ],
+    )
+    def test_builder_raises_where_clause_error(self, builder, value) -> None:
+        with pytest.raises(WhereClauseError):
+            builder(SQL("(data ->> 'embedding')"), value)

--- a/tests/unit/sql/where/operators/test_vectors.py
+++ b/tests/unit/sql/where/operators/test_vectors.py
@@ -9,6 +9,7 @@ These tests focus on SQL generation for pgvector's three native distance operato
 import pytest
 from psycopg.sql import SQL, Composed
 
+from fraiseql.errors.exceptions import WhereClauseError
 from fraiseql.sql.where.core.field_detection import FieldType
 from fraiseql.sql.where.operators import get_operator_function
 from fraiseql.sql.where.operators.vectors import (
@@ -325,12 +326,15 @@ class TestVectorAggregationOperators:
         sql_str = result.as_string(None)
         assert "AVG(" in sql_str
 
-    def test_vector_norm_sql(self):
-        """Test vector norm calculation."""
-        path_sql = SQL("embedding")
-        result = build_vector_norm_sql(path_sql, None)
-        sql_str = result.as_string(None)
-        assert "vector_norm(" in sql_str or "l2_norm(" in sql_str
+    def test_vector_norm_is_rejected(self):
+        """A norm is a number, so it is refused in a WHERE clause (#510).
+
+        This previously asserted that ``vector_norm(col, 'l2')`` rendered.
+        pgvector declares ``vector_norm(vector)`` -- one argument -- so that
+        call never existed and PostgreSQL rejected every execution of it.
+        """
+        with pytest.raises(WhereClauseError):
+            build_vector_norm_sql(SQL("embedding"), None)
 
 
 class TestSparseVectorAggregationOperators:
@@ -370,35 +374,35 @@ class TestHalfVectorAggregationOperators:
 
 
 class TestVectorQuantizationOperators:
-    """Test vector quantization and reconstruction operators."""
+    """Quantization operators are not WHERE predicates and are refused (#510).
 
-    def test_quantized_distance_sql(self):
-        """Test quantized vector distance."""
-        path_sql = SQL("quantized_embedding")
+    Both named functions -- ``quantized_<type>_distance`` and
+    ``reconstruct_quantized_vector`` -- are undefined, and neither returns a
+    boolean. The assertions here previously pinned that broken rendering.
+    Reachability and the injection channels are covered in
+    ``test_vector_non_predicate_operators.py``.
+    """
+
+    def test_quantized_distance_is_rejected(self):
+        """``quantized_cosine_distance`` is not a function FraiseQL defines."""
         config = {"target_vector": [0.1, 0.2, 0.3], "distance_type": "cosine"}
-        result = build_quantized_distance_sql(path_sql, config)
-        sql_str = result.as_string(None)
-        assert "quantized_cosine_distance(" in sql_str
-        assert "::vector" in sql_str
+        with pytest.raises(WhereClauseError):
+            build_quantized_distance_sql(SQL("quantized_embedding"), config)
 
-    def test_quantization_reconstruct_sql(self):
-        """Test quantization reconstruction."""
-        path_sql = SQL("quantized_vector")
-        result = build_quantization_reconstruct_sql(path_sql, None)
-        sql_str = result.as_string(None)
-        assert "reconstruct_quantized_vector(" in sql_str
+    def test_quantization_reconstruct_is_rejected(self):
+        """Reconstruction returns a vector, never a predicate."""
+        with pytest.raises(WhereClauseError):
+            build_quantization_reconstruct_sql(SQL("quantized_vector"), None)
 
 
 class TestCustomVectorDistanceOperators:
-    """Test custom vector distance operators."""
+    """``custom_distance`` is not a WHERE predicate and is refused (#510)."""
 
-    def test_custom_distance_sql(self):
-        """Test custom distance calculation."""
-        path_sql = SQL("custom_vector")
+    def test_custom_distance_is_rejected(self):
+        """A bare call to a caller-supplied function, with no way to validate it."""
         config = {"function": "my_distance_func", "parameters": [1.0, 2.0, 3.0]}
-        result = build_custom_distance_sql(path_sql, config)
-        sql_str = result.as_string(None)
-        assert "my_distance_func(" in sql_str
+        with pytest.raises(WhereClauseError):
+            build_custom_distance_sql(SQL("custom_vector"), config)
 
 
 class TestBinaryVectorBitWidth:


### PR DESCRIPTION
Closes #510.

Four entries in the vector operator registry render an expression rather than a boolean, so none can serve as a WHERE predicate. Rendered through the real registry path on `5ad28d61c`:

```
custom_distance     my_dist((data ->> 'embedding'), 1, 2)
vector_norm         vector_norm((data ->> 'embedding'), 'l2')
quantized_distance  quantized_cosine_distance((data ->> 'qv'), [0.1,0.2]::vector)
reconstruct         reconstruct_quantized_vector((data ->> 'qv'))
```

## Correcting the issue's scope on two points

**The quantized pair has the identical defect and is not in #510.** It is also *more* reachable than the dense case: `QuantizedVectorField` is mapped in `FieldType.from_python_type`, so a plain type hint reaches it, whereas `FieldType.VECTOR` has no mapping at all and is reached only by field-name detection with no resolved hint.

**`parameters` is a second raw-interpolation channel.** #510 reports `value["function"]`; `build_custom_distance_sql` also renders every entry of `parameters` with `SQL(str(param))`, and `build_quantized_distance_sql` carries the same two channels through `distance_type` and through each element of `target_vector`.

What #510 gets exactly right, and this PR does not widen: `VectorFilter` declares none of these operators, so no GraphQL request reaches them. They are reachable only by application code passing a dict into a vector filter.

## None of the four has ever executed

`vector_norm` is the clearest case. pgvector declares `vector_norm(vector)` — one argument:

```
=# SELECT id FROM t WHERE vector_norm((data ->> 'embedding'), 'l2');
ERROR:  function vector_norm(text, unknown) does not exist
```

The two-argument form does not exist at any arity. The column was never cast to `vector` either, and the sparse registration points at the wrong name — pgvector calls that one `l2_norm(sparsevec)`, so one builder could not have served both registrations. `quantized_distance` names two functions FraiseQL does not define and emits its vector literal unquoted, so the fragment does not parse.

Both injection channels do execute. Against live pgvector, with two rows:

```
scoped baseline   WHERE vector_norm((data ->> 'embedding')::vector) < 1.5   -> [1]
function channel  {"function": "true OR 1=1 --"}                            -> [1, 2]
parameters        {"function": "strpos", "parameters": ["'x') > -1 OR true --"]} -> [1, 2]
```

## Why reject rather than give them a threshold shape

`custom_distance` calls a function FraiseQL cannot know, and there is no registry of user-defined distance functions to validate a name against — an allow-list would have nothing in it. `Identifier` would close the name channel but leaves an operator that still renders a non-boolean. The other three name functions that do not exist. Giving any of them a threshold shape would be new feature work on a path no GraphQL query can reach, so they are refused instead.

## Rejecting is not the same as unregistering

All six `OPERATOR_MAP` entries stay registered on purpose. Deleting them is the tempting fix and is worse: `get_operator_function` raises `ValueError` for an unknown operator, and `_make_filter_field_composed` swallows it with `except ValueError: continue`. The vector filter would vanish while its sibling scoping filters survived, so the query would succeed over a wider row set instead of failing. A registered builder raising `WhereClauseError` — a `FraiseQLException`, deliberately not a `ValueError` — propagates.

The e2e test executes that surviving scope filter, rendered by the real renderer, to show it returns both rows before asserting the real path raises.

## Changes

- Raise `WhereClauseError` from all four builders, with the message halves held in a `NON_PREDICATE_OPERATORS` table
- Drop `VectorOrderBy.custom_distance` and `.vector_norm` — declared GraphQL input fields that nothing read, since `_append_vector_order_by` iterates `VECTOR_DISTANCE_OPERATORS`, which names the six real operators. A client could send either and get no `ORDER BY` term and no error. The new test pins declared-equals-read in both directions
- Replace the four unit tests that asserted the old broken rendering

## Verification

- ✅ New tests fail on dev: 20 of 22 unit, 4 of 5 e2e, 3 of 3 order-by. The 5th e2e is the regression guard for the six operators #511 fixed, which correctly passes both ways
- ✅ New tests **also** fail against the naive fix — deleting the `OPERATOR_MAP` entries: 18 of 24 fail, because the filter is silently dropped rather than refused
- ✅ Both injection channels executed against live pgvector before the fix and returned every row; the e2e runs those statements so the assertions are anchored to a demonstrated result set, not a string match
- ✅ 5 new e2e tests confirmed PASSED, not skipped, in `-v` output
- ✅ `uv run pytest tests/unit/ tests/integration/ -q`: 6119 passed (`test_nested_organization_without_tenant_id` fails on dev already)
- ✅ ruff check + format clean; `uv run ty check` unchanged at 538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N