### PR TITLE
docs: pin fraiseql installs to <2 so they get v1, not v2

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -23,7 +23,7 @@ Complete guide to implementing enterprise-grade authentication and authorization
 Complete example: JWT authentication with FraiseQL.
 
 Prerequisites:
-- pip install fraiseql pyjwt cryptography
+- pip install "fraiseql<2" pyjwt cryptography
 - Generate a secret key: python -c "import secrets; print(secrets.token_hex(32))"
 """
 

--- a/docs/architecture/reliability/versioning-strategy.md
+++ b/docs/architecture/reliability/versioning-strategy.md
@@ -973,7 +973,7 @@ Security fixes are released as new versions on PyPI. Upgrade promptly when a sec
 is published:
 
 ```bash
-uv add "fraiseql>=1.23.11"
+uv add "fraiseql>=1.23.11,<2"
 ```
 
 ### 11.3 End-of-Life Behaviour

--- a/docs/archive/benchmarks/methodology.md
+++ b/docs/archive/benchmarks/methodology.md
@@ -203,7 +203,7 @@ FROM tb_user;
 
 ```bash
 # Install dependencies
-pip install fraiseql pytest pytest-benchmark
+pip install "fraiseql<2" pytest pytest-benchmark
 
 # Start benchmark environment
 cd benchmarks

--- a/docs/archive/development/new-user-confusions.md
+++ b/docs/archive/development/new-user-confusions.md
@@ -81,9 +81,9 @@ As a new user exploring this repository, I encountered several areas that were n
 
 **Confusion**: Multiple installation methods mentioned without clear guidance:
 
-- `pip install fraiseql`
-- `pip install fraiseql[rust]`
-- `pip install fraiseql[fastapi]`
+- `pip install "fraiseql<2"`
+- `pip install "fraiseql[rust]<2"`
+- `pip install "fraiseql[fastapi]<2"`
 - Different Python version requirements (3.11+ vs 3.13+)
 - Optional Rust compilation
 

--- a/docs/archive/journeys/junior-developer.md
+++ b/docs/archive/journeys/junior-developer.md
@@ -24,7 +24,7 @@ By the end, you'll understand:
 1. **Install Python dependencies:**
 
    ```bash
-   pip install fraiseql fastapi uvicorn
+   pip install "fraiseql<2" fastapi uvicorn
    ```
 
 2. **Verify installation:**
@@ -234,7 +234,7 @@ query {
 
 **"ImportError: No module named 'fraiseql'"**
 
-- Solution: `pip install fraiseql`
+- Solution: `pip install "fraiseql<2"`
 
 **"Connection refused" to database**
 

--- a/docs/archive/planning/phase4-ecosystem-implementation-plan.md
+++ b/docs/archive/planning/phase4-ecosystem-implementation-plan.md
@@ -455,7 +455,7 @@ FraiseQL provides native integration with LangChain for building RAG application
 ## Installation
 
 ```bash
-pip install fraiseql[langchain]
+pip install "fraiseql[langchain]<2"
 ```
 
 ## Quick Start
@@ -741,7 +741,7 @@ Use FraiseQL with LlamaIndex for data-augmented LLM applications.
 ## Installation
 
 ```bash
-pip install fraiseql[llamaindex]
+pip install "fraiseql[llamaindex]<2"
 ```
 
 ## Loading Data

--- a/docs/archive/rollback/schema-registry-rollback.md
+++ b/docs/archive/rollback/schema-registry-rollback.md
@@ -229,7 +229,7 @@ uv build
 pip install dist/*.whl
 
 # Or deploy via package manager
-pip install git+https://github.com/fraiseql/fraiseql@hotfix/branch
+pip install git+https://github.com/fraiseql/fraiseql-python@hotfix/branch
 ```
 
 6. **Monitor closely:**

--- a/docs/archive/rust/rust-first-pipeline.md
+++ b/docs/archive/rust/rust-first-pipeline.md
@@ -229,7 +229,7 @@ return await repo.find_rust("users", "users", info)
 
 **"fraiseql-rs not found"**
 
-- Install: `pip install fraiseql[rust]`
+- Install: `pip install "fraiseql[rust]<2"`
 - Verify: `python -c "import fraiseql_rs"`
 
 **Slow performance**

--- a/docs/archive/rust/rust-pipeline-implementation-guide.md
+++ b/docs/archive/rust/rust-pipeline-implementation-guide.md
@@ -21,7 +21,7 @@ The Rust pipeline is **always active** in FraiseQL. It automatically handles all
 To use the Rust pipeline, ensure you have:
 
 - [ ] FraiseQL installed
-- [ ] Rust extensions installed: `pip install fraiseql[rust]`
+- [ ] Rust extensions installed: `pip install "fraiseql[rust]<2"`
 - [ ] PostgreSQL database with JSONB views
 - [ ] GraphQL schema with proper type definitions
 
@@ -227,10 +227,10 @@ print(f"Average: {total_time/100:.4f}s per query")
 
 ```bash
 # Install Rust extensions
-pip install fraiseql[rust]
+pip install "fraiseql[rust]<2"
 
 # Or with uv
-uv add fraiseql[rust]
+uv add "fraiseql[rust]<2"
 ```
 
 **Performance optimization**

--- a/docs/archive/security-compliance/slsa-provenance.md
+++ b/docs/archive/security-compliance/slsa-provenance.md
@@ -380,7 +380,7 @@ An SBOM (Software Bill of Materials) lists all software components, libraries, a
 
 ```bash
 # Install fraiseql
-pip install fraiseql
+pip install "fraiseql<2"
 
 # Generate SBOM (uses the fraiseql CLI)
 fraiseql sbom generate --format cyclonedx --output sbom.json
@@ -597,7 +597,7 @@ SBOM may be generated separately from release artifacts:
 
 ```bash
 # Generate SBOM from installed package
-pip install fraiseql
+pip install "fraiseql<2"
 fraiseql sbom generate --format cyclonedx --output sbom.json
 ```
 

--- a/docs/archive/strategic/audiences.md
+++ b/docs/archive/strategic/audiences.md
@@ -95,7 +95,7 @@ cd examples/blog_simple/
 
 ```bash
 # Production installation
-pip install fraiseql[enterprise]
+pip install "fraiseql[enterprise]<2"
 
 # Start with enterprise examples
 cd examples/ecommerce/
@@ -261,7 +261,7 @@ open examples/blog_simple/
 
 ```bash
 # Enterprise setup
-pip install fraiseql[enterprise]
+pip install "fraiseql[enterprise]<2"
 
 # Performance-focused examples
 open examples/ecommerce/

--- a/docs/archive/strategic/project-structure.md
+++ b/docs/archive/strategic/project-structure.md
@@ -71,7 +71,7 @@ FraiseQL uses a unified architecture with exclusive Rust pipeline execution:
 - **`fraiseql_rs/`**: Exclusive query execution engine
 - **Purpose**: Core performance component for all operations
 - **Architecture**: PostgreSQL → Rust Transformation → HTTP Response
-- **Installation**: Automatically included with `pip install fraiseql`
+- **Installation**: Automatically included with `pip install "fraiseql<2"`
 
 ### **Supporting Components**
 

--- a/docs/archive/strategic/rust-backend-completion.md
+++ b/docs/archive/strategic/rust-backend-completion.md
@@ -129,10 +129,10 @@ Most applications will experience **automatic performance improvements** with mi
 
 ```bash
 # Update to v1.9+
-pip install fraiseql>=1.9.0
+pip install "fraiseql>=1.9.0,<2"
 
 # For development
-pip install fraiseql[dev]>=1.9.0
+pip install "fraiseql[dev]>=1.9.0,<2"
 ```
 
 #### Step 2: Repository Method Updates (If Using Legacy Methods)

--- a/docs/archive/strategic/version-status.md
+++ b/docs/archive/strategic/version-status.md
@@ -24,7 +24,7 @@ FraiseQL uses a unified architecture with exclusive Rust pipeline execution for 
 
 ```bash
 # Install FraiseQL with exclusive Rust pipeline
-pip install fraiseql
+pip install "fraiseql<2"
 ```
 
 **Why FraiseQL?**

--- a/docs/core/dependencies.md
+++ b/docs/core/dependencies.md
@@ -172,7 +172,7 @@ This allows you to:
 Users just install FraiseQL, which automatically pulls confiture from PyPI:
 
 ```bash
-pip install fraiseql
+pip install "fraiseql<2"
 # confiture is installed automatically as a dependency
 ```
 

--- a/docs/core/rust-backend-migration.md
+++ b/docs/core/rust-backend-migration.md
@@ -358,14 +358,14 @@ def test_user_query(client) -> None:
 
 ```
 ImportError: fraiseql Rust extension is not available.
-Please reinstall fraiseql: pip install --force-reinstall fraiseql
+Please reinstall fraiseql: pip install --force-reinstall "fraiseql<2"
 ```
 
 The Rust transform is bundled with FraiseQL as `fraiseql._fraiseql_rs`. If the wheel was built
 without it (or a source install failed to compile), reinstall a prebuilt wheel:
 
 ```bash
-pip install --force-reinstall fraiseql
+pip install --force-reinstall "fraiseql<2"
 ```
 
 If you build from source, ensure a Rust toolchain and maturin are available, then rebuild.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -88,7 +88,7 @@ Once you've completed these guides, continue your learning journey:
 
 **Prerequisites**: Python 3.13+, PostgreSQL 13+
 
-**Installation**: `pip install fraiseql`
+**Installation**: `pip install "fraiseql<2"`
 
 **Documentation Hub**: [Documentation Home](../index.md)
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -37,19 +37,19 @@ Choose your installation path:
 ```
 What do you want to do?
 ├── 🚀 Quick Start (Recommended for most users - 5 minutes)
-│   └── pip install fraiseql
+│   └── pip install "fraiseql<2"
 │       └── fraiseql init my-project
 │           └── fraiseql dev
 ├── 🧪 Development/Testing
-│   └── pip install fraiseql[dev]
+│   └── pip install "fraiseql[dev]<2"
 ├── 📊 Production with Observability
-│   └── pip install fraiseql[tracing]
+│   └── pip install "fraiseql[tracing]<2"
 ├── 🔐 Production with Auth0
-│   └── pip install fraiseql[auth0]
+│   └── pip install "fraiseql[auth0]<2"
 ├── 📚 Documentation Building
-│   └── pip install fraiseql[docs]
+│   └── pip install "fraiseql[docs]<2"
 └── 🏗️ Everything (Development + Production)
-    └── pip install fraiseql[all]
+    └── pip install "fraiseql[all]<2"
 ```
 
 
@@ -64,7 +64,7 @@ What do you want to do?
 
 ```bash
 # Install core FraiseQL
-pip install fraiseql
+pip install "fraiseql<2"
 
 # Verify installation
 fraiseql --version
@@ -95,10 +95,10 @@ fraiseql dev
 
 ```bash
 # Install with development dependencies
-pip install fraiseql[dev]
+pip install "fraiseql[dev]<2"
 
 # Or install all optional dependencies
-pip install fraiseql[all]
+pip install "fraiseql[all]<2"
 ```
 
 **What you get** (in addition to Quick Start):
@@ -118,7 +118,7 @@ pip install fraiseql[all]
 
 ```bash
 # Install with observability features
-pip install fraiseql[tracing]
+pip install "fraiseql[tracing]<2"
 ```
 
 **What you get** (in addition to Quick Start):
@@ -137,7 +137,7 @@ pip install fraiseql[tracing]
 
 ```bash
 # Install with Auth0 support
-pip install fraiseql[auth0]
+pip install "fraiseql[auth0]<2"
 ```
 
 **What you get** (in addition to Quick Start):
@@ -155,7 +155,7 @@ pip install fraiseql[auth0]
 
 ```bash
 # Install with documentation tools
-pip install fraiseql[docs]
+pip install "fraiseql[docs]<2"
 ```
 
 **What you get** (in addition to Quick Start):
@@ -172,7 +172,7 @@ pip install fraiseql[docs]
 
 ```bash
 # Install everything (development + production features)
-pip install fraiseql[all]
+pip install "fraiseql[all]<2"
 ```
 
 **What you get** (all features from all options above):
@@ -310,7 +310,7 @@ xcode-select --install
 
 # Then reinstall FraiseQL
 pip uninstall fraiseql
-pip install fraiseql --no-cache-dir
+pip install "fraiseql<2" --no-cache-dir
 ```
 
 #### Issue: "Python version 3.13+ required"
@@ -336,11 +336,11 @@ pyenv global 3.13.0
 
 ```bash
 # Make sure you're in the right environment
-pip install fraiseql
+pip install "fraiseql<2"
 
 # Or reinstall
 pip uninstall fraiseql
-pip install fraiseql
+pip install "fraiseql<2"
 ```
 
 #### Issue: "fraiseql command not found"
@@ -355,7 +355,7 @@ python -m fraiseql --version
 pip show fraiseql
 
 # Option 3: Reinstall with --force
-pip install --force-reinstall fraiseql
+pip install --force-reinstall "fraiseql<2"
 ```
 
 #### Issue: "PostgreSQL connection failed"
@@ -410,7 +410,7 @@ python -c "from fraiseql.core.database import DatabasePool; print('Rust backend 
 
 # If import fails, reinstall with Rust
 pip uninstall fraiseql
-pip install fraiseql --no-cache-dir --verbose
+pip install "fraiseql<2" --no-cache-dir --verbose
 
 # Check for missing dependencies
 python -c "import sys; print('Python path:'); [print(p) for p in sys.path]"
@@ -441,7 +441,7 @@ pip uninstall fraiseql fraiseql-confiture -y
 pip cache purge
 
 # Reinstall
-pip install fraiseql[dev]
+pip install "fraiseql[dev]<2"
 ```
 
 #### Environment Issues

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -22,7 +22,7 @@ Get started with FraiseQL in 5 minutes! This guide will walk you through creatin
 ## Step 1: Install FraiseQL
 
 ```bash
-pip install fraiseql[all]
+pip install "fraiseql[all]<2"
 ```
 
 ## Step 2: Create Database

--- a/docs/guides/filtering.md
+++ b/docs/guides/filtering.md
@@ -24,7 +24,7 @@ Complete runnable example showing FraiseQL filtering.
 
 Prerequisites:
 - PostgreSQL with a users table/view
-- FraiseQL installed: pip install fraiseql
+- FraiseQL installed: pip install "fraiseql<2"
 """
 
 import asyncio

