### PR TITLE
fix(meta): point v1 repo URLs at fraiseql-python, not the v2 repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: GitHub Discussions
+  - name: FraiseQL Discussions (shared with v2)
     url: https://github.com/fraiseql/fraiseql/discussions
-    about: Ask questions or share ideas in discussions
+    about: Ask questions or share ideas. Hosted on the v2 repo; covers both v1 and v2.
   - name: Email
     url: mailto:team@fraiseql.dev
     about: For security issues or confidential feedback

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ typed GraphQL API over FastAPI — no build step, no code generation.
 PostgreSQL returns JSONB. An integrated Rust pipeline (`fraiseql_rs`) transforms it
 into the HTTP response. You write Python; the hot path runs in Rust.
 
-**Requires:** Python 3.13+ · PostgreSQL 13+
+**Requires:** Python 3.13 (3.14 not yet supported) · PostgreSQL 13+
 
 ```python
 import fraiseql

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,16 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
-| 0.11.x  | :white_check_mark: |
-| < 0.11  | :x:                |
+| Version                   | Supported          |
+| ------------------------- | ------------------ |
+| Latest 1.x release        | :white_check_mark: |
+| Any earlier 1.x release   | :x:                |
+
+Fixes ship in the next release cut from `dev`. There are no maintenance branches and
+older minors are not backported, so "supported" means the most recent release on PyPI.
+
+Note that v1 is this repository, `fraiseql-python`. The separate v2 project
+(`fraiseql/fraiseql`) has its own security policy; report v2 issues there.
 
 ## Reporting a Vulnerability
 
@@ -18,7 +23,7 @@ Please do not report security vulnerabilities through public GitHub issues.
 
 ### 2. Email Security Team
 
-**Report via GitHub Security Advisories**: [Create a Security Advisory](https://github.com/fraiseql/fraiseql/security/advisories/new)
+**Report via GitHub Security Advisories**: [Create a Security Advisory](https://github.com/fraiseql/fraiseql-python/security/advisories/new)
 
 If you prefer email, send details to: **security@fraiseql.com** (response may be delayed)
 
@@ -187,7 +192,7 @@ audit.log_mutation("update_user", user_id=123)
 
 ## Known Issues
 
-Check the [Security Advisories](https://github.com/fraiseql/fraiseql/security/advisories) page for known vulnerabilities.
+Check the [Security Advisories](https://github.com/fraiseql/fraiseql-python/security/advisories) page for known vulnerabilities.
 
 ## Disclosure Policy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,11 +187,11 @@ tracing = [
 fraiseql = "fraiseql.cli:main"
 
 [project.urls]
-Changelog = "https://github.com/fraiseql/fraiseql/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/fraiseql/fraiseql-python/blob/dev/CHANGELOG.md"
 Documentation = "https://fraiseql.dev"
-Homepage = "https://github.com/fraiseql/fraiseql"
-Issues = "https://github.com/fraiseql/fraiseql/issues"
-Repository = "https://github.com/fraiseql/fraiseql"
+Homepage = "https://github.com/fraiseql/fraiseql-python"
+Issues = "https://github.com/fraiseql/fraiseql-python/issues"
+Repository = "https://github.com/fraiseql/fraiseql-python"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Follow-up to #524. A README review turned up that essentially every outward-facing link
identifying this project pointed at `fraiseql/fraiseql` — the **v2** repo. This fixes the
identity links; the docs pin sweep and the `fraiseql init`/`dev` bug are separate.

## The one that matters

`SECURITY.md` routed vulnerability reports to v2's advisory form. A researcher following
this repo's security policy filed into another project's queue. Both the reporting form
and the Known Issues listing are corrected.

Its supported-versions table was also wrong in a way that inverted its meaning:

| was | now |
|---|---|
| `1.0.x` ✅, `0.11.x` ✅, `< 0.11` ❌ | Latest 1.x ✅, earlier 1.x ❌ |

The old table implied the shipping release (1.25.0) was **unsupported**. I checked whether
older minors actually get patched — `git tag --sort=-creatordate` runs v1.23.5 → v1.23.12 →
1.24.0 → 1.25.0 with no out-of-order patch releases, and there are no maintenance branches.
So no backporting happens, and the table now states that policy rather than naming versions
that go stale on every release.

⚠️ **Please confirm the support policy is what you want stated** — I described observed
practice, but it is a maintainer's call to make.

## PyPI sidebar

`[project.urls]` had Homepage, Repository, Issues and Changelog all resolving to v2 —
creating exactly the confusion the README's v1-vs-v2 table exists to prevent, and filing v1
bugs into v2's tracker. Changelog now targets `dev`, this repo's default branch (verified
the file resolves on both `dev` and `main`).

## Discussions link: relabelled, not repointed

`.github/ISSUE_TEMPLATE/config.yml` pointed Discussions at v2. The obvious fix is wrong —
`gh repo view` confirms **Discussions is disabled on `fraiseql-python`**, so repointing it
would 404. The v2 forum is currently the only working venue, so the link now says so
explicitly rather than surprising a v1 user. If you'd rather, enabling Discussions here and
repointing is the better long-term fix.

## README

"Python 3.13+" → "Python 3.13 (3.14 not yet supported)". `requires-python` is
`>=3.13,<3.14`, so the `+` would send a 3.14 user into a resolver error.

## Not changed — needs your call

`SECURITY.md` says **`security@fraiseql.com`**; `.github/ISSUE_TEMPLATE/config.yml` says
**`team@fraiseql.dev`**. Different addresses on different TLDs, and the docs site is
`fraiseql.dev`. I can't verify which mailbox is monitored, so I left both alone — but a
security contact that bounces is worth a minute of your time.

## Verification

- ✅ `uv run pytest tests/unit/ tests/integration/ -q` — **6121 passed, 2 skipped**
- ✅ `pyproject.toml` parses; all five project URLs return **200** (checked with curl)
- ✅ `config.yml` parses as valid YAML
- ✅ Discussions-disabled confirmed via `gh repo view --json hasDiscussionsEnabled`
- ✅ `CHANGELOG.md` confirmed present on both `dev` and `main` via the GitHub API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N
