### PR TITLE
fix(cli): make `fraiseql init` → `fraiseql dev` actually serve a query

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/fraiseql/fraiseql/discussions
     about: Ask questions or share ideas. Hosted on the v2 repo; covers both v1 and v2.
   - name: Email
-    url: mailto:team@fraiseql.dev
+    url: mailto:security@fraiseql.dev
     about: For security issues or confidential feedback

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ Please do not report security vulnerabilities through public GitHub issues.
 
 **Report via GitHub Security Advisories**: [Create a Security Advisory](https://github.com/fraiseql/fraiseql-python/security/advisories/new)
 
-If you prefer email, send details to: **security@fraiseql.com** (response may be delayed)
+If you prefer email, send details to: **security@fraiseql.dev** (response may be delayed)
 
 Include:
 
@@ -238,6 +238,6 @@ Contact us for compliance documentation.
 For security questions that aren't vulnerabilities:
 
 - Open a GitHub discussion
-- Email: security@fraiseql.com
+- Email: security@fraiseql.dev
 
 Thank you for helping keep FraiseQL secure!

--- a/deploy/deployment-security-guide.md
+++ b/deploy/deployment-security-guide.md
@@ -624,7 +624,7 @@ kubectl run -n fraiseql-production test-pod \
 
 ## Support
 
-For security issues, contact: security@fraiseql.io
+For security issues, contact: security@fraiseql.dev
 For general questions: docs@fraiseql.io
 
 ---

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -73,8 +73,11 @@ fraiseql --version
 fraiseql init my-first-api
 cd my-first-api
 
-# Start development server
+# Start development server - /graphql is live straight away
 fraiseql dev
+
+# Start the bundled PostgreSQL and load the example schema
+docker compose up -d
 ```
 
 **What you get**:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -63,7 +63,7 @@ fraiseql init PROJECT_NAME [OPTIONS]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--template [basic\|blog\|ecommerce]` | `basic` | Project template to use |
-| `--database-url TEXT` | `postgresql://localhost/mydb` | PostgreSQL connection URL |
+| `--database-url TEXT` | the bundled compose service | PostgreSQL connection URL |
 | `--no-git` | Flag | Skip git repository initialization |
 
 ### Templates
@@ -95,23 +95,40 @@ my-project/
 │   ├── types/               # FraiseQL type definitions
 │   ├── mutations/           # GraphQL mutations
 │   └── queries/             # Custom query logic
+├── db/
+│   ├── schema/              # SQL loaded into a fresh database
+│   │   └── 001_users.sql    # tb_user, v_user, and two seed rows
+│   ├── seeds/               # Environment-specific seed data
+│   ├── migrations/          # Incremental schema changes
+│   └── environments/        # Per-environment migration config
 ├── tests/                   # Test files
-├── migrations/              # Database migrations
+├── docker-compose.yml      # PostgreSQL for local development
 ├── .env                     # Environment variables
 ├── .gitignore              # Git ignore patterns
 ├── pyproject.toml          # Project configuration
 └── README.md               # Project documentation
 ```
 
+The `db/` layout is the one `fraiseql migrate init` expects, so the two
+commands agree about where migrations live.
+
 ### Environment Variables
 
 The `.env` file is created with:
 
 ```bash
-FRAISEQL_DATABASE_URL=postgresql://localhost/mydb
+FRAISEQL_DATABASE_URL=postgresql://fraiseql:fraiseql@localhost:54320/my_project
 FRAISEQL_AUTO_CAMEL_CASE=true
-FRAISEQL_DEV_AUTH_PASSWORD=development-only-password
+FRAISEQL_DATABASE_POOL_TIMEOUT=5
 ```
+
+The URL points at the PostgreSQL in the generated `docker-compose.yml`, which
+publishes port 54320 rather than 5432 so it cannot collide with a PostgreSQL
+already installed on the machine.
+
+`FRAISEQL_DEV_AUTH_PASSWORD` is written commented out. Uncommenting it puts
+HTTP basic auth in front of `/graphql`, so every request — including
+GraphiQL's — then needs credentials.
 
 ### Examples
 
@@ -143,8 +160,13 @@ cd PROJECT_NAME
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -e ".[dev]"
-fraiseql dev
+fraiseql dev              # serves /graphql immediately, with no database
+docker compose up -d      # starts PostgreSQL and loads db/schema/*.sql
 ```
+
+`fraiseql dev` works before the database exists: queries resolve to empty
+results until `docker compose up -d` has run, and the server says so once at
+startup instead of repeating pool errors.
 
 ---
 

--- a/src/fraiseql/cli/commands/dev.py
+++ b/src/fraiseql/cli/commands/dev.py
@@ -1,6 +1,8 @@
 """Development server command."""
 
+import os
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 import click
 
@@ -13,6 +15,52 @@ try:
     import uvicorn
 except ImportError:
     uvicorn = None
+
+CONNECT_TIMEOUT_SECONDS = 2
+
+
+def _redact_password(database_url: str) -> str:
+    """Return the URL with any password replaced by ``***``."""
+    parts = urlsplit(database_url)
+    if not parts.password:
+        return database_url
+    userinfo = f"{parts.username}:***" if parts.username else "***"
+    netloc = f"{userinfo}@{parts.hostname}"
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit(parts._replace(netloc=netloc))
+
+
+def _database_is_reachable(database_url: str) -> bool:
+    """Open and immediately close one connection, to see if the server answers.
+
+    A false negative here is harmless: it only suppresses a hint.
+    """
+    try:
+        import psycopg
+    except ImportError:
+        return True
+
+    try:
+        with psycopg.connect(database_url, connect_timeout=CONNECT_TIMEOUT_SECONDS):
+            return True
+    except (psycopg.Error, OSError, ValueError):
+        return False
+
+
+def _warn_if_database_unreachable() -> None:
+    """Say once, in one line, that there is no database - then get out of the way.
+
+    Without this the only signal is the connection pool retrying forever, which
+    buries the actual cause under a wall of identical tracebacks.
+    """
+    database_url = os.environ.get("FRAISEQL_DATABASE_URL")
+    if not database_url or _database_is_reachable(database_url):
+        return
+
+    click.echo(f"⚠️  No database reachable at {_redact_password(database_url)}")
+    click.echo("   Start the one this project ships with: docker compose up -d")
+    click.echo("   Until then queries resolve to empty results.\n")
 
 
 @click.command()
@@ -65,16 +113,22 @@ def dev(host: str, port: int, reload: bool, app: str) -> None:
 
     click.echo("\n   Press CTRL+C to stop\n")
 
+    _warn_if_database_unreachable()
+
     # Check if uvicorn is available
     if uvicorn is None:
         click.echo("Error: uvicorn not installed. Run 'pip install uvicorn'", err=True)
         msg = "uvicorn not installed"
         raise click.ClickException(msg)
 
+    # `app` is an import string, and uvicorn.run() - unlike the uvicorn CLI -
+    # does not put the working directory on sys.path by itself. Without app_dir
+    # the default target "src.main:app" fails with "No module named 'src'".
     uvicorn.run(
         app,
         host=host,
         port=port,
         reload=reload,
         log_level="info",
+        app_dir=str(Path.cwd()),
     )

--- a/src/fraiseql/cli/commands/init.py
+++ b/src/fraiseql/cli/commands/init.py
@@ -6,6 +6,27 @@ from pathlib import Path
 
 import click
 
+# v1 and v2 share the `fraiseql` name on PyPI and the bare name resolves to v2,
+# which is a different framework. A generated project must pin below 2.
+FRAISEQL_PIN = "fraiseql>=1.25,<2"
+REQUIRES_PYTHON = ">=3.13,<3.14"
+PYTHON_TAG = "py313"
+PYTHON_VERSION = "3.13"
+
+# Credentials for the Postgres this project ships with, kept in one place so
+# .env and docker-compose.yml cannot drift apart.
+DB_USER = "fraiseql"
+DB_PASSWORD = "fraiseql"
+# Deliberately far from 5432: a developer with PostgreSQL already installed
+# would otherwise hit "port is already allocated" on their first
+# docker compose up. The container still listens on 5432 internally.
+DB_PORT = 54320
+
+
+def _database_name(project_name: str) -> str:
+    """Return a name usable as an unquoted PostgreSQL identifier."""
+    return project_name.replace("-", "_").replace(".", "_")
+
 
 @click.command()
 @click.argument("project_name")
@@ -17,15 +38,15 @@ import click
 )
 @click.option(
     "--database-url",
-    default="postgresql://localhost/mydb",
-    help="PostgreSQL database URL",
+    default=None,
+    help="PostgreSQL database URL (defaults to the bundled docker compose service)",
 )
 @click.option(
     "--no-git",
     is_flag=True,
     help="Skip git initialization",
 )