--- a/docs/guides/mutation-sql-requirements.md
+++ b/docs/guides/mutation-sql-requirements.md
@@ -22,7 +22,7 @@ End-to-end example: Creating a user with FraiseQL mutations.
 
 Prerequisites:
 - PostgreSQL database
-- FraiseQL installed: pip install fraiseql
+- FraiseQL installed: pip install "fraiseql<2"
 - Run the SQL setup below first
 """
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -56,10 +56,10 @@ psql your_database_name -c "\dv v_*"
 
 ```bash
 # Install FraiseQL
-pip install fraiseql[all]
+pip install "fraiseql[all]<2"
 
 # Or if using uv
-uv add fraiseql
+uv add "fraiseql<2"
 
 # Verify installation
 python -c "import fraiseql; print('FraiseQL installed!')"

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ Run it with any ASGI server (`uvicorn app:app`) and open `/graphql`.
 | Install FraiseQL and PostgreSQL | [Installation](getting-started/installation.md) |
 
 ```bash
-pip install "fraiseql[all]"
+pip install "fraiseql[all]<2"
 ```
 
 Requirements: **Python 3.13+** and **PostgreSQL 13+**.

--- a/docs/integrations/authentication/README.md
+++ b/docs/integrations/authentication/README.md
@@ -26,7 +26,7 @@ and PostgreSQL Row-Level Security (RLS).
 
 **Required tools:**
 
-- FraiseQL v1 installed (`pip install fraiseql` / `uv add fraiseql`)
+- FraiseQL v1 installed (`pip install "fraiseql<2"` / `uv add "fraiseql<2"`)
 - A PostgreSQL 14+ database
 - Your chosen identity provider's console (for Auth0 or another OIDC issuer)
 

--- a/docs/integrations/authentication/setup-google-oauth.md
+++ b/docs/integrations/authentication/setup-google-oauth.md
@@ -37,7 +37,7 @@ FraiseQL ships an `Auth0Provider` and a base `AuthProvider` ABC. There is **no**
 
 **Required Software:**
 
-- FraiseQL v1 (`pip install fraiseql` / `uv add fraiseql`)
+- FraiseQL v1 (`pip install "fraiseql<2"` / `uv add "fraiseql<2"`)
 - curl or a GraphQL client (for testing the API)
 - A PostgreSQL database (FraiseQL is PostgreSQL-only)
 - For Path A: an Auth0 tenant (free tier is fine)

--- a/docs/integrations/sdk/python-reference.md
+++ b/docs/integrations/sdk/python-reference.md
@@ -33,10 +33,10 @@ The runtime follows a CQRS split against PostgreSQL:
 
 ```bash
 # uv (recommended)
-uv add fraiseql
+uv add "fraiseql<2"
 
 # or pip
-pip install fraiseql
+pip install "fraiseql<2"
 ```
 
 FastAPI integration is included. The optional Rust extension (`fraiseql_rs`) accelerates

--- a/docs/migration/migration-checklist.md
+++ b/docs/migration/migration-checklist.md
@@ -178,7 +178,7 @@ Use this checklist alongside framework-specific guides:
 
 ### Application Setup
 
-- [ ] Install FraiseQL: `pip install fraiseql`
+- [ ] Install FraiseQL: `pip install "fraiseql<2"`
 - [ ] Configure `create_fraiseql_app()`
 - [ ] Set database URL
 - [ ] Enable Rust pipeline: `enable_rust_pipeline=True`

--- a/docs/operations/distributed-tracing.md
+++ b/docs/operations/distributed-tracing.md
@@ -30,7 +30,7 @@ Tracing depends on the OpenTelemetry SDK and exporters. Install the tracing extr
 
 ```bash
 # OpenTelemetry SDK + OTLP/Jaeger exporters and psycopg instrumentation
-pip install "fraiseql[tracing]"
+pip install "fraiseql[tracing]<2"
 
 # Or install the OpenTelemetry packages directly
 pip install opentelemetry-sdk \
@@ -312,7 +312,7 @@ Start at `1.0` in development and lower the rate as traffic grows. Because the s
 
 ### No traces appearing
 
-- Confirm OpenTelemetry is installed (`pip install "fraiseql[tracing]"`); without it, tracing is a no-op.
+- Confirm OpenTelemetry is installed (`pip install "fraiseql[tracing]<2"`); without it, tracing is a no-op.
 - Confirm `enabled=True` and that `export_endpoint` points at a reachable collector.
 - Check the request path is not in `exclude_paths`.
 - Verify `sample_rate` is greater than `0.0`.

--- a/docs/performance/benchmarking-guide.md
+++ b/docs/performance/benchmarking-guide.md
@@ -26,7 +26,7 @@ This guide provides practical tools and techniques for benchmarking your FraiseQ
 Complete FraiseQL benchmarking script.
 
 Requirements:
-- pip install fraiseql psycopg asyncio timeit
+- pip install "fraiseql<2" psycopg asyncio timeit
 """
 
 import asyncio

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,7 +19,7 @@ Complete command-line interface reference for FraiseQL. The CLI provides project
 The CLI is installed automatically with FraiseQL:
 
 ```bash
-pip install fraiseql
+pip install "fraiseql<2"
 fraiseql --version
 ```
 
