### PR TITLE
test(repository): teach the nested-tenant stub about mandatory_filters

### DIFF
--- a/tests/integration/database/repository/test_nested_tenant_integration.py
+++ b/tests/integration/database/repository/test_nested_tenant_integration.py
@@ -1,173 +1,34 @@
-"""Test the nested object tenant_id fix with a real database.
+"""A nested object with its own ``sql_source`` resolves from embedded JSONB.
 
-This test creates the necessary database schema and demonstrates that
-the fix allows nested objects with sql_source to work without requiring
-tenant_id when the data is embedded.
+``User.organization`` is declared with ``sql_source="mv_organization"`` but its
+data is embedded in ``v_user``'s ``data`` column. Resolving it must not demand a
+``tenant_id`` from the GraphQL context, because nothing needs to be looked up.
+
+The tests run against the shared test container through ``class_db_pool`` and
+``test_schema``. They previously built their own connection from ``DB_HOST`` and
+friends and created a whole ``fraiseql_nested_test`` database, then skipped
+themselves whenever ``GITHUB_ACTIONS`` was set -- so CI never ran them and
+``test_nested_organization_without_tenant_id`` sat red for three and a half
+months without anything reporting it (#516).
 """
 
-import asyncio
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
-import psycopg
 import pytest
+import pytest_asyncio
 from graphql import GraphQLResolveInfo
+from psycopg.sql import SQL, Identifier
 
 from fraiseql import query
 from fraiseql import type as fraiseql_type
 
 pytestmark = pytest.mark.database
 
-
-async def setup_test_database() -> None:
-    """Create a test database with the necessary schema."""
-    # Get database connection details from environment
-    import os
-
-    # Use environment variables that match GitHub Actions setup
-    db_host = os.environ.get("DB_HOST", "localhost")
-    db_port = os.environ.get("DB_PORT", "5432")
-    db_user = os.environ.get("DB_USER", "fraiseql")
-    db_password = os.environ.get("DB_PASSWORD", "fraiseql")
-
-    # Connect to PostgreSQL to create test database
-    conn = await psycopg.AsyncConnection.connect(
-        f"host={db_host} port={db_port} user={db_user} password={db_password} dbname=postgres",
-        autocommit=True,
-    )
-
-    try:
-        # Drop and recreate test database
-        await conn.execute("DROP DATABASE IF EXISTS fraiseql_nested_test")
-        await conn.execute("CREATE DATABASE fraiseql_nested_test")
-    finally:
-        await conn.close()
-
-    # Connect to the new test database
-    conn = await psycopg.AsyncConnection.connect(
-        f"host={db_host} port={db_port} user={db_user} password={db_password} dbname=fraiseql_nested_test"
-    )
-
-    try:
-        # Create schemas
-        await conn.execute("CREATE SCHEMA IF NOT EXISTS tenant")
-        await conn.execute("CREATE SCHEMA IF NOT EXISTS public")
-
-        # Create the organizations table
-        await conn.execute(
-            """
-            CREATE TABLE tenant.tb_organization (
-                pk_organization UUID PRIMARY KEY,
-                name TEXT NOT NULL,
-                identifier TEXT UNIQUE NOT NULL,
-                data JSONB NOT NULL DEFAULT '{}'::jsonb,
-                created_at TIMESTAMPTZ DEFAULT NOW()
-            )
-        """
-        )
-
-        # Create the contacts table
-        await conn.execute(
-            """
-            CREATE TABLE tenant.tb_contact (
-                pk_contact UUID PRIMARY KEY,
-                fk_customer_org UUID NOT NULL REFERENCES tenant.tb_organization(pk_organization),
-                first_name TEXT NOT NULL,
-                last_name TEXT NOT NULL,
-                email_address TEXT UNIQUE NOT NULL,
-                data JSONB NOT NULL DEFAULT '{}'::jsonb,
-                created_at TIMESTAMPTZ DEFAULT NOW()
-            )
-        """
-        )
-
-        # Create materialized view for organizations
-        await conn.execute(
-            """
-            CREATE MATERIALIZED VIEW public.mv_organization AS
-            SELECT
-                pk_organization AS id,
-                pk_organization AS tenant_id,  -- org is its own tenant
-                jsonb_build_object(
-                    'id', pk_organization,
-                    'name', name,
-                    'identifier', identifier,
-                    'status', COALESCE(data->>'status', 'active')
-                ) AS data
-            FROM tenant.tb_organization
-        """
-        )
-
-        # Create view for users with EMBEDDED organization data
-        await conn.execute(
-            """
-            CREATE VIEW public.v_user AS
-            SELECT
-                c.pk_contact AS id,
-                c.fk_customer_org AS tenant_id,
-                jsonb_build_object(
-                    'id', c.pk_contact,
-                    'first_name', c.first_name,
-                    'last_name', c.last_name,
-                    'email_address', c.email_address,
-                    'organization', jsonb_build_object(  -- EMBEDDED organization
-                        'id', o.pk_organization,
-                        'name', o.name,
-                        'identifier', o.identifier,
-                        'status', COALESCE(o.data->>'status', 'active')
-                    )
-                ) AS data
-            FROM tenant.tb_contact c
-            JOIN tenant.tb_organization o ON c.fk_customer_org = o.pk_organization
-        """
-        )
-
-        # Insert test data
-        await conn.execute(
-            """
-            INSERT INTO tenant.tb_organization (pk_organization, name, identifier, data)
-            VALUES (
-                '6f726700-0000-0000-0000-000000000000'::uuid,
-                'Test Organization',
-                'TEST-ORG',
-                '{"status": "active", "type": "enterprise"}'::jsonb
-            )
-        """
-        )
-
-        await conn.execute(
-            """
-            INSERT INTO tenant.tb_contact (
-                pk_contact,
-                fk_customer_org,
-                first_name,
-                last_name,
-                email_address,
-                data
-            )
-            VALUES (
-                '75736572-0000-0000-0000-000000000000'::uuid,
-                '6f726700-0000-0000-0000-000000000000'::uuid,
-                'Alice',
-                'Cooper',
-                'alice@example.com',
-                '{"role": "admin", "department": "Engineering"}'::jsonb
-            )
-        """
-        )
-
-        # Refresh materialized view
-        await conn.execute("REFRESH MATERIALIZED VIEW public.mv_organization")
-
-        await conn.commit()
-        return conn
-    except Exception:
-        await conn.rollback()
-        await conn.close()
-        raise
+ORG_ID = UUID("6f726700-0000-0000-0000-000000000000")
+USER_ID = UUID("75736572-0000-0000-0000-000000000000")
 
 
-# Define GraphQL types with sql_source
 @fraiseql_type(sql_source="mv_organization")
 class Organization:
     """Organization type with sql_source pointing to materialized view."""
@@ -178,7 +39,7 @@ class Organization:
     status: str = "active"
 
     @classmethod
-    def from_dict(cls, data: dict) -> None:
+    def from_dict(cls, data: dict) -> "Organization":
         """Create Organization from dictionary."""
         return cls(
             id=data.get("id"),
@@ -199,12 +60,10 @@ class User:
     organization: Optional[Organization] = None  # This is EMBEDDED in data column
 
     @classmethod
-    def from_dict(cls, data: dict) -> None:
+    def from_dict(cls, data: dict) -> "User":
         """Create User from dictionary."""
         org_data = data.get("organization")
-        org = None
-        if org_data:
-            org = Organization.from_dict(org_data)
+        org = Organization.from_dict(org_data) if org_data else None
 
         return cls(
             id=data.get("id"),
@@ -215,200 +74,124 @@ class User:
         )
 
 
-@pytest.mark.asyncio
-async def test_nested_organization_without_tenant_id() -> None:
-    """Test that querying user with nested organization works without tenant_id."""
-    # Skip in CI environment where database setup may differ
-    import os
+class StubRepository:
+    """Minimal ``find_one`` over a raw connection, for resolvers under test.
 
-    if os.environ.get("GITHUB_ACTIONS") == "true":
-        pytest.skip("Test requires complex database setup not available in CI")
+    One definition rather than a copy per test: the two copies this replaces
+    drifted apart, and only the one that had been updated to pass
+    ``mandatory_filters`` was broken by it (#516).
+    """
 
-    # Define database connection variables first
-    db_host = os.environ.get("DB_HOST", "localhost")
-    db_port = os.environ.get("DB_PORT", "5432")
-    db_user = os.environ.get("DB_USER", "fraiseql")
-    db_password = os.environ.get("DB_PASSWORD", "fraiseql")
+    def __init__(self, connection) -> None:
+        self.connection = connection
 
-    # Skip if no local database available
-    try:
-        # Try a quick connection test first
-        test_conn = await psycopg.AsyncConnection.connect(
-            f"host={db_host} port={db_port} user={db_user} password={db_password} dbname=postgres",
-            autocommit=True,
-            connect_timeout=1,
-        )
-        await test_conn.close()
-    except Exception:
-        pytest.skip("Test requires PostgreSQL database connection")
+    async def find_one(self, table: str, **kwargs: Any) -> dict[str, Any] | None:
+        """Return one row's ``data``, honouring the real ``mandatory_filters`` contract.
 
-    # Setup database
-    conn = await setup_test_database()
-
-    try:
-        # Create a FraiseQL repository wrapper
-        from fraiseql.cqrs.repository import CQRSRepository
-
-        class TestRepository(CQRSRepository):
-            async def find_one(self, table: str, **kwargs) -> None:
-                """Find one record from a table/view."""
-                where_conditions = []
-                params = []
-
-                for key, value in kwargs.items():
-                    where_conditions.append(f"{key} = %s")
-                    params.append(value)
-
-                where_clause = " AND ".join(where_conditions) if where_conditions else "1=1"
-
-                query = f"SELECT data FROM {table} WHERE {where_clause} LIMIT 1"
-
-                async with self.connection.cursor() as cursor:
-                    await cursor.execute(query, params)
-                    result = await cursor.fetchone()
-
-                    if result:
-                        return result[0]  # Return the JSONB data
-                    return None
-
-        db = TestRepository(conn)
-
-        # Define query resolver
-        @query
-        async def user(info: GraphQLResolveInfo, user_id: Optional[UUID] = None) -> Optional[User]:
-            """Query to get a user by ID."""
-            db = info.context["db"]
-
-            # Use a fixed test user ID if not provided
-            if user_id is None:
-                user_id = UUID("75736572-0000-0000-0000-000000000000")
-
-            result = await db.find_one("v_user", mandatory_filters={"id": user_id})
-
-            if result:
-                return User.from_dict(result)
-            return None
-
-        # Build GraphQL schema
-        from fraiseql.gql.builders.registry import SchemaRegistry
-        from fraiseql.gql.builders.schema_composer import SchemaComposer
-
-        registry = SchemaRegistry()
-        registry.register_query(user)  # Just pass the function
-        registry.register_type(User)
-        registry.register_type(Organization)
-
-        composer = SchemaComposer(registry)
-        schema = composer.compose()
-
-        # Execute GraphQL query
-        from graphql import graphql
-
-        query_str = """
-        query GetUser {
-          user {
-            id
-            firstName
-            lastName
-            emailAddress
-            organization {
-              id
-              name
-              identifier
-              status
-            }
-          }
-        }
+        ``FraiseQLRepository.find_one`` takes ``mandatory_filters`` as a mapping
+        of column to value and AND-s it into the WHERE clause. Treating it as a
+        column in its own right -- as this stub did until #516 -- builds
+        ``WHERE mandatory_filters = %s`` and hands psycopg a dict, which raises
+        ``cannot adapt type 'dict' using placeholder '%s'``. GraphQL then
+        recorded that as a field error and resolved the field to ``None``.
         """
+        filters: dict[str, Any] = {}
+        for key, value in kwargs.items():
+            if key == "mandatory_filters":
+                filters.update(value or {})
+            else:
+                filters[key] = value
 
-        # Context WITHOUT tenant_id - this is the key test
-        context = {
-            "db": db,
-            # Note: NOT providing tenant_id
-        }
+        statement = SQL("SELECT data FROM {}").format(Identifier(table))
+        if filters:
+            predicates = SQL(" AND ").join(
+                SQL("{} = %s").format(Identifier(column)) for column in filters
+            )
+            statement = statement + SQL(" WHERE ") + predicates
+        statement = statement + SQL(" LIMIT 1")
 
-        result = await graphql(schema, query_str, context_value=context)
-
-        # Check results
-        if result.errors:
-            error_messages = [str(e) for e in result.errors]
-
-            # The bug would cause "missing a required argument: 'tenant_id'" error
-            has_tenant_error = any("tenant_id" in msg.lower() for msg in error_messages)
-
-            if has_tenant_error:
-                pytest.fail(
-                    f"❌ Bug still present: Got tenant_id error when querying embedded organization.\n"
-                    f"Errors: {error_messages}"
-                )
-
-        # Verify the data was returned correctly
-        assert result.data is not None, "No data returned"
-        assert result.data["user"] is not None, "User data is None"
-
-        user_data = result.data["user"]
-        assert user_data["firstName"] == "Alice"
-        assert user_data["lastName"] == "Cooper"
-        assert user_data["emailAddress"] == "alice@example.com"
-
-        # Most importantly, the organization should be returned
-        assert user_data["organization"] is not None, (
-            "Organization data is None (embedded data not returned)"
-        )
-
-        org_data = user_data["organization"]
-        assert org_data["name"] == "Test Organization"
-        assert org_data["identifier"] == "TEST-ORG"
-        assert org_data["status"] == "active"
-
-    finally:
-        # Cleanup
-        await conn.close()
-
-        # Drop test database
-        cleanup_conn = await psycopg.AsyncConnection.connect(
-            f"host={db_host} port={db_port} user={db_user} password={db_password} dbname=postgres",
-            autocommit=True,
-        )
-        await cleanup_conn.execute("DROP DATABASE IF EXISTS fraiseql_nested_test")
-        await cleanup_conn.close()
+        async with self.connection.cursor() as cursor:
+            await cursor.execute(statement, list(filters.values()))
+            row = await cursor.fetchone()
+            return row[0] if row else None
 
 
-@pytest.mark.asyncio
-async def test_comparison_with_and_without_embedded() -> None:
-    """Compare behavior with embedded vs non-embedded organization data."""
-    # Skip in CI environment where database setup may differ
-    import os
+@pytest_asyncio.fixture(scope="class", loop_scope="class")
+async def nested_tenant_schema(class_db_pool, test_schema) -> None:
+    """Build the tables and views the resolvers query, inside the class schema."""
+    async with class_db_pool.connection() as conn:
+        await conn.execute(f"SET search_path TO {test_schema}, public")
 
-    if os.environ.get("GITHUB_ACTIONS") == "true":
-        pytest.skip("Test requires complex database setup not available in CI")
-
-    # Define database connection variables first
-    db_host = os.environ.get("DB_HOST", "localhost")
-    db_port = os.environ.get("DB_PORT", "5432")
-    db_user = os.environ.get("DB_USER", "fraiseql")
-    db_password = os.environ.get("DB_PASSWORD", "fraiseql")
-
-    # Skip if no local database available
-    try:
-        # Try a quick connection test first
-        test_conn = await psycopg.AsyncConnection.connect(
-            f"host={db_host} port={db_port} user={db_user} password={db_password} dbname=postgres",
-            autocommit=True,
-            connect_timeout=1,
-        )
-        await test_conn.close()
-    except Exception:
-        pytest.skip("Test requires PostgreSQL database connection")
-
-    # Setup database
-    conn = await setup_test_database()
-
-    try:
-        # Also create a view WITHOUT embedded organization (for comparison)
         await conn.execute(
             """
-            CREATE VIEW public.v_user_no_embed AS
+            CREATE TABLE tb_organization (
+                pk_organization UUID PRIMARY KEY,
+                name TEXT NOT NULL,
+                identifier TEXT UNIQUE NOT NULL,
+                data JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ DEFAULT NOW()
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE tb_contact (
+                pk_contact UUID PRIMARY KEY,
+                fk_customer_org UUID NOT NULL REFERENCES tb_organization(pk_organization),
+                first_name TEXT NOT NULL,
+                last_name TEXT NOT NULL,
+                email_address TEXT UNIQUE NOT NULL,
+                data JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ DEFAULT NOW()
+            )
+            """
+        )
+
+        await conn.execute(
+            """
+            INSERT INTO tb_organization (pk_organization, name, identifier, data)
+            VALUES (
+                '6f726700-0000-0000-0000-000000000000'::uuid,
+                'Test Organization',
+                'TEST-ORG',
+                '{"status": "active", "type": "enterprise"}'::jsonb
+            )
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO tb_contact (
+                pk_contact, fk_customer_org, first_name, last_name, email_address, data
+            )
+            VALUES (
+                '75736572-0000-0000-0000-000000000000'::uuid,
+                '6f726700-0000-0000-0000-000000000000'::uuid,
+                'Alice', 'Cooper', 'alice@example.com',
+                '{"role": "admin", "department": "Engineering"}'::jsonb
+            )
+            """
+        )
+
+        await conn.execute(
+            """
+            CREATE MATERIALIZED VIEW mv_organization AS
+            SELECT
+                pk_organization AS id,
+                pk_organization AS tenant_id,  -- org is its own tenant
+                jsonb_build_object(
+                    'id', pk_organization,
+                    'name', name,
+                    'identifier', identifier,
+                    'status', COALESCE(data->>'status', 'active')
+                ) AS data
+            FROM tb_organization
+            """
+        )
+
+        # The organization is embedded in the user's own data column.
+        await conn.execute(
+            """
+            CREATE VIEW v_user AS
             SELECT
                 c.pk_contact AS id,
                 c.fk_customer_org AS tenant_id,
@@ -417,65 +200,152 @@ async def test_comparison_with_and_without_embedded() -> None:
                     'first_name', c.first_name,
                     'last_name', c.last_name,
                     'email_address', c.email_address,
-                    'organization_id', c.fk_customer_org  -- Just the FK, not embedded
+                    'organization', jsonb_build_object(
+                        'id', o.pk_organization,
+                        'name', o.name,
+                        'identifier', o.identifier,
+                        'status', COALESCE(o.data->>'status', 'active')
+                    )
                 ) AS data
-            FROM tenant.tb_contact c
-        """
+            FROM tb_contact c
+            JOIN tb_organization o ON c.fk_customer_org = o.pk_organization
+            """
         )
+
+        # The same user carrying only the foreign key, for the comparison test.
+        await conn.execute(
+            """
+            CREATE VIEW v_user_no_embed AS
+            SELECT
+                c.pk_contact AS id,
+                c.fk_customer_org AS tenant_id,
+                jsonb_build_object(
+                    'id', c.pk_contact,
+                    'first_name', c.first_name,
+                    'last_name', c.last_name,
+                    'email_address', c.email_address,
+                    'organization_id', c.fk_customer_org
+                ) AS data
+            FROM tb_contact c
+            """
+        )
+
         await conn.commit()
 
-        from fraiseql.cqrs.repository import CQRSRepository
 
-        class TestRepository(CQRSRepository):
-            async def find_one(self, table: str, **kwargs) -> None:
-                """Find one record from a table/view."""
-                where_conditions = []
-                params = []
+@pytest.mark.usefixtures("nested_tenant_schema")
+class TestNestedOrganizationEmbedding:
+    """Embedded nested data must resolve without a tenant_id in the context."""
 
-                for key, value in kwargs.items():
-                    where_conditions.append(f"{key} = %s")
-                    params.append(value)
+    @staticmethod
+    async def _repository(pool, schema) -> tuple[Any, Any]:
+        """Open a connection on the class schema and wrap it for the resolver."""
+        conn = await pool.getconn()
+        await conn.execute(f"SET search_path TO {schema}, public")
+        return conn, StubRepository(conn)
 
-                where_clause = " AND ".join(where_conditions) if where_conditions else "1=1"
+    async def test_nested_organization_without_tenant_id(
+        self, class_db_pool, test_schema
+    ) -> None:
+        """A query with no tenant_id in context must still return the organization."""
+        from graphql import graphql
 
-                query = f"SELECT data FROM {table} WHERE {where_clause} LIMIT 1"
+        from fraiseql.gql.builders.registry import SchemaRegistry
+        from fraiseql.gql.builders.schema_composer import SchemaComposer
 
-                async with self.connection.cursor() as cursor:
-                    await cursor.execute(query, params)
-                    result = await cursor.fetchone()
+        conn, db = await self._repository(class_db_pool, test_schema)
+        try:
 
-                    if result:
-                        return result[0]
-                    return None
+            @query
+            async def user(
+                info: GraphQLResolveInfo, user_id: Optional[UUID] = None
+            ) -> Optional[User]:
+                """Query to get a user by ID."""
+                repo = info.context["db"]
+                result = await repo.find_one(
+                    "v_user", mandatory_filters={"id": user_id or USER_ID}
+                )
+                return User.from_dict(result) if result else None
 
-        db = TestRepository(conn)
+            registry = SchemaRegistry()
+            registry.register_query(user)
+            registry.register_type(User)
+            registry.register_type(Organization)
+            schema = SchemaComposer(registry).compose()
 
-        # Test 1: With embedded data (should work)
-        result = await db.find_one("v_user", id=UUID("75736572-0000-0000-0000-000000000000"))
-        assert result is not None
-        assert "organization" in result
-        assert result["organization"]["name"] == "Test Organization"
+            query_str = """
+            query GetUser {
+              user {
+                id
+                firstName
+                lastName
+                emailAddress
+                organization { id name identifier status }
+              }
+            }
+            """
 
-        # Test 2: Without embedded data (would need separate query)
-        result = await db.find_one(
-            "v_user_no_embed", id=UUID("75736572-0000-0000-0000-000000000000")
-        )
-        assert result is not None
-        assert "organization" not in result  # No embedded org
-        assert "organization_id" in result  # Just the FK
+            # Deliberately no tenant_id: that is the whole point of the test.
+            result = await graphql(schema, query_str, context_value={"db": db})
 
-    finally:
-        await conn.close()
+            # Every error is reported, not just the tenant_id one. Checking only
+            # for "tenant_id" let an unrelated psycopg adapter failure through in
+            # silence, so the test reported "User data is None" -- the
+            # consequence -- for three and a half months instead of the cause
+            # (#516).
+            assert not result.errors, f"GraphQL errors: {[str(e) for e in result.errors]}"
 
-        # Cleanup
-        cleanup_conn = await psycopg.AsyncConnection.connect(
-            "host=localhost port=5432 user=postgres dbname=postgres", autocommit=True
-        )
-        await cleanup_conn.execute("DROP DATABASE IF EXISTS fraiseql_nested_test")
-        await cleanup_conn.close()
+            assert result.data is not None, "No data returned"
+            assert result.data["user"] is not None, "User data is None"
 
+            user_data = result.data["user"]
+            assert user_data["firstName"] == "Alice"
+            assert user_data["lastName"] == "Cooper"
+            assert user_data["emailAddress"] == "alice@example.com"
 
-if __name__ == "__main__":
-    # Run tests directly
-    asyncio.run(test_nested_organization_without_tenant_id())
-    asyncio.run(test_comparison_with_and_without_embedded())
+            assert user_data["organization"] is not None, (
+                "Organization data is None (embedded data not returned)"
+            )
+            assert user_data["organization"]["name"] == "Test Organization"
+            assert user_data["organization"]["identifier"] == "TEST-ORG"
+            assert user_data["organization"]["status"] == "active"
+        finally:
+            await class_db_pool.putconn(conn)
+
+    async def test_mandatory_filters_and_direct_columns_agree(
+        self, class_db_pool, test_schema
+    ) -> None:
+        """``mandatory_filters={"id": x}`` must select the same row as ``id=x``.
+
+        The regression in #516 was exactly this divergence: the stub understood
+        one spelling and not the other, so the resolver silently returned
+        nothing.
+        """
+        conn, db = await self._repository(class_db_pool, test_schema)
+        try:
+            direct = await db.find_one("v_user", id=USER_ID)
+            mandatory = await db.find_one("v_user", mandatory_filters={"id": USER_ID})
+
+            assert direct is not None
+            assert direct == mandatory
+        finally:
+            await class_db_pool.putconn(conn)
+
+    async def test_comparison_with_and_without_embedded(
+        self, class_db_pool, test_schema
+    ) -> None:
+        """Only the embedding view carries the organization; the other has the FK."""
+        conn, db = await self._repository(class_db_pool, test_schema)
+        try:
+            embedded = await db.find_one("v_user", id=USER_ID)
+            assert embedded is not None
+            assert "organization" in embedded
+            assert embedded["organization"]["name"] == "Test Organization"
+
+            flat = await db.find_one("v_user_no_embed", id=USER_ID)
+            assert flat is not None
+            assert "organization" not in flat, "No embedded org expected"
+            assert "organization_id" in flat, "Expected just the FK"
+            assert UUID(flat["organization_id"]) == ORG_ID
+        finally:
+            await class_db_pool.putconn(conn)


### PR DESCRIPTION
Closes #516.

`test_nested_organization_without_tenant_id` had failed since 2026-05-14 and nothing reported it. The framework was never at fault.

`092a66e72` changed the resolver in this file:

```diff
-            result = await db.find_one("v_user", id=user_id)
+            result = await db.find_one("v_user", mandatory_filters={"id": user_id})
```

but left the test's own `find_one` stub, which turns every kwarg into a column equality. That built `WHERE mandatory_filters = %s` and handed psycopg a dict:

```
ProgrammingError: cannot adapt type 'dict' using placeholder '%s' (format: AUTO)
```

The real `FraiseQLRepository.find_one` (`db.py:1992`) does accept `mandatory_filters` and merges it into the WHERE clause, so the resolver's call was correct against the real API. Only the stub was not.

## Why it survived three and a half months

Two reasons, both fixed here:

- **The failure lied.** The error check only called `pytest.fail` for messages containing `tenant_id`, so the adapter failure fell through in silence and the assertion three lines later reported `User data is None` — the consequence, not the cause.
- **CI never ran it.** Both tests skipped themselves when `GITHUB_ACTIONS` was set. Every green run since May was green *without* this file.

## Changes

- **One `StubRepository`**, shared by all three tests. The two previous copies drifted, and only the copy that had been updated to pass `mandatory_filters` was broken by it. It now honours the same contract as the real repository and composes SQL through `psycopg.sql` instead of f-strings.
- **Assert on any GraphQL error**, reporting the messages.
- **Run against the shared test container** via `class_db_pool` / `test_schema`, instead of building a connection from `DB_HOST`/`DB_USER` and creating an entire `fraiseql_nested_test` database. This drops the `GITHUB_ACTIONS` skip, the hardcoded `fraiseql`/`fraiseql` credentials, and a teardown that connected as a *different* user (`postgres`) than the setup did.
- **New test** asserting `mandatory_filters={"id": x}` and `id=x` select the same row — the exact divergence that caused this.

## Verification

- ✅ Restoring the old stub fails 2 of the 3 tests, and the failure now names the cause: ``GraphQL errors: ["cannot adapt type 'dict' ..."]`` rather than `User data is None`
- ✅ `pytest tests/unit/ tests/integration/ -q`: **6121 passed, 0 failed** — the suite is fully green, having carried this failure since May
- ✅ ruff clean; `uv run ty check` unchanged at 538
- ⏳ The point of the change is that CI runs these now; I'll confirm from the job log that all three execute rather than skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N