-def init(project_name: str, template: str, database_url: str, no_git: bool) -> None:
+def init(project_name: str, template: str, database_url: str | None, no_git: bool) -> None:
     """Initialize a new FraiseQL project.
 
     Creates a new directory with the given PROJECT_NAME and sets up
@@ -39,19 +60,28 @@ def init(project_name: str, template: str, database_url: str, no_git: bool) -> N
         msg = f"Directory '{project_name}' already exists"
         raise click.ClickException(msg)
 
+    db_name = _database_name(project_name)
+    if database_url is None:
+        database_url = f"postgresql://{DB_USER}:{DB_PASSWORD}@localhost:{DB_PORT}/{db_name}"
+
     click.echo(f"🚀 Creating FraiseQL project '{project_name}'...")
 
     # Create project directory
     project_path.mkdir(parents=True)
 
-    # Create directory structure
+    # Create directory structure. The db/ layout matches what `fraiseql migrate
+    # init` expects, so the two commands agree about where migrations live.
     directories = [
         "src",
         "src/types",
         "src/mutations",
         "src/queries",
         "tests",
-        "migrations",
+        "db/schema",
+        "db/seeds/common",
+        "db/seeds/development",
+        "db/migrations",
+        "db/environments",
     ]
 
     for directory in directories:
@@ -61,13 +91,77 @@ def init(project_name: str, template: str, database_url: str, no_git: bool) -> N
     env_content = f"""# FraiseQL Configuration
 FRAISEQL_DATABASE_URL={database_url}
 FRAISEQL_AUTO_CAMEL_CASE=true