@@ -887,7 +887,7 @@ FraiseQL CLI respects these environment variables:
 
 ```bash
 # Ensure fraiseql is installed
-pip install fraiseql
+pip install "fraiseql<2"
 
 # Check installation
 which fraiseql

--- a/docs/reference/quick-reference.md
+++ b/docs/reference/quick-reference.md
@@ -58,7 +58,7 @@ psql mydb -c "\dv v_*"                          # List views
 psql mydb -c "\dt tb_*"                         # List tables
 
 # Run application
-pip install fraiseql[all]                       # Install
+pip install "fraiseql[all]<2"                   # Install
 uvicorn app:app --reload                        # Start server
 curl http://localhost:8000/graphql              # Test endpoint
 

--- a/docs/reference/testing-checklist.md
+++ b/docs/reference/testing-checklist.md
@@ -119,14 +119,14 @@ This checklist ensures FraiseQL documentation meets production quality standards
 
 ### **Basic Installation**
 
-- [ ] `pip install fraiseql` works
+- [ ] `pip install "fraiseql<2"` works
 - [ ] All dependencies install correctly
 - [ ] Import statements work
 - [ ] Basic functionality available
 
 ### **Enterprise Installation**
 
-- [ ] `pip install fraiseql[enterprise]` succeeds
+- [ ] `pip install "fraiseql[enterprise]<2"` succeeds
 - [ ] Optional dependencies install
 - [ ] Enterprise features are available
 - [ ] Performance optimizations active

--- a/docs/tutorials/beginner-path.md
+++ b/docs/tutorials/beginner-path.md
@@ -267,7 +267,7 @@ def items() -> list[Item]:
 
 ```bash
 # Install
