### PR TITLE
chore(release): v1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,74 @@ All notable changes to FraiseQL are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.25.0] - 2026-08-30
 
-Entries below cover the vector operator series and the Rust benchmark targets.
-Other changes landed since 1.24.0 are not yet logged here.
+### Added
+
+- **`default_string_collation` now reaches the query.** The setting is
+  documented as applying to "all text fields in ORDER BY unless overridden
+  per-field" and had never affected a sort. #481 deliberately left it inert,
+  because nothing in the `order_by` pipeline knew which fields were text and a
+  blanket default would have produced a silently lexicographic sort for a
+  numeric JSONB field (1, 10, 2) and `collations are not supported by type
+  integer` for a numeric flat column. Sort paths are now resolved against the
+  source type's annotations, and the default applies only to `str` leaves.
+  Anything unresolved -- an unregistered view, an aggregation prefix, an
+  undeclared field -- keeps the behaviour it had. (#482, #502)
 
 ### Fixed
 
+- **`OrderBy.collation` was applied by none of the three paths that render a
+  sort key.** Both flat-column branches returned before the `COLLATE` block ran
+  and dropped the clause outright. The JSONB branch emitted
+  `data -> 'name' COLLATE "x"`, which parses as `data -> ('name' COLLATE "x")`
+  -- `COLLATE` binds tighter than `->`, so the collation attached to the key
+  literal, the comparison stayed `jsonb`, and PostgreSQL accepted it in
+  silence. Every collatable branch now routes through one helper. Note that a
+  collated sort is a text sort, so an explicit JSON null now sorts with an
+  absent key rather than ahead of every string. (#476, #481)
+- **`order_by` given as a list of dicts did not recurse into nested fields.**
+  `{"measures": {"cost": "desc"}}` sorted correctly; the same value wrapped in
+  a list sorted by `measures ASC` -- wrong field and wrong direction, with no
+  error. The list branch had its own shallower parser that handed the nested
+  dict to the direction normaliser, which does not recognise a dict and
+  returned the ASC default. Both shapes now walk the same collector, and a
+  value neither shape can read warns and is dropped instead of silently
+  defaulting to ASC. (#475, #484)
+- **Schema-qualified view names rendered as one quoted identifier containing a
+  dot.** A view registered as `myschema.v_stats` has to become
+  `"myschema"."v_stats"`; passing the whole string to a single-argument
+  `Identifier` produced `"myschema.v_stats"` and the statement failed with
+  `relation "myschema.v_stats" does not exist`. Fixed across every site in
+  three passes: the partial-period UNION branch builders plus eleven repeated
+  copies in `db.py` (#472, #485), cursor pagination, reachable from any
+  `@connection` query (#486, #487), and the SQL, mutation and langchain
+  generators (#488, #489). The splitting helper now lives in
+  `sql/identifiers.py` as `qualified_identifier`, so there is one spelling of
+  it.
+- **The langchain vector store's read path interpolated five
+  constructor-supplied names as bare text.** `asimilarity_search` built its
+  statement as an f-string while the two write paths rendered the same names
+  through `psycopg.sql`, so the same constructor arguments were accepted on
+  write and rejected on read: an unquoted name is folded to lower case, so any
+  name needing quotes -- mixed case, a reserved word, a hyphen -- resolved one
+  way and failed the other. Request-controlled values were already
+  parameterised. (#490, #492)
+- **Three of the six `VectorOrderBy` distance operators were unusable, and the
+  two `order_by` shapes disagreed about which.** The dict shape emitted no
+  instruction at all for `l1_distance`, `hamming_distance` and
+  `jaccard_distance`, so the query ran unsorted and returned rows in scan
+  order; the `__gql_fields__` shape emitted a JSONB path sort against a vector
+  column, which the server rejects. The bit-string operators also emitted a
+  second, contradictory `DESC` term, because a `VectorOrderBy` was handled and
+  then recursed into as a nested input. Both shapes now read one operator tuple
+  and append through one helper. (#483, #493)
+- **Aggregation `measures` and `native_measures` keys are normalised at
+  registration.** Both are matched against dotted field paths built with
+  `to_snake_case`, so a key written in GraphQL spelling -- `measures.totalCost`
+  -- matched nothing, with no error and no warning. This is the casing trap
+  #467 fixed for `native_dimension_mapping` and deliberately left here. (#477,
+  #496)
 - **Vector distance filters are now boolean WHERE predicates.** All six
   operators rendered a bare distance expression -- a `double precision` -- so
   PostgreSQL rejected any WHERE clause containing one with `argument of WHERE
@@ -41,12 +102,54 @@ Other changes landed since 1.24.0 are not yet logged here.
   benches had drifted past the API they call and no job built them.
   [@Joemon24](https://github.com/Joemon24) identified the same drift and posted
   equivalent source fixes in #491 two hours before this landed. (#471, #500)
+- **`DATABASE_URL` no longer leaks out of the example fixtures into later
+  tests.** Two fixtures set six environment variables with bare
+  `os.environ[...]` and never restored them, so a CLI test that should fail on
+  a missing argument instead connected to whatever server the inherited URL
+  named. (#470, #497)
 
 ### Removed
 
 - **`VectorOrderBy.custom_distance` and `.vector_norm`** -- declared GraphQL
   input fields that nothing read, so a client could send either and get no
   `ORDER BY` term and no error. (#512)
+- **`fraiseql.security.startup_checks`**, a security module nothing imported.
+  It could not have been wired in as written: `disable_sqlite_fts5()` was a
+  no-op calling a `Connection` method as though it were module-level,
+  `run_all_security_checks()` called `sys.exit(1)` from library code, and two
+  further checks raised when running as root. A security control nobody calls
+  reads as a control during an audit and enforces nothing. (#473, #499)
+- **`aiosqlite` from `[project.dependencies]`** -- installed by every
+  `pip install fraiseql` and imported by nothing in the repository. Vestigial
+  from the multi-database ambition v1 dropped; v1 is PostgreSQL-only. The
+  package remains in the lock as a `llama-index-core` dependency, so the
+  `llamaindex` extra still resolves. (#474, #498)
+- **Four `fraiseql_rs/tests/` directories**, 423 lines that no cargo target
+  reaches in runnable form. `tests/common/` was type-checked through an
+  `include!` in `src/lib.rs` but could never execute, because the lib test
+  binary cannot link under pyo3's `extension-module`; the other three were not
+  cargo targets at all. (#501, #506)
+
+### Security
+
+- **The compliance report's "Unpatched vulnerabilities" counter could only ever
+  report 0.** It tested `FixedVersion == ""`, but Trivy omits the key entirely
+  when upstream has no fix, so the key read as null and matched nothing -- in
+  an artifact stamped "Compliance Level: Government Agency Ready", stating the
+  inverse of the truth. A FIXABLE complement was added alongside. (#478, #480)
+- **The scan summary now counts UNKNOWN-severity CVEs**, closing a 7-finding
+  gap against the Security tab (88 vs 81). The SARIF upload always contained
+  them: `severity:` on that step is inert, because trivy-action unsets
+  `TRIVY_SEVERITY` for SARIF format. (#508)
+
+### Internal
+
+- Recorded why the Trivy SARIF `category:` must never change: GitHub closes an
+  alert only when a later analysis for the same category omits it, so a rename
+  strands every alert uploaded under the old one. (#503)
+- Added `CONTRIBUTORS.md`, recording external contributions that shaped what
+  shipped including work folded into another pull request, and pointed
+  `CONTRIBUTING.md` at it. (#513)
 
 ## [1.24.0] - 2026-08-30
 

--- a/fraiseql_rs/Cargo.toml
+++ b/fraiseql_rs/Cargo.toml
@@ -158,7 +158,7 @@ name = "fraiseql_rs"
 publish = false
 readme = "README.md"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "1.24.0"
+version = "1.25.0"
 
 # Benchmark profile for accurate measurements
 [profile.bench]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ keywords = [
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
-version = "1.24.0"
+version = "1.25.0"
 
 [project.optional-dependencies]
 all = [

--- a/uv.lock
+++ b/uv.lock
@@ -740,7 +740,7 @@ dependencies = [
 ]
 name = "fraiseql"
 source = {editable = "."}
-version = "1.24.0"
+version = "1.25.0"
 
 [package.dev-dependencies]
 dev = [


### PR DESCRIPTION
Twenty-two commits landed on `dev` since v1.24.0 and none were logged. This writes the CHANGELOG section covering all of them and bumps the version in the three files that carry it.

**Minor, not patch.** #502 adds a feature — `default_string_collation` finally reaches the query — and #512 removes two declared GraphQL input fields from `VectorOrderBy`.

## What's in the release

The batch is mostly correctness, and several of them made whole features unusable rather than merely wrong:

- **Schema-qualified view names** failed everywhere they were rendered as a single `Identifier`, producing `relation "myschema.v_stats" does not exist`. Fixed in three passes across `db.py`, cursor pagination, and the SQL/mutation/langchain generators (#485, #487, #489), now behind one `qualified_identifier` helper.
- **Vector filtering was non-functional end to end.** All six WHERE distance operators rendered a non-boolean and Postgres rejected the statement (#511); three of six ORDER BY operators emitted nothing or an invalid JSONB sort (#493); bit distances collapsed to `bit(1)` so every row scored 0 (#504); Jaccard could not survive a parameterised statement (#507). #512 then refused the four operators that can never be predicates.
- **`OrderBy.collation` reached none of the three sort paths** (#481) — the JSONB one parsed as `data -> ('name' COLLATE "x")` and was accepted in silence — and nested `order_by` silently sorted by the wrong field when wrapped in a list (#484).
- **Security reporting corrected twice**: the "Unpatched vulnerabilities" counter was structurally incapable of returning anything but 0 (#480), and the scan summary now counts UNKNOWN CVEs, closing the 88-vs-81 gap against the Security tab (#508).

External contributors @mikemikimike (#509) and @Joemon24 (#491) are credited inline in the entries their work shaped.

## Changes

- `CHANGELOG.md` — `[1.25.0]` section; every one of the 22 commits verified present by PR number
- `pyproject.toml`, `fraiseql_rs/Cargo.toml` — 1.24.0 → 1.25.0, kept in sync because `release-check` compares them and fails on a mismatch
- `uv.lock` — the editable package version only, edited by hand so a re-lock doesn't rewrite thousands of lines as pure format churn

## Verification

- ✅ `make release-check` passes for v1.25.0: clean tree, versions consistent, ruff clean, 3636 unit tests
- ✅ `uv lock --check` resolves clean; the `uv.lock` diff is exactly 1 line
- ✅ `pytest tests/unit/ tests/integration/ -q`: 6119 passed
- ✅ The one integration failure (`test_nested_organization_without_tenant_id`) fails identically when checked out at the `v1.24.0` tag — pre-existing and already shipped in 1.24.0, not a regression from this batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N