-FRAISEQL_DEV_AUTH_PASSWORD=development-only-password
+
+# Fail fast while developing. Without this a missing database costs 30s per
+# query while the connection pool retries.
+FRAISEQL_DATABASE_POOL_TIMEOUT=5
+
+# Uncomment to put HTTP basic auth in front of /graphql, as user 'admin'.
+# Every request then needs credentials, GraphiQL's included.
+# FRAISEQL_DEV_AUTH_PASSWORD=development-only-password
 
 # Production settings (uncomment for production)
 # FRAISEQL_ENVIRONMENT=production
 # SECRET_KEY=your-secret-key-here
 """
     (project_path / ".env").write_text(env_content)
+
+    # Create docker-compose.yml so a real database is one command away rather
+    # than a prerequisite the user has to satisfy before anything works.
+    compose_content = f"""services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: {db_name}
+      POSTGRES_USER: {DB_USER}
+      POSTGRES_PASSWORD: {DB_PASSWORD}
+    ports:
+      - "{DB_PORT}:5432"
+    volumes:
+      - {db_name}_data:/var/lib/postgresql/data
+      # Applied once, the first time this volume is created.
+      - ./db/schema:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U {DB_USER} -d {db_name}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  {db_name}_data:
+"""
+    (project_path / "docker-compose.yml").write_text(compose_content)
+
+    # Schema for the shipped database, loaded automatically by the container.
+    schema_content = """-- Loaded by docker-entrypoint-initdb.d the first time the volume
+-- is created. To re-run it: docker compose down -v && docker compose up -d
+
+CREATE TABLE IF NOT EXISTS tb_user (
+    id         SERIAL PRIMARY KEY,
+    name       TEXT NOT NULL,
+    email      TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- FraiseQL reads one JSONB column per row, so the object is composed in SQL
+-- instead of being assembled from joins in Python.
+CREATE OR REPLACE VIEW v_user AS
+SELECT
+    id,
+    jsonb_build_object(
+        'id', id,
+        'name', name,
+        'email', email,
+        'created_at', created_at
+    ) AS data
+FROM tb_user;
+
+INSERT INTO tb_user (name, email) VALUES
+    ('Ada Lovelace', 'ada@example.com'),
+    ('Alan Turing', 'alan@example.com')
+ON CONFLICT (email) DO NOTHING;
+"""
+    (project_path / "db" / "schema" / "001_users.sql").write_text(schema_content)
 
     # Create .gitignore
     gitignore_content = """# Python
@@ -117,9 +211,10 @@ Thumbs.db
 name = "{project_name}"
 version = "0.1.0"
 description = "A FraiseQL GraphQL API"
-requires-python = ">=3.10"
+requires-python = "{REQUIRES_PYTHON}"
 dependencies = [
-    "fraiseql>=0.2.1",
+    # The bare name resolves to FraiseQL v2 on PyPI, a different framework.
+    "{FRAISEQL_PIN}",
     "uvicorn>=0.34.3",
     "python-dotenv>=1.0.0",
 ]
@@ -133,10 +228,10 @@ dev = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "{PYTHON_TAG}"
 
 [tool.pyright]
-pythonVersion = "3.10"
+pythonVersion = "{PYTHON_VERSION}"
 typeCheckingMode = "strict"
 """
     (project_path / "pyproject.toml").write_text(pyproject_content)
@@ -154,47 +249,71 @@ typeCheckingMode = "strict"
     # Create README
     readme_content = f"""# {project_name}
 
-A FraiseQL GraphQL API project.
+A FraiseQL GraphQL API.
 
-## Getting Started
+## Getting started
 
-1. Set up a Python virtual environment:
+1. Create a virtual environment and install the project:
+
    ```bash
    python -m venv .venv
    source .venv/bin/activate  # On Windows: .venv\\Scripts\\activate
-   ```
-
-2. Install dependencies:
-   ```bash
    pip install -e ".[dev]"
    ```
 
-3. Set up your PostgreSQL database and update the DATABASE_URL in `.env`
+2. Start the development server:
 
-4. Run migrations:
-   ```bash
-   fraiseql migrate
-   ```
-
-5. Start the development server:
    ```bash
    fraiseql dev
    ```
 
-Your GraphQL API will be available at http://localhost:8000/graphql
+   Your API is live at <http://localhost:8000/graphql>. Open it and run:
 
-## Project Structure
+   ```graphql
+   {{ users {{ id name email }} }}
+   ```
 
-- `src/` - Application source code
-  - `types/` - FraiseQL type definitions
-  - `mutations/` - GraphQL mutations
-  - `queries/` - Custom query logic
-- `tests/` - Test files
-- `migrations/` - Database migrations
+   It answers with an empty list until you finish step 3.
 
-## Learn More
+3. Start the bundled PostgreSQL:
 
-- [FraiseQL Documentation](https://fraiseql.readthedocs.io)
+   ```bash
+   docker compose up -d
+   ```
+
+   The container loads `db/schema/*.sql` the first time it starts, which
+   creates `v_user` and seeds two rows. Re-run the query above and it
+   returns them.
+
+## Configuration
+
+Settings live in `.env` and are read by FraiseQL directly. The one that
+matters most is `FRAISEQL_DATABASE_URL`, which already points at the
+database `docker compose` starts for you.
+
+## Changing the schema
+
+```bash
+fraiseql migrate create add_something   # writes db/migrations/<timestamp>_add_something
+fraiseql migrate up                     # applies pending migrations
+fraiseql migrate status                 # shows what has been applied
+```
+
+`fraiseql migrate` on its own only prints help; the subcommands do the work.
+
+## Project structure
+
+- `src/` — application source code
+  - `types/` — FraiseQL type definitions
+  - `mutations/` — GraphQL mutations
+  - `queries/` — custom query logic
+- `db/schema/` — SQL loaded into a fresh database
+- `db/migrations/` — incremental schema changes
+- `tests/` — test files
+
+## Learn more
+
+- [FraiseQL documentation](https://fraiseql.readthedocs.io)
 - [GraphQL](https://graphql.org)
 """
     (project_path / "README.md").write_text(readme_content)
@@ -222,8 +341,8 @@ Next steps:
 2. python -m venv .venv
 3. source .venv/bin/activate  # On Windows: .venv\\Scripts\\activate
 4. pip install -e ".[dev]"
-5. Set up your PostgreSQL database
-6. fraiseql dev
+5. fraiseql dev            # serves http://localhost:8000/graphql right away
+6. docker compose up -d    # starts PostgreSQL and loads db/schema/*.sql
 
 Happy coding! 🎉
 """,
@@ -236,39 +355,47 @@ def create_basic_template(project_path: Path) -> None:
     main_content = '''"""Main application entry point."""
 
 import os
+from datetime import datetime
 
 import fraiseql
-from fraiseql import fraise_field
+from dotenv import load_dotenv
+from psycopg import OperationalError
 
-# Define your types
-@fraiseql.type
+load_dotenv()
+
+
+@fraiseql.type(sql_source="v_user", jsonb_column="data")
 class User:
     """A user in the system."""
-    id: int = fraise_field(description="User ID")
-    name: str = fraise_field(description="User's display name")
-    email: str = fraise_field(description="User's email address")
-    created_at: str = fraise_field(description="When the user was created")
+
+    id: int
+    name: str
+    email: str
+    created_at: datetime
 
 
-@fraiseql.type
-class QueryRoot:
-    """Root query type."""
-    users: list[User] = fraise_field(default_factory=list, description="List all users")
-
-    async def resolve_users(self, info):
-        # TODO: Implement actual database query
+@fraiseql.query
+async def users(info) -> list[User]:
+    """Every row of the v_user view, oldest first."""
+    db = info.context["db"]
+    try:
+        return await db.find("v_user", "users", info, order_by=[("id", "ASC")])
+    except OperationalError:
+        # No database yet. `docker compose up -d` starts the one this project
+        # ships with; delete this guard once you always have one.
         return []
 
 
-# Create the FastAPI app
+# @fraiseql.query registers `users` on import, so it needs no queries= here.
 app = fraiseql.create_fraiseql_app(
-    queries=[QueryRoot],
-    database_url=os.getenv("DATABASE_URL"),
+    types=[User],
+    database_url=os.getenv("FRAISEQL_DATABASE_URL"),
 )
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)
+
+    uvicorn.run(app, host="127.0.0.1", port=8000)
 '''
     (project_path / "src" / "main.py").write_text(main_content)
 
@@ -356,42 +483,49 @@ class Comment:
 import os
 
 import fraiseql
-from fraiseql import fraise_field
+from dotenv import load_dotenv
 
-from src.types.user import User
-from src.types.post import Post
 from src.types.comment import Comment
+from src.types.post import Post
+from src.types.user import User
+
+load_dotenv()
 
 
-@fraiseql.type
-class QueryRoot:
-    """Root query type for blog."""
-    users: list[User] = fraise_field(default_factory=list, description="List all users")
-    posts: list[Post] = fraise_field(default_factory=list, description="List all posts")
-    comments: list[Comment] = fraise_field(default_factory=list, description="List all comments")
+@fraiseql.query
+async def users(info) -> list[User]:
+    """List all users.
 
-    async def resolve_users(self, info):
-        # TODO: Implement actual database query
-        return []
+    Point this at a view once you have one, the way the basic template does:
 
-    async def resolve_posts(self, info):
-        # TODO: Implement actual database query
-        return []
-
-    async def resolve_comments(self, info):
-        # TODO: Implement actual database query
-        return []
+        db = info.context["db"]
+        return await db.find("v_user", "users", info)
+    """
+    return []
 
 
-# Create the FastAPI app
+@fraiseql.query
+async def posts(info) -> list[Post]:
+    """List all posts. See `users` for how to back this with a view."""
+    return []
+
+
+@fraiseql.query
+async def comments(info) -> list[Comment]:
+    """List all comments. See `users` for how to back this with a view."""
+    return []
+
+
+# @fraiseql.query registers each resolver on import, so no queries= here.
 app = fraiseql.create_fraiseql_app(
-    queries=[QueryRoot],
-    database_url=os.getenv("DATABASE_URL"),
+    types=[User, Post, Comment],
+    database_url=os.getenv("FRAISEQL_DATABASE_URL"),
 )
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)
+
+    uvicorn.run(app, host="127.0.0.1", port=8000)
 '''
     (project_path / "src" / "main.py").write_text(main_content)
 

--- a/tests/unit/cli/test_init_dev_first_run.py
+++ b/tests/unit/cli/test_init_dev_first_run.py
@@ -1,0 +1,254 @@
+"""The `fraiseql init` -> `fraiseql dev` first-run path.
+
+These cover the four commands a new user types before anything else:
+
+    fraiseql init demo && cd demo && fraiseql dev
+
+Every failure mode here was reproduced by hand against a generated project
+before the test was written.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from fraiseql.cli.commands.dev import dev
+from fraiseql.cli.commands.init import init
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def project(runner: CliRunner, _in_tmp_cwd: None) -> Path:
+    """A generated project on disk, as `fraiseql init demo` leaves it."""
+    result = runner.invoke(init, ["demo", "--no-git"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    return Path("demo").resolve()
+
+
+@pytest.fixture(autouse=True)
+def _in_tmp_cwd(runner: CliRunner, tmp_path: Path):
+    """Run each test in a scratch directory, with os.environ restored after.
+
+    `fraiseql dev` calls load_dotenv(), which mutates the real process
+    environment; without this the .env written here would leak into the rest
+    of the suite.
+    """
+    saved = os.environ.copy()
+    try:
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+def _env_vars(project: Path) -> dict[str, str]:
+    """Parse the generated .env, ignoring commented-out lines."""
+    values = {}
+    for raw in (project / ".env").read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        values[key.strip()] = value.strip()
+    return values
+
+
+class TestDevServerImports:
+    """`fraiseql dev` must be able to import the project it is run inside."""
+
+    def test_dev_puts_the_project_root_on_sys_path(self, tmp_path: Path) -> None:
+        """Without this, uvicorn.run() raises `No module named 'src'`.
+
+        The uvicorn *CLI* inserts the app dir into sys.path; uvicorn.run()
+        only does so when handed `app_dir`.
+        """
+        Path("pyproject.toml").write_text("[project]\nname = 'demo'\n")
+        fake_uvicorn = MagicMock()
+
+        with patch("fraiseql.cli.commands.dev.uvicorn", fake_uvicorn):
+            CliRunner().invoke(dev, ["--no-reload"], catch_exceptions=False)
+
+        assert fake_uvicorn.run.called, "uvicorn.run was never invoked"
+        kwargs = fake_uvicorn.run.call_args.kwargs
+        assert kwargs.get("app_dir") == str(Path.cwd()), (
+            "dev must hand uvicorn the project root, or the string app target "
+            f"{kwargs.get('app_dir')!r} cannot be imported"
+        )
+
+
+class TestDatabaseUrlVariable:
+    """The variable `init` writes must be the variable the app reads."""
+
+    def test_env_variable_is_the_one_main_py_reads(self, project: Path) -> None:
+        env = _env_vars(project)
+        main = (project / "src" / "main.py").read_text()
+
+        read_vars = set(re.findall(r"getenv\(\s*[\"']([A-Z_]+)[\"']", main))
+        assert read_vars, "src/main.py reads no environment variable at all"
+        assert read_vars <= set(env), (
+            f"src/main.py reads {sorted(read_vars - set(env))} but .env defines "
+            f"{sorted(env)} - the URL in .env is silently ignored"
+        )
+
+    def test_generated_readme_names_a_variable_that_exists(self, project: Path) -> None:
+        readme = (project / "README.md").read_text()
+        env = _env_vars(project)
+        assert "FRAISEQL_DATABASE_URL" in env
+        assert not re.search(r"(?<!FRAISEQL_)\bDATABASE_URL\b", readme), (
+            "README tells the user to edit a variable .env does not contain"
+        )
+
+
+class TestGeneratedPyproject:
+    """A generated project must resolve to v1, on a Python v1 supports."""
+
+    def test_fraiseql_dependency_is_pinned_below_v2(self, project: Path) -> None:
+        data = tomllib.loads((project / "pyproject.toml").read_text())
+        deps = data["project"]["dependencies"]
+        pin = next((d for d in deps if d.startswith("fraiseql")), None)
+        assert pin is not None, f"no fraiseql dependency in {deps}"
+        assert "<2" in pin, (
+            f"{pin!r} is unpinned - `pip install -e .` installs v2 from PyPI, "
+            "which is a different framework"
+        )
+
+    def test_requires_python_matches_v1(self, project: Path) -> None:
+        data = tomllib.loads((project / "pyproject.toml").read_text())
+        assert data["project"]["requires-python"] == ">=3.13,<3.14"
+
+
+class TestFirstQueryIsNotBlocked:
+    """Nothing may stand between the user and their first query."""
+
+    def test_dev_auth_is_not_enabled_by_default(self, project: Path) -> None:
+        """An active dev-auth password makes every /graphql request a 401."""
+        assert "FRAISEQL_DEV_AUTH_PASSWORD" not in _env_vars(project), (
+            "generated .env enables DevAuthMiddleware, so the first query "
+            "returns 401 Development authentication required"
+        )
+
+    def test_serves_a_query_with_no_database_running(self, project: Path) -> None:
+        """The whole point: four commands, one working query, no Postgres."""
+        probe = project / "_probe.py"
+        probe.write_text(
+            "import json\n"
+            "from fastapi.testclient import TestClient\n"
+            "from src.main import app\n"
+            "with TestClient(app) as c:\n"
+            "    r = c.post('/graphql', json={'query': '{ users { id name } }'})\n"
+            "    print('PROBE', r.status_code, json.dumps(r.json()))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "_probe.py"],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+        line = next(
+            (ln for ln in result.stdout.splitlines() if ln.startswith("PROBE")),
+            None,
+        )
+        assert line is not None, (
+            f"generated app never answered\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr[-3000:]}"
+        )
+        _, status, payload = line.split(" ", 2)
+        body = json.loads(payload)
+        assert status == "200", f"{status}: {payload}"
+        assert "errors" not in body, f"query errored: {body['errors']}"
+        assert body["data"] == {"users": []}
+
+
+class TestMigrationLayout:
+    """`fraiseql init` and `fraiseql migrate` must agree with each other."""
+
+    def test_migrations_live_where_migrate_init_puts_them(self, project: Path) -> None:
+        assert (project / "db" / "migrations").is_dir(), (
+            "init creates migrations/ but `fraiseql migrate init` uses db/migrations/"
+        )
+
+    def test_readme_does_not_tell_users_to_run_the_group(self, project: Path) -> None:
+        """`fraiseql migrate` is a click group - it prints help and exits."""
+        readme = (project / "README.md").read_text()
+        assert not re.search(r"`?fraiseql migrate`?\s*$", readme, re.MULTILINE), (
+            "README says `fraiseql migrate`, which only prints help; "
+            "the real commands are `migrate init` and `migrate up`"
+        )
+
+
+class TestShippedDatabase:
+    """Real data must be one command away, not an assumed prerequisite."""
+
+    def test_ships_a_compose_file(self, project: Path) -> None:
+        compose = project / "docker-compose.yml"
+        assert compose.exists(), "no docker-compose.yml - `docker compose up -d` fails"
+        assert "postgres" in compose.read_text()
+
+    def test_compose_database_matches_the_env_url(self, project: Path) -> None:
+        """Starting the shipped Postgres must satisfy the shipped URL."""
+        compose = (project / "docker-compose.yml").read_text()
+        url = _env_vars(project)["FRAISEQL_DATABASE_URL"]
+        parsed = re.match(
+            r"postgresql://(?P<user>[^:]+):(?P<password>[^@]+)@[^:/]+"
+            r":(?P<port>\d+)/(?P<db>\w+)",
+            url,
+        )
+        assert parsed, f"{url!r} is not a full URL, so compose cannot match it"
+        for key, value in parsed.groupdict().items():
+            assert value in compose, f"compose does not set {key}={value} from .env"
+
+    def test_published_port_avoids_a_local_postgres(self, project: Path) -> None:
+        """5432 is taken on any machine that already runs PostgreSQL."""
+        url = _env_vars(project)["FRAISEQL_DATABASE_URL"]
+        port = int(re.search(r":(\d+)/", url).group(1))
+        assert port != 5432, (
+            "publishing 5432 means `docker compose up -d` fails with "
+            "'port is already allocated' for anyone running PostgreSQL locally"
+        )
+
+    def test_ships_schema_sql_creating_the_queried_view(self, project: Path) -> None:
+        sql = "\n".join(p.read_text() for p in project.glob("db/schema/*.sql"))
+        assert sql.strip(), "no db/schema/*.sql - the shipped Postgres boots empty"
+        assert "v_user" in sql, "schema does not create the view main.py queries"
+
+
+class TestUnreachableDatabaseDiagnostic:
+    """A missing database is one line, not a flood of pool tracebacks."""
+
+    def test_dev_warns_once_and_still_starts(self, tmp_path: Path) -> None:
+        Path("pyproject.toml").write_text("[project]\nname = 'demo'\n")
+        Path(".env").write_text(
+            "FRAISEQL_DATABASE_URL=postgresql://fraiseql:fraiseql@localhost:5432/demo\n"
+        )
+        fake_uvicorn = MagicMock()
+
+        with (
+            patch("fraiseql.cli.commands.dev.uvicorn", fake_uvicorn),
+            patch(
+                "fraiseql.cli.commands.dev._database_is_reachable",
+                return_value=False,
+            ),
+        ):
+            result = CliRunner().invoke(dev, ["--no-reload"], catch_exceptions=False)
+
+        assert "docker compose up -d" in result.output, (
+            f"no actionable diagnostic for an unreachable database:\n{result.output}"
+        )
+        assert fake_uvicorn.run.called, "dev must still start without a database"


### PR DESCRIPTION
A new user's first four commands did not produce a running API, despite the README's "Your API is live at `http://localhost:8000/graphql`".

Five independent defects. Each was reproduced by hand against a generated project before its test was written.

## What was broken

| # | Defect | Symptom |
|---|---|---|
| 1 | `uvicorn.run()` got the import string `"src.main:app"` with nothing on `sys.path` | `Error: No module named 'src'` |
| 2 | `.env` wrote `FRAISEQL_DATABASE_URL`; `src/main.py` read `DATABASE_URL` | URL ignored; fell back to a database named `fraiseql`, flooding pool errors |
| 3 | Generated `pyproject.toml` declared `fraiseql>=0.2.1`, `requires-python = ">=3.10"` | `pip install -e .` installs **v2** — a different framework |
| 4 | `.env` set `FRAISEQL_DEV_AUTH_PASSWORD` | Every `/graphql` request → `401 Development authentication required` |
| 5 | Template's `resolve_users(self, info)` is bound, then called with root + info | `takes 2 positional arguments but 3 were given` on every query |

Defects 4 and 5 were not in the original report; they surfaced while verifying 1–3, and each independently prevents a working query.

The report also claimed the generated schema ends up empty, citing `No fields were added from QueryRoot`. It isn't — the schema really is `type Query { users: [User] }`. That log line is spurious: `field_count` in `query_builder.py` is initialized to `0` and never incremented, so the warning fires unconditionally. Left alone here; it deserves its own PR.

## Approach to the database

The scaffold **boots with no PostgreSQL at all**, and ships the database rather than assuming it. This follows what comparable scaffolders do — `django-admin startproject`, `rails new` and `prisma init` never require a pre-existing database, and `supabase init` supplies its own. Requiring one would just have traded `No module named 'src'` for `database "mydb" does not exist`.

```bash
fraiseql init x && cd x && fraiseql dev
# ⚠️  No database reachable at postgresql://fraiseql:***@localhost:54320/x
#    Start the one this project ships with: docker compose up -d
{ users { id name email } }   # → {"data":{"users":[]}}, HTTP 200

docker compose up -d          # loads db/schema/001_users.sql
{ users { id name email } }   # → Ada Lovelace, Alan Turing
```

Both paths were run end-to-end against a real PostgreSQL, not just asserted in tests.

The compose service publishes **54320, not 5432**, so it cannot collide with a PostgreSQL already installed — a collision this branch hit for real on the development machine, twice, which is why there is now a test for it.

## Also in here

- `fraiseql dev` reports an unreachable database once, in one line, instead of leaving the pool to repeat the same traceback. `FRAISEQL_DATABASE_POOL_TIMEOUT=5` in the scaffold cuts the first failed query from 30s to 5s.
- `init` now creates `db/migrations/`, where `fraiseql migrate init` puts them, instead of `migrations/`. The generated README no longer says `fraiseql migrate` — that is a click group which only prints help; the real commands are `migrate create` / `migrate up` / `migrate status`.
- Security contact unified on `security@fraiseql.dev`, confirmed by the maintainer. Three files gave three different addresses (`security@fraiseql.com`, `team@fraiseql.dev`, `security@fraiseql.io`).
- `docs/reference/cli.md` and the installation quickstart updated to match the new scaffold.

Defect 3 is the last place the v1/v2 PyPI name collision survived after #524, #525 and #526.

## Verification

- `fraiseql init x && cd x && fraiseql dev` serves `{"users": []}` with no database; after `docker compose up -d`, the same query returns the two seeded rows. Both confirmed by hand, with a live server and `curl`.
- `docker compose config` validates; the container reports healthy in 6s.
- 14 new tests, one per defect plus the drift invariants (`.env` ↔ compose credentials and port, `.env` ↔ what `main.py` reads).
- `uv run pytest tests/unit/ tests/integration/ -q` → **6135 passed, 2 skipped** (6121 on `dev`).
- `ruff check` clean; `mkdocs build` passes.

## Not included

Three things found while verifying, each independent and left for its own PR: the spurious `QueryRoot` warning above, the stale "7-10x" figure in six files, and `pyproject.toml`'s marketing `description` that renders above the README on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKJBwaCRWEKrUwp972aB1N
