### PR TITLE
docs: credit external contributors whose work shaped what shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Entries below cover the vector operator series and the Rust benchmark targets.
+Other changes landed since 1.24.0 are not yet logged here.
+
+### Fixed
+
+- **Vector distance filters are now boolean WHERE predicates.** All six
+  operators rendered a bare distance expression -- a `double precision` -- so
+  PostgreSQL rejected any WHERE clause containing one with `argument of WHERE
+  must be type boolean`. The distance is now wrapped in the requested
+  comparison, and every accepted input shape is normalised through one
+  function. The root cause was diagnosed first by
+  [@mikemikimike](https://github.com/mikemikimike) in #509, whose approach this
+  builds on. (#505, #511)
+- **`custom_distance`, `vector_norm`, `quantized_distance` and `reconstruct`
+  are refused in a WHERE clause** instead of rendering an expression that is
+  not a predicate. None of the four ever executed: `vector_norm` emitted a
+  two-argument call to a pgvector function that takes one, and the quantized
+  pair name functions FraiseQL does not define. `custom_distance` and
+  `quantized_distance` also concatenated caller-supplied strings into the
+  statement through `psycopg.sql.SQL()`, which does not escape; neither was
+  reachable from a GraphQL request, since `VectorFilter` declares no such
+  field. They stay registered so the rejection raises `WhereClauseError` rather
+  than being swallowed as an unsupported operator, which would drop the filter
+  and widen the result set. (#510, #512)
+- **Jaccard distance renders as a function call rather than the `<%>`
+  operator**, which psycopg rejects as a placeholder whenever the statement
+  carries parameters. (#495, #507)
+- **Both operands of a bit distance carry the literal's width.** A bare
+  `::bit` is `bit(1)`, so the distance was computed over a single bit and every
+  row reported 0. (#494, #504)
+- **The Rust benchmark targets compile, and CI keeps them compiling.** The
+  benches had drifted past the API they call and no job built them.
+  [@Joemon24](https://github.com/Joemon24) identified the same drift and posted
+  equivalent source fixes in #491 two hours before this landed. (#471, #500)
+
+### Removed
+
+- **`VectorOrderBy.custom_distance` and `.vector_norm`** -- declared GraphQL
+  input fields that nothing read, so a client could send either and get no
+  `ORDER BY` term and no error. (#512)
+
 ## [1.24.0] - 2026-08-30
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,6 +310,15 @@ Before submitting a PR, ensure:
 Your change merges into `dev` and ships to `main` on the next `dev → main`
 sync, included in the next release.
 
+### Credit
+
+Contributions that shape what ships are recorded in
+[CONTRIBUTORS.md](CONTRIBUTORS.md). That includes work folded into another pull
+request rather than merged on its own: a diagnosis that was correct first still
+counts, and the CHANGELOG entry names you alongside the fix. If your work
+shaped a change and you are not listed, say so on the pull request — the
+omission is an oversight, not a judgement.
+
 ---
 
 ## Release Process

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,37 @@
+# Contributors
+
+FraiseQL is maintained by [@evoludigit](https://github.com/evoludigit).
+
+This file records people outside the maintainer group whose work has shaped the
+project. It is not a list of everyone who has opened a pull request — it names
+contributions that changed what shipped, including diagnoses that were correct
+first and were then built on.
+
+## Contributions
+
+### [@mikemikimike](https://github.com/mikemikimike)
+
+Identified the root cause behind [#505](https://github.com/fraiseql/fraiseql-python/issues/505):
+all six vector distance operators rendered a bare distance expression, which is
+a `double precision` and not a predicate, so PostgreSQL rejected every WHERE
+clause containing one with `argument of WHERE must be type boolean`. The fix —
+wrap the distance in the requested comparison inside the operator registry — is
+the approach [#511](https://github.com/fraiseql/fraiseql-python/pull/511)
+shipped, filed in [#509](https://github.com/fraiseql/fraiseql-python/pull/509)
+an hour and a half before that PR was opened.
+
+### [@Joemon24](https://github.com/Joemon24)
+
+Produced the compile fixes for the Rust benchmark targets in
+[#491](https://github.com/fraiseql/fraiseql-python/pull/491), answering
+[#471](https://github.com/fraiseql/fraiseql-python/issues/471): the benches had
+drifted past the API they call, and no CI job compiled them. The source changes
+that landed in [#500](https://github.com/fraiseql/fraiseql-python/pull/500) two
+hours later are equivalent to theirs.
+
+## Adding to this file
+
+Maintainers add entries when a contribution lands, whether it merged as its own
+pull request or was folded into another. If your work shaped a change and you
+are not listed, say so on the pull request or open an issue — the omission is an
+oversight, not a judgement.


### PR DESCRIPTION
Two external pull requests reached a correct diagnosis first and were then superseded by a maintainer PR, leaving no durable credit behind. #511's body names @mikemikimike in prose; #500 does not mention #491 at all, and neither merged commit carries a `Co-authored-by` trailer. Timeline checked against the GitHub API:

| | filed | superseded by | gap |
|---|---|---|---|
| @mikemikimike, #509 | 15:29 | #511 opened 16:59, merged 17:05 | 1h30m |
| @Joemon24, #491 | 10:30 | #500 opened 12:39, merged 13:50 | 2h09m |

Both were answering an issue the maintainer had filed hours earlier (#505 and #471), and both got the root cause right.

## Changes

- **`CONTRIBUTORS.md`** — records what each contribution actually was, not just a name. States explicitly that work folded into another PR still counts, so the file does not quietly become a list of people who happened to get merged.
- **`CHANGELOG.md`** — adds an `[Unreleased]` section covering the vector operator series (#504, #507, #511, #512) and the Rust benches (#500), naming both contributors inline. Scoped deliberately, and the section says so: roughly sixteen other commits landed since the 1.24.0 entry and are not logged here. Backfilling those is separate work.
- **`CONTRIBUTING.md`** — points the PR process at `CONTRIBUTORS.md` so the file is discoverable, and says how to correct an omission.

## Verification

- ✅ Docs only; no source changes
- ✅ Every date, author and PR relationship read from the GitHub API rather than recalled
- ✅ Pre-commit passed (`markdownlint` skipped per the repo's docs convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N