-pip install fraiseql fastapi uvicorn
+pip install "fraiseql<2" fastapi uvicorn
 
 # Create database
 createdb myapp

--- a/docs/tutorials/python-blog-api.md
+++ b/docs/tutorials/python-blog-api.md
@@ -549,7 +549,7 @@ if __name__ == "__main__":
 Run it:
 
 ```bash
-pip install "fraiseql[all]"
+pip install "fraiseql[all]<2"
 export DATABASE_URL=postgresql://localhost/blog
 uvicorn app:app --reload
 ```


### PR DESCRIPTION
Third of three follow-ups from the README review (after #524 and #525).

v1 and v2 share the `fraiseql` name on PyPI, and the bare name resolves to **2.14.1** — v2.
#524 pinned the README's quick start to `<2`; this pins the docs, which were undoing it one
click later. `docs/getting-started/quickstart.md:25` — the page the README labels *"copy,
paste, run"* — said `pip install fraiseql[all]`, so a reader who followed the README's
advice and then clicked its first link got v2 anyway.

## Scope

**67 install commands across 34 files** — `pip install`, `uv add`, `uv pip install`,
including every extra (`[all]`, `[dev]`, `[rust]`, `[tracing]`, `[auth0]`, `[docs]`,
`[enterprise]`, `[fastapi]`, `[langchain]`, `[llamaindex]`).

The quoting is load-bearing, not stylistic: `pip install fraiseql<2` unquoted is a shell
redirection, so every rewrite is `pip install "fraiseql<2"`.

**Three specifiers had a floor but no ceiling** and so still resolved to 2.x despite looking
pinned. These got an upper bound rather than a rewrite:

| was | now |
|---|---|
| `pip install fraiseql>=1.9.0` | `pip install "fraiseql>=1.9.0,<2"` |
| `pip install fraiseql[dev]>=1.9.0` | `pip install "fraiseql[dev]>=1.9.0,<2"` |
| `uv add "fraiseql>=1.23.11"` | `uv add "fraiseql>=1.23.11,<2"` |

**One more wrong-repo link,** same class as #525: the rollback runbook installed a hotfix
from `github.com/fraiseql/fraiseql` (v2). Now `fraiseql-python`.

## Why `docs/archive/` is included

10 of the 34 files are under `docs/archive/`. It looked like history, but it is not: it
builds to **100 published HTML pages**, and the README links directly into it
(`docs/archive/testing/chaos-engineering-strategy.md`). A reader landing there via search
runs the same command and gets the same wrong package, so the pin applies.

## Deliberately untouched — each checked individually

- **Exact pins** (`fraiseql==1.23.11`, `==1.22.0`, `==0.1.0`) — cannot resolve to v2.
- **Placeholders** (`fraiseql==<previous-version>`, ×2).
- **Different packages** — `fraiseql-confiture` (×2), `fraiseql-rs`, `confiture.git`. The
  matching pattern excludes `fraiseql-*` deliberately.
- **`uv add "fraiseql>=1.23,<2"`** in `versioning-strategy.md` — already correct.

## Verification

- ✅ `uv run mkdocs build` exit 0
- ✅ **89 warnings before my change, 89 after** — no new ones. (These are the pre-existing
  broken anchors; I touched none of the files they name.)
- ✅ Applied via a dry run first, with every one of the 67 rewrites reviewed line by line
- ✅ Residue swept: every remaining unpinned `fraiseql` occurrence in `docs/` is in the
  untouched list above
- ✅ No malformed or double-applied pins (`<2"<2`, `[all]<2]`, etc.)

Not a code change — no test run. `pytest` was green on `dev` at #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N
